### PR TITLE
[#97] Avoid logging error on unexpected Collection

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
              <groupId>junit</groupId>
              <artifactId>junit</artifactId>
-             <version>4.13</version>
              <scope>test</scope>
          </dependency>
     </dependencies>

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -64,6 +64,14 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Testing -->
+        <dependency>
+             <groupId>junit</groupId>
+             <artifactId>junit</artifactId>
+             <version>4.13</version>
+             <scope>test</scope>
+         </dependency>
     </dependencies>
 
     <profiles>

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/ReflectionDataFetcher.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/ReflectionDataFetcher.java
@@ -65,7 +65,6 @@ public class ReflectionDataFetcher implements DataFetcher {
     private final List<Argument> arguments;
     private final boolean hasArguments;
     private final String methodName;
-    private final CollectionHelper collectionHelper = new CollectionHelper();
 
     private final Class declaringClass;
     private final Class[] parameterClasses;
@@ -218,7 +217,7 @@ public class ReflectionDataFetcher implements DataFetcher {
     private Object handleCollection(Object argumentValue, Argument a) throws GraphQLException {
         Class clazz = a.getArgumentClass();
         Type type = a.getType();
-        Collection convertedList = collectionHelper.newCollection(clazz);
+        Collection convertedList = CollectionHelper.newCollection(clazz);
 
         Collection givenCollection = (Collection) argumentValue;
 

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/TransformableDataFetcherHelper.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/TransformableDataFetcherHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.smallrye.graphql.bootstrap.datafetcher;
 
 import java.text.NumberFormat;
@@ -20,7 +36,6 @@ import io.smallrye.graphql.bootstrap.schema.helper.FormatHelper;
  */
 public class TransformableDataFetcherHelper {
     private final FormatHelper formatHelper = new FormatHelper();
-    private final CollectionHelper collectionHelper = new CollectionHelper();
 
     private DateTimeFormatter dateTimeFormatter = null;
     private NumberFormat numberFormat = null;
@@ -45,7 +60,7 @@ public class TransformableDataFetcherHelper {
             }
         } else if (Collection.class.isInstance(o)) {
             Collection collection = Collection.class.cast(o);
-            Collection transformedCollection = collectionHelper.newCollection(o.getClass());
+            Collection transformedCollection = CollectionHelper.newCollection(o.getClass());
             for (Object oo : collection) {
                 transformedCollection.add(transform(oo));
             }

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/TransformableDataFetcherHelper.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/TransformableDataFetcherHelper.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.smallrye.graphql.bootstrap.datafetcher;
 
 import java.text.NumberFormat;

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/schema/helper/CollectionHelper.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/schema/helper/CollectionHelper.java
@@ -15,8 +15,6 @@
  */
 package io.smallrye.graphql.bootstrap.schema.helper;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -40,20 +38,17 @@ public class CollectionHelper {
      * @param type the collection class
      * @return the collection
      */
-    public Collection newCollection(Class type) {
-        if (type.equals(Collection.class) || type.equals(List.class)) {
-            return new ArrayList();
-        } else if (type.equals(Set.class)) {
-            return new HashSet();
-        } else {
-            try {
-                Constructor constructor = type.getConstructor();
-                constructor.setAccessible(true);
-                return (Collection) constructor.newInstance();
-            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException ex) {
-                LOG.error("Can not create new collection of [" + type.getName() + "]", ex);
-                return new ArrayList(); // default ?
+    public static Collection<?> newCollection(Class<?> type) {
+        try {
+            return (Collection<?>) type.newInstance();
+        } catch (Exception ex) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Can not create no-arg collection instance of [" + type + "]", ex);
             }
         }
+        if (Set.class.isAssignableFrom(type)) {
+            return new HashSet<>();
+        }
+        return new ArrayList<>();
     }
 }

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/schema/helper/CollectionHelper.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/schema/helper/CollectionHelper.java
@@ -42,9 +42,7 @@ public class CollectionHelper {
         try {
             return (Collection<?>) type.newInstance();
         } catch (Exception ex) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Can not create no-arg collection instance of [" + type + "]", ex);
-            }
+            LOG.debug("Cannot create no-arg instance of [" + (type == null ? "null" : type.getName()) + "]", ex);
         }
         if (Set.class.isAssignableFrom(type)) {
             return new HashSet<>();

--- a/implementation/src/test/java/io/smallrye/graphql/bootstrap/schema/helper/CollectionHelperTest.java
+++ b/implementation/src/test/java/io/smallrye/graphql/bootstrap/schema/helper/CollectionHelperTest.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.graphql.bootstrap.schema.helper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeSet;
+import java.util.Vector;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.Test;
+
+public class CollectionHelperTest {
+
+    private void test(Collection<?> c, Class<?> expected) {
+        assertTrue("Return value is null", c != null);
+        assertEquals("Unexpected type returned, expected " + expected + ", found: " + c.getClass(),
+                expected, c.getClass());
+        assertTrue("Unexpected non-empty collection returned: " + c, c.isEmpty());
+    }
+
+    @Test
+    public void newCollection_Set() throws Exception {
+        test(CollectionHelper.newCollection(Set.class), HashSet.class);
+
+    }
+
+    @Test
+    public void newCollection_HashSet() throws Exception {
+        test(CollectionHelper.newCollection(HashSet.class), HashSet.class);
+    }
+
+    @Test
+    public void newCollection_LinkedHashSet() throws Exception {
+        test(CollectionHelper.newCollection(LinkedHashSet.class), LinkedHashSet.class);
+    }
+
+    @Test
+    public void newCollection_TreeSet() throws Exception {
+        test(CollectionHelper.newCollection(TreeSet.class), TreeSet.class);
+    }
+
+    @Test
+    public void newCollection_ConcurrentSkipListSet() throws Exception {
+        test(CollectionHelper.newCollection(ConcurrentSkipListSet.class), ConcurrentSkipListSet.class);
+    }
+
+    @Test
+    public void newCollection_CustomSet() throws Exception {
+        test(CollectionHelper.newCollection(CustomSet.class), HashSet.class);
+    }
+
+    @Test
+    public void newCollection_EmptySet() throws Exception {
+        test(CollectionHelper.newCollection(Collections.EMPTY_SET.getClass()), HashSet.class);
+    }
+
+    @Test
+    public void newCollection_EmptySetMethod() throws Exception {
+        test(CollectionHelper.newCollection(Collections.emptySet().getClass()), HashSet.class);
+    }
+
+    @Test
+    public void newCollection_CollectionsSingleton() throws Exception {
+        test(CollectionHelper.newCollection(Collections.singleton("foo").getClass()), HashSet.class);
+    }
+
+    @Test
+    public void newCollection_Collection() throws Exception {
+        test(CollectionHelper.newCollection(Collection.class), ArrayList.class);
+    }
+
+    @Test
+    public void newCollection_List() throws Exception {
+        test(CollectionHelper.newCollection(List.class), ArrayList.class);
+    }
+
+    @Test
+    public void newCollection_ArrayList() throws Exception {
+        test(CollectionHelper.newCollection(ArrayList.class), ArrayList.class);
+    }
+
+    @Test
+    public void newCollection_LinkedList() throws Exception {
+        test(CollectionHelper.newCollection(LinkedList.class), LinkedList.class);
+    }
+
+    @Test
+    public void newCollection_Stack() throws Exception {
+        test(CollectionHelper.newCollection(Stack.class), Stack.class);
+    }
+
+    @Test
+    public void newCollection_Vector() throws Exception {
+        test(CollectionHelper.newCollection(Vector.class), Vector.class);
+    }
+
+    @Test
+    public void newCollection_CopyOnWriteArrayList() throws Exception {
+        test(CollectionHelper.newCollection(CopyOnWriteArrayList.class), CopyOnWriteArrayList.class);
+    }
+
+    @Test
+    public void newCollection_CustomList() throws Exception {
+        test(CollectionHelper.newCollection(CustomList.class), CustomList.class);
+    }
+
+    @Test
+    public void newCollection_EmptyList() throws Exception {
+        test(CollectionHelper.newCollection(Collections.EMPTY_LIST.getClass()), ArrayList.class);
+    }
+
+    @Test
+    public void newCollection_EmptyListMethod() throws Exception {
+        test(CollectionHelper.newCollection(Collections.emptyList().getClass()), ArrayList.class);
+    }
+
+    @Test
+    public void newCollection_CollectionsSingletonList() throws Exception {
+        test(CollectionHelper.newCollection(Collections.singletonList("foo").getClass()), ArrayList.class);
+    }
+
+    static class CustomSet implements Set<Object> {
+
+        private CustomSet(String someString) {
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return false;
+        }
+
+        @Override
+        public Iterator<Object> iterator() {
+            return null;
+        }
+
+        @Override
+        public Object[] toArray() {
+            return null;
+        }
+
+        @Override
+        public <T> T[] toArray(T[] a) {
+            return null;
+        }
+
+        @Override
+        public boolean add(Object e) {
+            return false;
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            return false;
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> c) {
+            return false;
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends Object> c) {
+            return false;
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            return false;
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
+            return false;
+        }
+
+        @Override
+        public void clear() {
+        }
+    }
+
+    static class CustomList implements List<Object> {
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return false;
+        }
+
+        @Override
+        public Iterator<Object> iterator() {
+            return null;
+        }
+
+        @Override
+        public Object[] toArray() {
+            return null;
+        }
+
+        @Override
+        public <T> T[] toArray(T[] a) {
+            return null;
+        }
+
+        @Override
+        public boolean add(Object e) {
+            return false;
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            return false;
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> c) {
+            return false;
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends Object> c) {
+            return false;
+        }
+
+        @Override
+        public boolean addAll(int index, Collection<? extends Object> c) {
+            return false;
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
+            return false;
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            return false;
+        }
+
+        @Override
+        public void clear() {
+        }
+
+        @Override
+        public Object get(int index) {
+            return null;
+        }
+
+        @Override
+        public Object set(int index, Object element) {
+            return null;
+        }
+
+        @Override
+        public void add(int index, Object element) {
+        }
+
+        @Override
+        public Object remove(int index) {
+            return null;
+        }
+
+        @Override
+        public int indexOf(Object o) {
+            return 0;
+        }
+
+        @Override
+        public int lastIndexOf(Object o) {
+            return 0;
+        }
+
+        @Override
+        public ListIterator<Object> listIterator() {
+            return null;
+        }
+
+        @Override
+        public ListIterator<Object> listIterator(int index) {
+            return null;
+        }
+
+        @Override
+        public List<Object> subList(int fromIndex, int toIndex) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
- Made CollectionHelper.newCollection to be static
- Avoid logging an error when unexpected Collection type is passed in - maybe we do want an error logged if a non-Collection type is passed in?
- Added Copyright header to TransformableDataFetcherHelper
- Added unit tests for CollectionHelper

Fixes #97 