### PR TITLE
fix: support META-INF/jandex.idx in the WAR (#64)

### DIFF
--- a/implementation/src/main/java/io/smallrye/graphql/SmallRyeGraphQLBootstrap.java
+++ b/implementation/src/main/java/io/smallrye/graphql/SmallRyeGraphQLBootstrap.java
@@ -65,7 +65,7 @@ public class SmallRyeGraphQLBootstrap {
 
     public GraphQLSchema generateSchema() {
         if (this.index == null) {
-            try (InputStream stream = getClass().getResourceAsStream("META-INF/jandex.idx")) {
+            try (InputStream stream = getClass().getClassLoader().getResourceAsStream("META-INF/jandex.idx")) {
                 IndexReader reader = new IndexReader(stream);
                 this.index = reader.read();
                 LOG.info("Loaded index from [META-INF/jandex.idx]");


### PR DESCRIPTION
I've created a semi-fix: more robust reading of the `META-INF/jandex.idx` which uses the `ClassLoader` of this library,  which is mostly the loader of the WAR.

One needs to generate the `jandex.idx` file with the `org.jboss.jandex:jandex-maven-plugin` maven plugin (or manually).

Tested in Wildfly 18.