### PR TITLE
fix #100: introduce JUnit 5 (and assertj)

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -13,6 +13,8 @@
 
     <properties>
         <graphql-java.version>14.0</graphql-java.version>
+        <junit-jupiter.version>5.6.1</junit-jupiter.version>
+        <assertj.version>3.15.0</assertj.version>
     </properties>
 
     <dependencies>
@@ -67,10 +69,17 @@
 
         <!-- Testing -->
         <dependency>
-             <groupId>junit</groupId>
-             <artifactId>junit</artifactId>
-             <scope>test</scope>
-         </dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/implementation/src/test/java/io/smallrye/graphql/bootstrap/schema/helper/CollectionHelperTest.java
+++ b/implementation/src/test/java/io/smallrye/graphql/bootstrap/schema/helper/CollectionHelperTest.java
@@ -15,8 +15,7 @@
  */
 package io.smallrye.graphql.bootstrap.schema.helper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,115 +33,93 @@ import java.util.Vector;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class CollectionHelperTest {
+class CollectionHelperTest {
 
     private void test(Collection<?> c, Class<?> expected) {
-        assertTrue("Return value is null", c != null);
-        assertEquals("Unexpected type returned, expected " + expected + ", found: " + c.getClass(),
-                expected, c.getClass());
-        assertTrue("Unexpected non-empty collection returned: " + c, c.isEmpty());
+        assertThat(c).isNotNull();
+        assertThat(c.getClass()).isEqualTo(expected);
+        assertThat(c).isEmpty();
     }
 
-    @Test
-    public void newCollection_Set() throws Exception {
+    @Test void newCollection_Set() {
         test(CollectionHelper.newCollection(Set.class), HashSet.class);
-
     }
 
-    @Test
-    public void newCollection_HashSet() throws Exception {
+    @Test void newCollection_HashSet() {
         test(CollectionHelper.newCollection(HashSet.class), HashSet.class);
     }
 
-    @Test
-    public void newCollection_LinkedHashSet() throws Exception {
+    @Test void newCollection_LinkedHashSet() {
         test(CollectionHelper.newCollection(LinkedHashSet.class), LinkedHashSet.class);
     }
 
-    @Test
-    public void newCollection_TreeSet() throws Exception {
+    @Test void newCollection_TreeSet() {
         test(CollectionHelper.newCollection(TreeSet.class), TreeSet.class);
     }
 
-    @Test
-    public void newCollection_ConcurrentSkipListSet() throws Exception {
+    @Test void newCollection_ConcurrentSkipListSet() {
         test(CollectionHelper.newCollection(ConcurrentSkipListSet.class), ConcurrentSkipListSet.class);
     }
 
-    @Test
-    public void newCollection_CustomSet() throws Exception {
+    @Test void newCollection_CustomSet() {
         test(CollectionHelper.newCollection(CustomSet.class), HashSet.class);
     }
 
-    @Test
-    public void newCollection_EmptySet() throws Exception {
+    @Test void newCollection_EmptySet() {
         test(CollectionHelper.newCollection(Collections.EMPTY_SET.getClass()), HashSet.class);
     }
 
-    @Test
-    public void newCollection_EmptySetMethod() throws Exception {
+    @Test void newCollection_EmptySetMethod() {
         test(CollectionHelper.newCollection(Collections.emptySet().getClass()), HashSet.class);
     }
 
-    @Test
-    public void newCollection_CollectionsSingleton() throws Exception {
+    @Test void newCollection_CollectionsSingleton() {
         test(CollectionHelper.newCollection(Collections.singleton("foo").getClass()), HashSet.class);
     }
 
-    @Test
-    public void newCollection_Collection() throws Exception {
+    @Test void newCollection_Collection() {
         test(CollectionHelper.newCollection(Collection.class), ArrayList.class);
     }
 
-    @Test
-    public void newCollection_List() throws Exception {
+    @Test void newCollection_List() {
         test(CollectionHelper.newCollection(List.class), ArrayList.class);
     }
 
-    @Test
-    public void newCollection_ArrayList() throws Exception {
+    @Test void newCollection_ArrayList() {
         test(CollectionHelper.newCollection(ArrayList.class), ArrayList.class);
     }
 
-    @Test
-    public void newCollection_LinkedList() throws Exception {
+    @Test void newCollection_LinkedList() {
         test(CollectionHelper.newCollection(LinkedList.class), LinkedList.class);
     }
 
-    @Test
-    public void newCollection_Stack() throws Exception {
+    @Test void newCollection_Stack() {
         test(CollectionHelper.newCollection(Stack.class), Stack.class);
     }
 
-    @Test
-    public void newCollection_Vector() throws Exception {
+    @Test void newCollection_Vector() {
         test(CollectionHelper.newCollection(Vector.class), Vector.class);
     }
 
-    @Test
-    public void newCollection_CopyOnWriteArrayList() throws Exception {
+    @Test void newCollection_CopyOnWriteArrayList() {
         test(CollectionHelper.newCollection(CopyOnWriteArrayList.class), CopyOnWriteArrayList.class);
     }
 
-    @Test
-    public void newCollection_CustomList() throws Exception {
+    @Test void newCollection_CustomList() {
         test(CollectionHelper.newCollection(CustomList.class), CustomList.class);
     }
 
-    @Test
-    public void newCollection_EmptyList() throws Exception {
+    @Test void newCollection_EmptyList() {
         test(CollectionHelper.newCollection(Collections.EMPTY_LIST.getClass()), ArrayList.class);
     }
 
-    @Test
-    public void newCollection_EmptyListMethod() throws Exception {
+    @Test void newCollection_EmptyListMethod() {
         test(CollectionHelper.newCollection(Collections.emptyList().getClass()), ArrayList.class);
     }
 
-    @Test
-    public void newCollection_CollectionsSingletonList() throws Exception {
+    @Test void newCollection_CollectionsSingletonList() {
         test(CollectionHelper.newCollection(Collections.singletonList("foo").getClass()), ArrayList.class);
     }
 


### PR DESCRIPTION
`smallrye-parent` doesn't contain a version property or a managed dependency for JUnit 5, so I added a property and the dependency to the implementation module directly. The tck uses TestNG instead. The actual change is a different import and the test class and the test methods can be package private.

I also introduced [assertj](https://assertj.github.io/doc/) as that gives nice code and nice failure messages. What do you think?