### PR TITLE
Add an integration-tests module

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>smallrye-graphql-parent</artifactId>
+        <groupId>io.smallrye</groupId>
+        <version>1.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>smallrye-graphql-integration-tests</artifactId>
+    <name>SmallRye: MicroProfile GraphQL Integration Tests</name>
+
+    <properties>
+        <version.wildfly>19.0.0.Final</version.wildfly>
+    </properties>
+
+    <dependencies>
+        <!-- Arquillian and JUnit -->
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <!-- MicroProfile and Jakarta APIs -->
+        <dependency>
+            <groupId>org.eclipse.microprofile.graphql</groupId>
+            <artifactId>microprofile-graphql-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
+        </dependency>
+
+        <!-- HTTP client used in tests -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.4.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <JBOSS_HOME>${project.build.directory}/wildfly-${version.wildfly}</JBOSS_HOME>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>wildfly-dist</artifactId>
+                                    <version>${version.wildfly}</version>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/src/main/java/io/smallrye/graphql/tests/SmallRyeGraphQLArchiveProcessor.java
+++ b/integration-tests/src/main/java/io/smallrye/graphql/tests/SmallRyeGraphQLArchiveProcessor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.graphql.tests;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+/**
+ * Creates the deployable unit with all the needed dependencies.
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class SmallRyeGraphQLArchiveProcessor implements ApplicationArchiveProcessor {
+
+    @Override
+    public void process(Archive<?> applicationArchive, TestClass testClass) {
+
+        if (applicationArchive instanceof WebArchive) {
+            WebArchive testDeployment = (WebArchive) applicationArchive;
+
+            final File[] dependencies = Maven.resolver()
+                    .loadPomFromFile("pom.xml")
+                    .resolve("io.smallrye:smallrye-graphql-servlet")
+                    .withTransitivity()
+                    .asFile();
+            // Make sure it's unique
+            Set<File> dependenciesSet = new LinkedHashSet<>(Arrays.asList(dependencies));
+            testDeployment.addAsLibraries(dependenciesSet.toArray(new File[] {}));
+        }
+    }
+
+}

--- a/integration-tests/src/main/java/io/smallrye/graphql/tests/SmallRyeGraphQLExtension.java
+++ b/integration-tests/src/main/java/io/smallrye/graphql/tests/SmallRyeGraphQLExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.graphql.tests;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * Activating the extension
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class SmallRyeGraphQLExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(ApplicationArchiveProcessor.class, SmallRyeGraphQLArchiveProcessor.class);
+    }
+
+}

--- a/integration-tests/src/test/java/io/smallrye/graphql/tests/SimpleGraphQLClient.java
+++ b/integration-tests/src/test/java/io/smallrye/graphql/tests/SimpleGraphQLClient.java
@@ -1,0 +1,42 @@
+package io.smallrye.graphql.tests;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+/**
+ * A very stupid client for sending testing GraphQL queries. Once there's a spec-based client available,
+ * we might want to switch to that one instead.
+ */
+public class SimpleGraphQLClient {
+
+    private final URL baseURL;
+    private final OkHttpClient client;
+
+    private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+    public SimpleGraphQLClient(URL url) throws URISyntaxException, MalformedURLException {
+        this.baseURL = url.toURI().resolve(url.getPath() + "graphql").toURL();
+        this.client = new OkHttpClient();
+    }
+
+    public String query(String query) throws IOException {
+        JsonObject queryObject = Json.createObjectBuilder().add("query", query).build();
+        Response response = client.newCall(new Request.Builder()
+                .url(baseURL)
+                .post(RequestBody.create(queryObject.toString(), JSON))
+                .build()).execute();
+        return response.body().string();
+    }
+
+}

--- a/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/DummyGraphQLApi.java
+++ b/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/DummyGraphQLApi.java
@@ -1,0 +1,19 @@
+package io.smallrye.graphql.tests.metrics;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class DummyGraphQLApi {
+
+    @Query(value = "hello")
+    public String helloQuery() {
+        return "foo";
+    }
+
+    @Query(value = "mutate")
+    public String mutation() {
+        return "foo";
+    }
+
+}

--- a/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/MetricTest.java
+++ b/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/MetricTest.java
@@ -1,0 +1,81 @@
+package io.smallrye.graphql.tests.metrics;
+
+import java.net.URL;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.SimpleTimer;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.smallrye.graphql.tests.SimpleGraphQLClient;
+
+@RunWith(Arquillian.class)
+public class MetricTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "metrics-test.war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsResource(new StringAsset("smallrye.graphql.metrics.enabled=true"),
+                        "META-INF/microprofile-config.properties")
+                .addClass(DummyGraphQLApi.class);
+    }
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.VENDOR)
+    MetricRegistry metricRegistry;
+
+    @ArquillianResource
+    URL testingURL;
+
+    @Test
+    @InSequence(99)
+    public void verifyMetricsAreRegisteredEagerly() {
+        SimpleTimer metricForHelloQuery = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_hello"));
+        Assert.assertNotNull("Metric should be registered eagerly", metricForHelloQuery);
+
+        SimpleTimer metricForMutation = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_mutate"));
+        Assert.assertNotNull("Metric should be registered eagerly", metricForMutation);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(100)
+    public void invokeApi() throws Exception {
+        SimpleGraphQLClient client = new SimpleGraphQLClient(testingURL);
+        client.query("{hello}");
+        client.query("{mutate}");
+        client.query("{mutate}");
+    }
+
+    @Test
+    @InSequence(101)
+    public void verifyMetricsAreUpdated() {
+        SimpleTimer metricForHelloQuery = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_hello"));
+        Assert.assertEquals("The query was called once, this should be reflected in metric value",
+                1, metricForHelloQuery.getCount());
+        Assert.assertTrue("Total elapsed time for query should be greater than zero",
+                metricForHelloQuery.getElapsedTime().toNanos() > 0);
+
+        SimpleTimer metricForHelloMutation = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_mutate"));
+        Assert.assertEquals("The query was called twice, this should be reflected in metric value",
+                2, metricForHelloMutation.getCount());
+        Assert.assertTrue("Total elapsed time for query should be greater than zero",
+                metricForHelloMutation.getElapsedTime().toNanos() > 0);
+    }
+
+}

--- a/integration-tests/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/integration-tests/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+io.smallrye.graphql.tests.SmallRyeGraphQLExtension

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <module>implementation-servlet</module>
         <module>tck</module>
         <module>runner</module>
+        <module>integration-tests</module>
     </modules>
     
     <dependencyManagement>


### PR DESCRIPTION
and a test for metrics

It introduces a super basic GraphQL "client" to be used in tests. I don't quite know what else this client should be able to do, but I guess as we add more tests, we can improve the client over time. The first test just uses it to do a few queries, and isn't even interested in the returned data.