### PR TITLE
[#91] New metrics module for MP Metrics support

### DIFF
--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-graphql-parent</artifactId>
+        <version>1.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-graphql-metrics</artifactId>
+    <name>SmallRye: MicroProfile GraphQL Metrics Integration :: Metrics</name>
+
+    <dependencies>
+
+        <!-- The Implementation -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-graphql</artifactId>
+        </dependency>
+        <!-- From MicroProfile -->
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <version>1.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <version>2.3</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <properties>
+                <argLine>@{jacocoArgLine}</argLine>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/metrics/src/main/java/io/smallrye/graphql/metrics/MetricsInterceptor.java
+++ b/metrics/src/main/java/io/smallrye/graphql/metrics/MetricsInterceptor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.graphql.metrics;
+
+import java.lang.reflect.Method;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricRegistry.Type;
+import org.eclipse.microprofile.metrics.SimpleTimer;
+import org.eclipse.microprofile.metrics.SimpleTimer.Context;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.jboss.logging.Logger;
+
+@Dependent
+@GraphQLApi
+@Interceptor
+@Priority(Interceptor.Priority.PLATFORM_AFTER)
+public class MetricsInterceptor {
+    private final static Logger LOG = Logger.getLogger(MetricsInterceptor.class);
+    private final static String PREFIX = "mp_graphql_";
+
+    private MetricRegistry metrics;
+
+    @AroundInvoke
+    public Object captureMetrics(InvocationContext ctx) throws Exception {
+        Method m = ctx.getMethod();
+        String fqMethodName = PREFIX + m.getDeclaringClass().getName() + "." + m.getName();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("invoking " + fqMethodName);
+        }
+        SimpleTimer timer = getMetrics().simpleTimer(fqMethodName);
+        try (Context c = timer.time()) {
+            return ctx.proceed();
+        } finally {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("invoked " + timer.getCount() + " times");
+            }
+        }
+    }
+
+    protected MetricRegistry getMetrics() {
+        return metrics;
+    }
+
+    @Inject
+    @RegistryType(type = Type.VENDOR)
+    protected void setMetrics(MetricRegistry metrics) {
+        this.metrics = metrics;
+    }
+}

--- a/metrics/src/main/resources/META-INF/beans.xml
+++ b/metrics/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       bean-discovery-mode="all" >
+
+  <interceptors>
+    <class>io.smallrye.graphql.metrics.MetricsInterceptor</class>
+  </interceptors>
+</beans>

--- a/metrics/src/test/java/io/smallrye/grapqhql/metrics/MetricsInterceptorTest.java
+++ b/metrics/src/test/java/io/smallrye/grapqhql/metrics/MetricsInterceptorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.graphql.metrics;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+public class MetricsInterceptorTest {
+
+    @Test
+    public void testMetricsInterceptor() throws Exception {
+        Method mockGraphQLApiMethod = MetricsInterceptorTest.class.getMethod("testMetricsInterceptor");
+        MockMetricRegistry mockRegistry = new MockMetricRegistry();
+        MetricsInterceptor interceptor = new MockMetricsInterceptor(mockRegistry);
+        MockInvocationContext mockInvocationContext = new MockInvocationContext();
+        mockInvocationContext.method = mockGraphQLApiMethod;
+        mockInvocationContext.proceedSupplier = () -> {
+            return "It worked!";
+        };
+
+        String metricName = "mp_graphql_io.smallrye.graphql.metrics.MetricsInterceptorTest.testMetricsInterceptor";
+        Object o = interceptor.captureMetrics(mockInvocationContext);
+        assertEquals("It worked!", o);
+        assertEquals(1, mockRegistry.simpleTimers.size());
+        assertEquals(1, mockRegistry.simpleTimers.get(metricName).getCount());
+
+        o = interceptor.captureMetrics(mockInvocationContext);
+        assertEquals("It worked!", o);
+        assertEquals(1, mockRegistry.simpleTimers.size());
+        assertEquals(2, mockRegistry.simpleTimers.get(metricName).getCount());
+
+    }
+}

--- a/metrics/src/test/java/io/smallrye/grapqhql/metrics/MockInvocationContext.java
+++ b/metrics/src/test/java/io/smallrye/grapqhql/metrics/MockInvocationContext.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.graphql.metrics;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import javax.interceptor.InvocationContext;
+
+public class MockInvocationContext implements InvocationContext {
+
+    Constructor<?> constructor;
+    Map<String, Object> contextData;
+    Method method;
+    Object[] parameters;
+    Object target;
+    Object timer;
+    Supplier<?> proceedSupplier;
+
+    @Override
+    public Constructor<?> getConstructor() {
+        return constructor;
+    }
+
+    @Override
+    public Map<String, Object> getContextData() {
+        return contextData;
+    }
+
+    @Override
+    public Method getMethod() {
+        return method;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public void setParameters(Object[] parameters) {
+        this.parameters = parameters;
+    }
+
+    @Override
+    public Object getTarget() {
+        return target;
+    }
+
+    @Override
+    public Object getTimer() {
+        return timer;
+    }
+
+    @Override
+    public Object proceed() throws Exception {
+        return proceedSupplier.get();
+    }
+}

--- a/metrics/src/test/java/io/smallrye/grapqhql/metrics/MockMetricRegistry.java
+++ b/metrics/src/test/java/io/smallrye/grapqhql/metrics/MockMetricRegistry.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2020 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.graphql.metrics;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+
+import org.eclipse.microprofile.metrics.*;
+
+public class MockMetricRegistry extends MetricRegistry {
+
+    Map<String, SimpleTimer> simpleTimers = new HashMap<>();
+
+    @Override
+    public SimpleTimer simpleTimer(String name) {
+        SimpleTimer simpleTimer = simpleTimers.computeIfAbsent(name, k -> new MockSimpleTimer());
+        return simpleTimer;
+    }
+
+    @Override
+    public ConcurrentGauge concurrentGauge(Metadata metadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConcurrentGauge concurrentGauge(Metadata metadata, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConcurrentGauge concurrentGauge(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConcurrentGauge concurrentGauge(String name, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Counter counter(Metadata metadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Counter counter(Metadata metadata, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Counter counter(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Counter counter(String name, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, ConcurrentGauge> getConcurrentGauges() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, ConcurrentGauge> getConcurrentGauges(MetricFilter filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, Counter> getCounters() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, Counter> getCounters(MetricFilter filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, Gauge> getGauges() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, Gauge> getGauges(MetricFilter filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, Histogram> getHistograms() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, Histogram> getHistograms(MetricFilter filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Metadata> getMetadata() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, Meter> getMeters() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, Meter> getMeters(MetricFilter filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedSet<MetricID> getMetricIDs() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<MetricID, Metric> getMetrics() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedSet<String> getNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, SimpleTimer> getSimpleTimers() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, SimpleTimer> getSimpleTimers(MetricFilter filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, Timer> getTimers() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedMap<MetricID, Timer> getTimers(MetricFilter filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Histogram histogram(Metadata metadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Histogram histogram(Metadata metadata, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Histogram histogram(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Histogram histogram(String name, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Meter meter(Metadata metadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Meter meter(Metadata metadata, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Meter meter(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Meter meter(String name, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends Metric> T register(Metadata metadata, T metric) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends Metric> T register(Metadata metadata, T metric, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends Metric> T register(String name, T metric) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(MetricID metricID) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeMatching(MetricFilter filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SimpleTimer simpleTimer(Metadata metadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SimpleTimer simpleTimer(Metadata metadata, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SimpleTimer simpleTimer(String name, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Timer timer(Metadata metadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Timer timer(Metadata metadata, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Timer timer(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Timer timer(String name, Tag... tags) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/metrics/src/test/java/io/smallrye/grapqhql/metrics/MockMetricsInterceptor.java
+++ b/metrics/src/test/java/io/smallrye/grapqhql/metrics/MockMetricsInterceptor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.graphql.metrics;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+
+public class MockMetricsInterceptor extends MetricsInterceptor {
+
+    MockMetricsInterceptor(MetricRegistry metrics) {
+        setMetrics(metrics);
+    }
+}

--- a/metrics/src/test/java/io/smallrye/grapqhql/metrics/MockSimpleTimer.java
+++ b/metrics/src/test/java/io/smallrye/grapqhql/metrics/MockSimpleTimer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.graphql.metrics;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+
+import org.eclipse.microprofile.metrics.SimpleTimer;
+import org.eclipse.microprofile.metrics.SimpleTimer.Context;
+
+public class MockSimpleTimer implements SimpleTimer {
+
+    private long count;
+    private Duration elapsedTime = Duration.ofMillis(0);
+
+    @Override
+    public long getCount() {
+        return count;
+    }
+
+    @Override
+    public Duration getElapsedTime() {
+        return elapsedTime;
+    }
+
+    @Override
+    public Context time() {
+        return new MockContext(this);
+    }
+
+    @Override
+    public <T> T time(Callable<T> event) throws Exception {
+        try (Context c = time()) {
+            return event.call();
+        }
+    }
+
+    @Override
+    public void time(Runnable event) {
+        try (Context c = time()) {
+            event.run();
+        }
+    }
+
+    @Override
+    public void update(Duration duration) {
+        elapsedTime.plus(duration);
+    }
+
+    public static class MockContext implements Context {
+        final MockSimpleTimer simpleTimer;
+        final long startTime;
+
+        MockContext(MockSimpleTimer simpleTimer) {
+            this.simpleTimer = simpleTimer;
+            simpleTimer.count++;
+            startTime = System.currentTimeMillis();
+        }
+
+        @Override
+        public void close() {
+            stop();
+        }
+
+        @Override
+        public long stop() {
+            long elapsed = System.currentTimeMillis() - startTime;
+            simpleTimer.elapsedTime.plusMillis(elapsed);
+            return elapsed;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <modules>
         <module>implementation</module>
         <module>implementation-servlet</module>
+        <module>metrics</module>
         <module>tck</module>
         <module>runner</module>
     </modules>


### PR DESCRIPTION
This approach uses CDI interceptors, which I understand is less popular in SmallRye?  The reason for choosing this approach is to give users the option of whether or not to collect metrics.  If they want that ability (and have the MP Metrics dependency), then they just need to pull in this new module.  If they don't, then they keep operating as normal - just pulling in the implementation module.

If it comes to it, we could probably replace the interceptor approach by instrumenting the actual implementation code, but my preference would be to leave that separate so that users could run MP GraphQL without needing MP Metrics.

Fixes #91