### PR TITLE
Support for metrics

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -42,6 +42,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
@@ -54,6 +59,14 @@
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- SmallRye -->
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-metrics</artifactId>
+            <version>${version.smallrye.metrics}</version>
             <scope>provided</scope>
         </dependency>
         

--- a/implementation/src/main/java/io/smallrye/graphql/execution/GraphQLConfig.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/GraphQLConfig.java
@@ -57,6 +57,10 @@ public class GraphQLConfig {
     @ConfigProperty(name = "mp.graphql.allowGet", defaultValue = "false")
     private boolean allowGet;
 
+    @Inject
+    @ConfigProperty(name = "smallrye.graphql.metrics.enabled", defaultValue = "false")
+    private boolean metricsEnabled;
+
     public String getDefaultErrorMessage() {
         return defaultErrorMessage;
     }
@@ -103,4 +107,7 @@ public class GraphQLConfig {
         this.allowGet = allowGet;
     }
 
+    public boolean isMetricsEnabled() {
+        return metricsEnabled;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
     <properties>
         <version.eclipse.microprofile.config>1.4</version.eclipse.microprofile.config>
         <version.eclipse.microprofile.graphql>1.0.1</version.eclipse.microprofile.graphql>
+        <version.eclipse.microprofile.metrics>2.3</version.eclipse.microprofile.metrics>
+        <version.smallrye.metrics>2.4.1</version.smallrye.metrics>
         
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/tck/target/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../tck/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
@@ -80,6 +82,12 @@
                 <groupId>org.eclipse.microprofile.config</groupId>
                 <artifactId>microprofile-config-api</artifactId>
                 <version>${version.eclipse.microprofile.config}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.metrics</groupId>
+                <artifactId>microprofile-metrics-api</artifactId>
+                <version>${version.eclipse.microprofile.metrics}</version>
             </dependency>
 
             <!-- Dependencies provided by the project -->


### PR DESCRIPTION
It's not completely polished yet, but it gives an idea. 

For example we might employ some guard check that detects if metrics are enabled by property, but they are not available in the classpath, in which case we should log a warning or something. Or we could add something that automatically defaults the value to `true` if we detect that metrics are in the classpath (but it should still be possible to disable them explicitly).

If the direct dependency on SmallRye Metrics is undesirable, we could change that to depending on just MP Metrics, I felt it would be nice to be able to use the SmallRye-specific `MetricRegistries` class to obtain a registry without injecting via CDI, but it's not necessary to do