### PR TITLE
[#84] Enable multiple apps to share SmallRye impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ client/shade/dependency-reduced-pom.xml
 
 # Zanata files
 **/.zanata-cache/
+.vscode/

--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SmallRyeGraphQLExecutionServlet.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SmallRyeGraphQLExecutionServlet.java
@@ -85,7 +85,12 @@ public class SmallRyeGraphQLExecutionServlet extends HttpServlet {
     }
 
     private void handleInput(Reader inputReader, HttpServletResponse response) {
+        if (LOG.isDebugEnabled()) {
+            inputReader = logInputReader(inputReader);
+        }
+
         try (JsonReader jsonReader = Json.createReader(inputReader)) {
+
             JsonObject jsonInput = jsonReader.readObject();
 
             JsonObject outputJson = executionService.execute(jsonInput);
@@ -101,6 +106,23 @@ public class SmallRyeGraphQLExecutionServlet extends HttpServlet {
         } catch (IOException ex) {
             LOG.log(Logger.Level.ERROR, null, ex);
         }
+    }
+
+    private static Reader logInputReader(Reader inputReader) {
+        try {
+            StringBuilder sb = new StringBuilder();
+            char[] buf = new char[4096];
+            int len;
+            while ((len = inputReader.read(buf)) > -1) {
+                sb.append(buf, 0, len);
+            }
+            String jsonInput = sb.toString();
+            LOG.debugf("JSON input: {0}", jsonInput);
+            inputReader = new StringReader(jsonInput);
+        } catch (Throwable t) {
+            LOG.warnf("Unable to log reader, {0}", inputReader);
+        }
+        return inputReader;
     }
 
     private static final String APPLICATION_JSON_UTF8 = "application/json;charset=UTF-8";

--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SmallRyeGraphQLExecutionServlet.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SmallRyeGraphQLExecutionServlet.java
@@ -52,6 +52,14 @@ public class SmallRyeGraphQLExecutionServlet extends HttpServlet {
     @Inject
     GraphQLConfig config;
 
+    public SmallRyeGraphQLExecutionServlet() {
+    }
+
+    public SmallRyeGraphQLExecutionServlet(ExecutionService executionService, GraphQLConfig config) {
+        this.executionService = executionService;
+        this.config = config;
+    }
+
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) {
         if (config.isAllowGet()) {

--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SmallRyeGraphQLSchemaServlet.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SmallRyeGraphQLSchemaServlet.java
@@ -26,8 +26,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.jboss.logging.Logger;
 
+import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.SchemaPrinter;
-import io.smallrye.graphql.bootstrap.SmallRyeGraphQLBootstrap;
 
 /**
  * Serving the GraphQL schema
@@ -38,19 +38,22 @@ import io.smallrye.graphql.bootstrap.SmallRyeGraphQLBootstrap;
 public class SmallRyeGraphQLSchemaServlet extends HttpServlet {
     private static final Logger LOG = Logger.getLogger(SmallRyeGraphQLSchemaServlet.class.getName());
 
+    public static final String SCHEMA_PROP = "io.smallrye.graphql.servlet.bootstrap";
+
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) {
         response.setContentType(CONTENT_TYPE);
         try (PrintWriter out = response.getWriter()) {
-            out.print(graphQLSchemaToString());
+            GraphQLSchema schema = (GraphQLSchema) request.getServletContext().getAttribute(SCHEMA_PROP);
+            out.print(graphQLSchemaToString(schema));
             out.flush();
         } catch (IOException ex) {
             LOG.log(Logger.Level.ERROR, null, ex);
         }
     }
 
-    private String graphQLSchemaToString() {
-        return SCHEMAPRINTER.print(SmallRyeGraphQLBootstrap.GRAPHQL_SCHEMA);
+    private String graphQLSchemaToString(GraphQLSchema schema) {
+        return SCHEMAPRINTER.print(schema);
     }
 
     private static final String CONTENT_TYPE = "text/plain";

--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/StartupListener.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/StartupListener.java
@@ -20,6 +20,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
 
+import javax.inject.Inject;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
@@ -39,6 +40,9 @@ import io.smallrye.graphql.bootstrap.index.IndexInitializer;
 public class StartupListener implements ServletContextListener {
     private static final Logger LOG = Logger.getLogger(StartupListener.class.getName());
 
+    @Inject
+    private SmallRyeGraphQLBootstrap bootstrap;
+
     private final IndexInitializer indexInitializer = new IndexInitializer();
 
     @Override
@@ -48,7 +52,7 @@ public class StartupListener implements ServletContextListener {
             String realPath = sce.getServletContext().getRealPath("WEB-INF/classes");
             URL url = Paths.get(realPath).toUri().toURL();
             IndexView index = indexInitializer.createIndex(url);
-            SmallRyeGraphQLBootstrap.bootstrap(index);
+            sce.getServletContext().setAttribute(SmallRyeGraphQLSchemaServlet.SCHEMA_PROP, bootstrap.bootstrap(index));
             LOG.info("SmallRye GraphQL initialized");
         } catch (MalformedURLException ex) {
             throw new RuntimeException(ex);

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/ObjectBag.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/ObjectBag.java
@@ -52,23 +52,20 @@ import io.smallrye.graphql.bootstrap.type.time.TimeScalar;
  */
 public class ObjectBag {
 
-    private ObjectBag() {
-    }
-
     // Some maps we populate during scanning
-    private static final Map<DotName, GraphQLInputType> INPUT_MAP = new HashMap<>();
-    private static final Map<DotName, GraphQLOutputType> TYPE_MAP = new HashMap<>();
-    private static final Map<DotName, GraphQLEnumType> ENUM_MAP = new HashMap<>();
-    private static final Map<DotName, GraphQLInterfaceType> INTERFACE_MAP = new HashMap<>();
-    private static final List<ClassInfo> TYPE_TODO_LIST = new ArrayList<>();
-    private static final Map<DotName, Jsonb> INPUT_JSON_MAP = new HashMap<>();
-    private static final Map<DotName, Map<String, Argument>> ARGUMENT_MAP = new HashMap<>();
-    private static final GraphQLCodeRegistry.Builder CODE_REGISTRY_BUILDER = GraphQLCodeRegistry.newCodeRegistry();
+    private final Map<DotName, GraphQLInputType> INPUT_MAP = new HashMap<>();
+    private final Map<DotName, GraphQLOutputType> TYPE_MAP = new HashMap<>();
+    private final Map<DotName, GraphQLEnumType> ENUM_MAP = new HashMap<>();
+    private final Map<DotName, GraphQLInterfaceType> INTERFACE_MAP = new HashMap<>();
+    private final List<ClassInfo> TYPE_TODO_LIST = new ArrayList<>();
+    private final Map<DotName, Jsonb> INPUT_JSON_MAP = new HashMap<>();
+    private final Map<DotName, Map<String, Argument>> ARGUMENT_MAP = new HashMap<>();
+    private final GraphQLCodeRegistry.Builder CODE_REGISTRY_BUILDER = GraphQLCodeRegistry.newCodeRegistry();
 
     // Scalar map we can just create now.
-    private static final Map<DotName, GraphQLScalarType> SCALAR_MAP = new HashMap<>();
+    public final Map<DotName, GraphQLScalarType> SCALAR_MAP = new HashMap<>();
 
-    static {
+    public ObjectBag() {
 
         SCALAR_MAP.put(DotName.createSimple(char.class.getName()), Scalars.GraphQLString);
         SCALAR_MAP.put(DotName.createSimple(Character.class.getName()), Scalars.GraphQLString);
@@ -90,45 +87,45 @@ public class ObjectBag {
         mapType(new DateTimeScalar());
     }
 
-    private static void mapType(Transformable transformable) {
+    private void mapType(Transformable transformable) {
         for (Class c : transformable.getSupportedClasses()) {
             SCALAR_MAP.put(DotName.createSimple(c.getName()), (GraphQLScalarType) transformable);
         }
     }
 
-    public static Map<DotName, GraphQLInputType> getInputMap() {
+    public Map<DotName, GraphQLInputType> getInputMap() {
         return INPUT_MAP;
     }
 
-    public static Map<DotName, GraphQLOutputType> getTypeMap() {
+    public Map<DotName, GraphQLOutputType> getTypeMap() {
         return TYPE_MAP;
     }
 
-    public static Map<DotName, GraphQLEnumType> getEnumMap() {
+    public Map<DotName, GraphQLEnumType> getEnumMap() {
         return ENUM_MAP;
     }
 
-    public static Map<DotName, GraphQLInterfaceType> getInterfaceMap() {
+    public Map<DotName, GraphQLInterfaceType> getInterfaceMap() {
         return INTERFACE_MAP;
     }
 
-    public static List<ClassInfo> getTypeTodoList() {
+    public List<ClassInfo> getTypeTodoList() {
         return TYPE_TODO_LIST;
     }
 
-    public static Map<DotName, Jsonb> getInputJsonMap() {
+    public Map<DotName, Jsonb> getInputJsonMap() {
         return INPUT_JSON_MAP;
     }
 
-    public static Map<DotName, Map<String, Argument>> getArgumentMap() {
+    public Map<DotName, Map<String, Argument>> getArgumentMap() {
         return ARGUMENT_MAP;
     }
 
-    public static GraphQLCodeRegistry.Builder getCodeRegistryBuilder() {
+    public GraphQLCodeRegistry.Builder getCodeRegistryBuilder() {
         return CODE_REGISTRY_BUILDER;
     }
 
-    public static Map<DotName, GraphQLScalarType> getScalarMap() {
+    public Map<DotName, GraphQLScalarType> getScalarMap() {
         return SCALAR_MAP;
     }
 }

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/SmallRyeGraphQLBootstrap.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/SmallRyeGraphQLBootstrap.java
@@ -16,6 +16,8 @@
 
 package io.smallrye.graphql.bootstrap;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.jboss.jandex.IndexView;
 
 import graphql.schema.GraphQLSchema;
@@ -27,15 +29,17 @@ import io.smallrye.graphql.bootstrap.schema.GraphQLSchemaInitializer;
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
+@ApplicationScoped
 public class SmallRyeGraphQLBootstrap {
-    public static GraphQLSchema GRAPHQL_SCHEMA;
+    private GraphQLSchema graphQLSchema;
 
-    public static GraphQLSchema bootstrap(IndexView index) {
+    public GraphQLSchema bootstrap(IndexView index) {
         GraphQLSchemaInitializer graphQLSchemaInitializer = new GraphQLSchemaInitializer(index);
-        GRAPHQL_SCHEMA = graphQLSchemaInitializer.generateGraphQLSchema();
-        return GRAPHQL_SCHEMA;
+        graphQLSchema = graphQLSchemaInitializer.generateGraphQLSchema();
+        return graphQLSchema;
     }
 
-    private SmallRyeGraphQLBootstrap() {
+    public GraphQLSchema getSchema() {
+        return graphQLSchema;
     }
 }

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/schema/GraphQLSchemaInitializer.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/schema/GraphQLSchemaInitializer.java
@@ -59,7 +59,7 @@ import io.smallrye.graphql.bootstrap.type.OutputTypeCreator;
 public class GraphQLSchemaInitializer {
     private static final Logger LOG = Logger.getLogger(GraphQLSchemaInitializer.class.getName());
 
-    private final EnumTypeCreator enumTypeCreator = new EnumTypeCreator();
+    private final EnumTypeCreator enumTypeCreator;
 
     private final AnnotationsHelper annotationsHelper = new AnnotationsHelper();
     private final ArgumentsHelper argumentsHelper = new ArgumentsHelper();
@@ -70,10 +70,13 @@ public class GraphQLSchemaInitializer {
     private final OutputTypeCreator outputTypeCreator;
     private final InputTypeCreator inputTypeCreator;
 
+    private final ObjectBag objectBag = new ObjectBag();
+
     public GraphQLSchemaInitializer(IndexView index) {
         this.index = index;
-        this.inputTypeCreator = new InputTypeCreator(index);
-        this.outputTypeCreator = new OutputTypeCreator(index, inputTypeCreator);
+        this.inputTypeCreator = new InputTypeCreator(index, objectBag);
+        this.outputTypeCreator = new OutputTypeCreator(index, inputTypeCreator, objectBag);
+        this.enumTypeCreator = new EnumTypeCreator(objectBag);
     }
 
     public GraphQLSchema generateGraphQLSchema() {
@@ -103,8 +106,8 @@ public class GraphQLSchemaInitializer {
         }
 
         // Let's see what still needs to be done.
-        for (ClassInfo todo : ObjectBag.getTypeTodoList()) {
-            if (!ObjectBag.getTypeMap().containsKey(todo.name())) {
+        for (ClassInfo todo : objectBag.getTypeTodoList()) {
+            if (!objectBag.getTypeMap().containsKey(todo.name())) {
                 outputTypeCreator.create(todo);
             }
         }
@@ -119,14 +122,15 @@ public class GraphQLSchemaInitializer {
         GraphQLFieldDefinition graphQLFieldDefinition = getGraphQLFieldDefinition(queryAnnotation);
         builder = builder.field(graphQLFieldDefinition);
         MethodInfo methodInfo = queryAnnotation.target().asMethod();
-        ObjectBag.getCodeRegistryBuilder().dataFetcher(
+        objectBag.getCodeRegistryBuilder().dataFetcher(
                 FieldCoordinates.coordinates(annotationToScan.withoutPackagePrefix(),
                         graphQLFieldDefinition.getName()),
-                new ReflectionDataFetcher(methodInfo, argumentsHelper.toArguments(methodInfo), annotationsForMethod));
+                new ReflectionDataFetcher(methodInfo, argumentsHelper.toArguments(methodInfo), annotationsForMethod,
+                        objectBag));
 
         // return type
         if (!methodInfo.returnType().kind().equals(Type.Kind.VOID)) {
-            scanType(methodInfo.returnType(), ObjectBag.getTypeMap(), this.outputTypeCreator);
+            scanType(methodInfo.returnType(), objectBag.getTypeMap(), this.outputTypeCreator);
         } else {
             throw new VoidReturnNotAllowedException("Can not have a void return for [" + annotationToScan.withoutPackagePrefix()
                     + "] on method [" + methodInfo.name() + "]");
@@ -135,7 +139,7 @@ public class GraphQLSchemaInitializer {
         // arguments on getters and setter
         List<Type> parameters = methodInfo.parameters();
         for (Type parameter : parameters) {
-            scanType(parameter, ObjectBag.getInputMap(), this.inputTypeCreator);
+            scanType(parameter, objectBag.getInputMap(), this.inputTypeCreator);
         }
 
         return builder;
@@ -146,16 +150,16 @@ public class GraphQLSchemaInitializer {
         GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
 
         Set<GraphQLType> additionalTypes = new HashSet<>();
-        additionalTypes.addAll(ObjectBag.getEnumMap().values());
-        additionalTypes.addAll(ObjectBag.getTypeMap().values());
-        additionalTypes.addAll(ObjectBag.getInputMap().values());
-        additionalTypes.addAll(ObjectBag.getInterfaceMap().values());
+        additionalTypes.addAll(objectBag.getEnumMap().values());
+        additionalTypes.addAll(objectBag.getTypeMap().values());
+        additionalTypes.addAll(objectBag.getInputMap().values());
+        additionalTypes.addAll(objectBag.getInterfaceMap().values());
         schemaBuilder = schemaBuilder.additionalTypes(additionalTypes);
 
         schemaBuilder = schemaBuilder.query(query);
         schemaBuilder = schemaBuilder.mutation(mutation);
 
-        schemaBuilder = schemaBuilder.codeRegistry(ObjectBag.getCodeRegistryBuilder().build());
+        schemaBuilder = schemaBuilder.codeRegistry(objectBag.getCodeRegistryBuilder().build());
 
         return schemaBuilder.build();
     }
@@ -200,12 +204,12 @@ public class GraphQLSchemaInitializer {
                 scanType(typeInCollection, map, creator);
                 break;
             case PRIMITIVE:
-                if (!ObjectBag.getScalarMap().containsKey(type.name())) {
+                if (!objectBag.getScalarMap().containsKey(type.name())) {
                     LOG.warn("No scalar mapping for " + type.name() + WITH_KIND + type.kind());
                 }
                 break;
             case CLASS:
-                if (!ObjectBag.getScalarMap().containsKey(type.name())) {
+                if (!objectBag.getScalarMap().containsKey(type.name())) {
                     ClassInfo classInfo = index.getClassByName(type.name());
                     if (classInfo != null) {
                         scanClass(classInfo, map, creator);
@@ -236,9 +240,9 @@ public class GraphQLSchemaInitializer {
 
     private void scanEnum(ClassInfo classInfo) {
         if (Classes.isEnum(classInfo) &&
-                !ObjectBag.getEnumMap().containsKey(classInfo.name())) {
+                !objectBag.getEnumMap().containsKey(classInfo.name())) {
             GraphQLEnumType created = enumTypeCreator.create(classInfo);
-            ObjectBag.getEnumMap().putIfAbsent(classInfo.name(), created);
+            objectBag.getEnumMap().putIfAbsent(classInfo.name(), created);
         }
     }
 

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/type/EnumTypeCreator.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/type/EnumTypeCreator.java
@@ -41,9 +41,15 @@ public class EnumTypeCreator {
     private final DescriptionHelper descriptionHelper = new DescriptionHelper();
     private final AnnotationsHelper annotationsHelper = new AnnotationsHelper();
 
+    private final ObjectBag objectBag;
+
+    public EnumTypeCreator(ObjectBag objectBag) {
+        this.objectBag = objectBag;
+    }
+
     public GraphQLEnumType create(ClassInfo classInfo) {
-        if (ObjectBag.getEnumMap().containsKey(classInfo.name())) {
-            return ObjectBag.getEnumMap().get(classInfo.name());
+        if (objectBag.getEnumMap().containsKey(classInfo.name())) {
+            return objectBag.getEnumMap().get(classInfo.name());
         } else {
             Annotations annotations = annotationsHelper.getAnnotationsForClass(classInfo);
             String name = nameHelper.getEnumName(classInfo, annotations);
@@ -63,7 +69,7 @@ public class EnumTypeCreator {
                 }
             }
             GraphQLEnumType enumType = builder.build();
-            ObjectBag.getEnumMap().put(classInfo.name(), enumType);
+            objectBag.getEnumMap().put(classInfo.name(), enumType);
             return enumType;
         }
     }

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/typeresolver/OutputTypeResolver.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/typeresolver/OutputTypeResolver.java
@@ -31,16 +31,19 @@ public class OutputTypeResolver implements TypeResolver {
 
     private final DotName interfaceName;
 
-    public OutputTypeResolver(DotName interfaceName) {
+    private final ObjectBag objectBag;
+
+    public OutputTypeResolver(DotName interfaceName, ObjectBag objectBag) {
         this.interfaceName = interfaceName;
+        this.objectBag = objectBag;
     }
 
     @Override
     public GraphQLObjectType getType(TypeResolutionEnvironment tre) {
 
         DotName lookingForContrete = DotName.createSimple(tre.getObject().getClass().getName());
-        if (ObjectBag.getTypeMap().containsKey(lookingForContrete)) {
-            return GraphQLObjectType.class.cast(ObjectBag.getTypeMap().get(lookingForContrete));
+        if (objectBag.getTypeMap().containsKey(lookingForContrete)) {
+            return GraphQLObjectType.class.cast(objectBag.getTypeMap().get(lookingForContrete));
         } else {
             throw new ConcreteImplementationNotFoundException(
                     "No concrete class named [" + lookingForContrete + "] found for interface ["

--- a/implementation/src/main/java/io/smallrye/graphql/cdi/CDIDelegate.java
+++ b/implementation/src/main/java/io/smallrye/graphql/cdi/CDIDelegate.java
@@ -1,0 +1,50 @@
+/*
+  * Copyright 2020 Red Hat, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package io.smallrye.graphql.cdi;
+
+import java.util.ServiceLoader;
+
+import javax.enterprise.inject.spi.CDI;
+
+public interface CDIDelegate {
+
+    public static CDIDelegate delegate() {
+        try {
+            ServiceLoader<CDIDelegate> sl = ServiceLoader.load(CDIDelegate.class);
+            return sl.iterator().next();
+        } catch (Exception ex) {
+            return new CDIDelegate() {
+
+                @Override
+                public Class<?> getClassFromCDI(Class<?> declaringClass) {
+                    Object declaringObject = getInstanceFromCDI(declaringClass);
+                    return declaringObject.getClass();
+                }
+
+                @Override
+                public Object getInstanceFromCDI(Class<?> declaringClass) {
+                    return CDI.current().select(declaringClass).get();
+                }
+            };
+        }
+    }
+
+    Class<?> getClassFromCDI(Class<?> declaringClass);
+
+    Object getInstanceFromCDI(Class<?> declaringClass);
+
+}

--- a/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -66,10 +66,21 @@ public class ExecutionService {
     @Inject
     private GraphQLConfig config;
 
+    @Inject
+    private SmallRyeGraphQLBootstrap bootstrap;
+
+    public ExecutionService() {
+    }
+
+    public ExecutionService(GraphQLConfig config, SmallRyeGraphQLBootstrap bootstrap) {
+        this.config = config;
+        this.bootstrap = bootstrap;
+    }
+
     @PostConstruct
     public void init() {
         ExceptionHandler exceptionHandler = new ExceptionHandler(config);
-        this.graphQL = getGraphQL(SmallRyeGraphQLBootstrap.GRAPHQL_SCHEMA, exceptionHandler);
+        this.graphQL = getGraphQL(bootstrap.getSchema(), exceptionHandler);
     }
 
     public JsonObject execute(JsonObject jsonInput) {
@@ -212,7 +223,7 @@ public class ExecutionService {
     private GraphQL getGraphQL(GraphQLSchema graphQLSchema, ExceptionHandler exceptionHandler) {
         if (graphQLSchema != null) {
             return GraphQL
-                    .newGraphQL(SmallRyeGraphQLBootstrap.GRAPHQL_SCHEMA)
+                    .newGraphQL(graphQLSchema)
                     .queryExecutionStrategy(new QueryExecutionStrategy(exceptionHandler))
                     .mutationExecutionStrategy(new MutationExecutionStrategy(exceptionHandler))
                     .build();

--- a/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -93,14 +93,14 @@ public class ExecutionService {
                     .executionId(ExecutionId.generate());
 
             // Variables
-            if (jsonInput.containsKey(VARIABLES)) {
-                JsonValue jvariables = jsonInput.get(VARIABLES);
-                if (!jvariables.equals(JsonValue.NULL)
-                        && !jvariables.equals(JsonValue.EMPTY_JSON_OBJECT)
-                        && !jvariables.equals(JsonValue.EMPTY_JSON_ARRAY)) {
-                    Map<String, Object> variables = toMap(jsonInput.getJsonObject(VARIABLES));
-                    executionBuilder.variables(variables);
-                }
+            JsonValue jvariables = jsonInput.get(VARIABLES);
+            if (null != jvariables
+                    && !JsonValue.NULL.equals(jvariables)
+                    && !JsonValue.EMPTY_JSON_OBJECT.equals(jvariables)
+                    && !JsonValue.EMPTY_JSON_ARRAY.equals(jvariables)) {
+
+                Map<String, Object> variables = toMap(jvariables.asJsonObject());
+                executionBuilder.variables(variables);
             }
 
             // Operation name


### PR DESCRIPTION
- Replaces some static variables with instance/local variables.  
- Small classloading change in Argument.java.
- Adding some constructors to allow this implementation to be used without declaring the implementation JAR(s) as bean deployment archives.
- Adding new `CDIDelegate` mechanism to allow app server vendors to swap in their own CDI calls to avoid `CDI.current()....` calls.

Fixes #84.