### PR TITLE
Correct Content-Type for schema servlet

### DIFF
--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SmallRyeGraphQLSchemaServlet.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SmallRyeGraphQLSchemaServlet.java
@@ -43,7 +43,7 @@ public class SmallRyeGraphQLSchemaServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) {
-        response.setContentType("plain/text");
+        response.setContentType("text/plain");
         try (PrintWriter out = response.getWriter()) {
             out.print(graphQLSchemaString);
             out.flush();


### PR DESCRIPTION
Not entirely sure that `text/plain` is the one we should use, but it's certainly more correct than `plain/text` :) 