### PR TITLE
Fix ConcurrentModificationException while iterating over type-todo-list

### DIFF
--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/SmallRyeGraphQLBootstrap.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/SmallRyeGraphQLBootstrap.java
@@ -111,7 +111,8 @@ public class SmallRyeGraphQLBootstrap {
         }
 
         // Let's see what still needs to be done.
-        for (ClassInfo todo : objectBag.getTypeTodoList()) {
+        while (!objectBag.getTypeTodoList().isEmpty()) { // Don't iterate to prevent ConcurrentModificationException
+            ClassInfo todo = objectBag.getTypeTodoList().remove(0);
             if (!objectBag.getTypeMap().containsKey(todo.name())) {
                 outputTypeCreator.create(todo);
             }


### PR DESCRIPTION
if a type in the todo-list contained other, unprocessed, types as fields, the for-each-loop failed with a `ConcurrentModificationException` when the outputTypeCreator added those to the todo-list.

This PR fixes this with replacing the for-each-loop with `isEmpty` and `remove`.