### PR TITLE
Add inputTypeTodoList analogous to typeTodoList

### DIFF
--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/ObjectBag.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/ObjectBag.java
@@ -58,6 +58,7 @@ public class ObjectBag {
     private final Map<DotName, GraphQLEnumType> ENUM_MAP = new HashMap<>();
     private final Map<DotName, GraphQLInterfaceType> INTERFACE_MAP = new HashMap<>();
     private final List<ClassInfo> TYPE_TODO_LIST = new ArrayList<>();
+    private final List<ClassInfo> INPUT_TYPE_TODO_LIST = new ArrayList<>();
     private final Map<DotName, Jsonb> INPUT_JSON_MAP = new HashMap<>();
     private final Map<DotName, Map<String, Argument>> ARGUMENT_MAP = new HashMap<>();
     private final GraphQLCodeRegistry.Builder CODE_REGISTRY_BUILDER = GraphQLCodeRegistry.newCodeRegistry();
@@ -111,6 +112,10 @@ public class ObjectBag {
 
     public List<ClassInfo> getTypeTodoList() {
         return TYPE_TODO_LIST;
+    }
+
+    public List<ClassInfo> getInputTypeTodoList() {
+        return INPUT_TYPE_TODO_LIST;
     }
 
     public Map<DotName, Jsonb> getInputJsonMap() {

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/SmallRyeGraphQLBootstrap.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/SmallRyeGraphQLBootstrap.java
@@ -118,6 +118,13 @@ public class SmallRyeGraphQLBootstrap {
             }
         }
 
+        while (!objectBag.getInputTypeTodoList().isEmpty()) { // Don't iterate to prevent ConcurrentModificationException
+            ClassInfo todo = objectBag.getInputTypeTodoList().remove(0);
+            if (!objectBag.getInputMap().containsKey(todo.name())) {
+                inputTypeCreator.create(todo);
+            }
+        }
+
         return createGraphQLSchema(queryBuilder.build(), mutationBuilder.build());
     }
 

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/type/InputTypeCreator.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/type/InputTypeCreator.java
@@ -224,6 +224,7 @@ public class InputTypeCreator implements Creator {
                 } else if (objectBag.getInputMap().containsKey(classInfo.name())) {
                     return objectBag.getInputMap().get(classInfo.name());
                 } else {
+                    objectBag.getInputTypeTodoList().add(classInfo);
                     Annotations annotationsForThisClass = annotationsHelper.getAnnotationsForClass(classInfo);
                     String name = nameHelper.getInputTypeName(classInfo, annotationsForThisClass);
                     return GraphQLTypeReference.typeRef(name);


### PR DESCRIPTION
InputTypes for methods with `@Source`-Arguments were added as type-refs, but not created as Types, if not used otherwise.

This PR adds a todo-list for input-types, analogous to typeTodoList, to create those types.