### PR TITLE
fix #79: more robust creation of collection instances

### DIFF
--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/AnnotatedPropertyDataFetcher.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/AnnotatedPropertyDataFetcher.java
@@ -70,7 +70,7 @@ public class AnnotatedPropertyDataFetcher extends PropertyDataFetcher {
             }
         } else if (Collection.class.isInstance(o)) {
             Collection collection = Collection.class.cast(o);
-            Collection transformedCollection = collectionHelper.getCorrectCollectionType(o.getClass());
+            Collection transformedCollection = collectionHelper.newCollection(o.getClass());
             for (Object oo : collection) {
                 transformedCollection.add(get(oo));
             }

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/ReflectionDataFetcher.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/ReflectionDataFetcher.java
@@ -209,7 +209,7 @@ public class ReflectionDataFetcher implements DataFetcher {
     private Object handleCollection(Object argumentValue, Argument a) throws GraphQLException {
         Class clazz = a.getArgumentClass();
         Type type = a.getType();
-        Collection convertedList = collectionHelper.getCorrectCollectionType(clazz);
+        Collection convertedList = collectionHelper.newCollection(clazz);
 
         Collection givenCollection = (Collection) argumentValue;
 

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/schema/helper/CollectionHelper.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/schema/helper/CollectionHelper.java
@@ -15,6 +15,8 @@
  */
 package io.smallrye.graphql.bootstrap.schema.helper;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -25,27 +27,30 @@ import org.jboss.logging.Logger;
 
 /**
  * Helping with collections
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class CollectionHelper {
     private static final Logger LOG = Logger.getLogger(CollectionHelper.class.getName());
 
-    public Collection getCorrectCollectionType(Class type) {
-
-        if (type.equals(Collection.class) || type.equals(List.class) || type.getName().equals(ARRAYS_ARRAYLIST)) {
+    /**
+     * Creates an empty instance of a non-interface type of collection, or a suitable subclass of
+     * the interfaces {@link List}, {@link Collection}, or {@link Set}.
+     */
+    public Collection newCollection(Class type) {
+        if (type.equals(Collection.class) || type.equals(List.class)) {
             return new ArrayList();
         } else if (type.equals(Set.class)) {
             return new HashSet();
         } else {
             try {
-                return (Collection) type.newInstance();
-            } catch (InstantiationException | IllegalAccessException ex) {
-                LOG.error("Can not create new collection of [" + type.getName() + "]");
+                Constructor constructor = type.getConstructor();
+                constructor.setAccessible(true);
+                return (Collection) constructor.newInstance();
+            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException ex) {
+                LOG.error("Can not create new collection of [" + type.getName() + "]", ex);
                 return new ArrayList(); // default ?
             }
         }
     }
-
-    private static final String ARRAYS_ARRAYLIST = "java.util.Arrays$ArrayList";
 }


### PR DESCRIPTION
It's tougher than I thought (as it always is ;-): I won't manage to make that interface heuristic bullet proof. There are many more interfaces that aren't recognized, e.g. `Queue` or `JsonArray`, and the application can add their own. But maybe it's good enough... at least if it's documented in the spec ;-)