### PR TITLE
Fix exception handling while transforming input-objects

### DIFF
--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/ReflectionDataFetcher.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/ReflectionDataFetcher.java
@@ -308,9 +308,9 @@ public class ReflectionDataFetcher implements DataFetcher {
     }
 
     private Object mapToPojo(Map m, Argument argument) throws GraphQLException {
-        String jsonString = toJsonString(m, argument);
         Jsonb jsonb = getJsonbForType(argument.getType());
         if (jsonb != null) {
+            String jsonString = toJsonString(m, argument);
             return jsonb.fromJson(jsonString, argument.getArgumentClass());
         }
         return m;

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/ReflectionDataFetcher.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/ReflectionDataFetcher.java
@@ -336,6 +336,8 @@ public class ReflectionDataFetcher implements DataFetcher {
             }
 
             return jsonb.toJson(inputMap);
+        } catch (TransformException te) {
+            throw te;
         } catch (Exception e) {
             LOG.warn("Could not close Jsonb");
             return null;

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/ReflectionDataFetcher.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/datafetcher/ReflectionDataFetcher.java
@@ -339,7 +339,7 @@ public class ReflectionDataFetcher implements DataFetcher {
         } catch (TransformException te) {
             throw te;
         } catch (Exception e) {
-            LOG.warn("Could not close Jsonb");
+            LOG.error("Could not close Jsonb", e);
             return null;
         }
     }


### PR DESCRIPTION
Currently, if the transformation of in input-object fails, eg because of a wrongly formatted date, the TransformException is caught but ignored, which leads to a NullPointerException.

The error in the GraphQL-result is something like this:

```
"errors": [{
      "message": "Unexpected failure in the system. Jarvis is working to fix it.",
      ...
      "extensions": {
        "exception": "java.lang.NullPointerException",
        "classification": "DataFetchingException"
      }}],
```

With this PR, the TransformException isn't ignored anymore, and the resulting GraphQL-result looks like:

```
  "errors": [
    {
      "message": "Validation error of type WrongType: argument 'dateOfBirth' with value 'StringValue{value='An unparseable date'}' is not a valid 'Date' @ 'createNewHero'",
      "extensions": {
        "description": "argument 'dateOfBirth' with value 'StringValue{value='An unparseable date'}' is not a valid 'Date'",
        "validationErrorType": "WrongType",
        "queryPath": [
          "createNewHero"
        ],
        "classification": "ValidationError"
      }}],
```

Also, other errors are now logged, previously just a warning without the cause were logged. 

A test case is added in eclipse/microprofile-graphql#217, but I'm not sure if it's besser suited in this repo, since the spec doesn't exactly define error-messages?
