### PR TITLE
fix config injection of optional black/whitelist

### DIFF
--- a/implementation/src/main/java/io/smallrye/graphql/execution/GraphQLConfig.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/GraphQLConfig.java
@@ -15,7 +15,10 @@
  */
 package io.smallrye.graphql.execution;
 
+import static java.util.Collections.emptyList;
+
 import java.util.List;
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -25,19 +28,19 @@ import org.eclipse.microprofile.graphql.ConfigKey;
 
 /**
  * Configuration for GraphQL
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 @ApplicationScoped
 public class GraphQLConfig {
 
     @Inject
-    @ConfigProperty(name = ConfigKey.EXCEPTION_BLACK_LIST, defaultValue = "[]")
-    private List<String> blackList;
+    @ConfigProperty(name = ConfigKey.EXCEPTION_BLACK_LIST)
+    private Optional<List<String>> blackList;
 
     @Inject
-    @ConfigProperty(name = ConfigKey.EXCEPTION_WHITE_LIST, defaultValue = "[]")
-    private List<String> whiteList;
+    @ConfigProperty(name = ConfigKey.EXCEPTION_WHITE_LIST)
+    private Optional<List<String>> whiteList;
 
     @Inject
     @ConfigProperty(name = ConfigKey.DEFAULT_ERROR_MESSAGE, defaultValue = "Server Error")
@@ -68,19 +71,19 @@ public class GraphQLConfig {
     }
 
     public List<String> getBlackList() {
-        return blackList;
+        return blackList.orElse(emptyList());
     }
 
     public void setBlackList(List<String> blackList) {
-        this.blackList = blackList;
+        this.blackList = Optional.ofNullable(blackList);
     }
 
     public List<String> getWhiteList() {
-        return whiteList;
+        return whiteList.orElse(emptyList());
     }
 
     public void setWhiteList(List<String> whiteList) {
-        this.whiteList = whiteList;
+        this.whiteList = Optional.ofNullable(whiteList);
     }
 
     public boolean isAllowGet() {

--- a/implementation/src/main/java/io/smallrye/graphql/execution/GraphQLConfig.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/GraphQLConfig.java
@@ -15,10 +15,7 @@
  */
 package io.smallrye.graphql.execution;
 
-import static java.util.Collections.emptyList;
-
 import java.util.List;
-import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -35,12 +32,12 @@ import org.eclipse.microprofile.graphql.ConfigKey;
 public class GraphQLConfig {
 
     @Inject
-    @ConfigProperty(name = ConfigKey.EXCEPTION_BLACK_LIST)
-    private Optional<List<String>> blackList;
+    @ConfigProperty(name = ConfigKey.EXCEPTION_BLACK_LIST, defaultValue = ",")
+    private List<String> blackList;
 
     @Inject
-    @ConfigProperty(name = ConfigKey.EXCEPTION_WHITE_LIST)
-    private Optional<List<String>> whiteList;
+    @ConfigProperty(name = ConfigKey.EXCEPTION_WHITE_LIST, defaultValue = ",")
+    private List<String> whiteList;
 
     @Inject
     @ConfigProperty(name = ConfigKey.DEFAULT_ERROR_MESSAGE, defaultValue = "Server Error")
@@ -71,19 +68,19 @@ public class GraphQLConfig {
     }
 
     public List<String> getBlackList() {
-        return blackList.orElse(emptyList());
+        return blackList;
     }
 
     public void setBlackList(List<String> blackList) {
-        this.blackList = Optional.ofNullable(blackList);
+        this.blackList = blackList;
     }
 
     public List<String> getWhiteList() {
-        return whiteList.orElse(emptyList());
+        return whiteList;
     }
 
     public void setWhiteList(List<String> whiteList) {
-        this.whiteList = Optional.ofNullable(whiteList);
+        this.whiteList = whiteList;
     }
 
     public boolean isAllowGet() {


### PR DESCRIPTION
When I start `smallrye-graphql` in a WildFly 19, it logs the following warning:

```[io.smallrye.graphql.execution.error.ExceptionLists] (default task-1) Could not create instance of exception class [[]]. Can not do transitive black/whitelist check for this class```

I found that in `GraphQLConfig` the default for the black/whitelist is `[]`, which obviously doesn't work as expected: it creates a list containing the string `"[]"`. So I changed it to an `Optional<List<String>>` instead and it works just fine.