### PR TITLE
Use ISO_DATE_TIME-format for java.util.Date

### DIFF
--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/FormatHelper.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/FormatHelper.java
@@ -84,14 +84,14 @@ public class FormatHelper {
     private static String getDefaultDateTimeFormatString(Type type) {
         // return the default dates format
         type = getCorrectType(type);
-        if (type.name().equals(Classes.LOCALDATE) || type.name().equals(Classes.UTIL_DATE)
-                || type.name().equals(Classes.SQL_DATE)) {
+        if (type.name().equals(Classes.LOCALDATE) || type.name().equals(Classes.SQL_DATE)) {
             return ISO_DATE;
         } else if (type.name().equals(Classes.LOCALTIME) || type.name().equals(Classes.SQL_TIME)) {
             return ISO_TIME;
         } else if (type.name().equals(Classes.OFFSETTIME)) {
             return ISO_OFFSET_TIME;
-        } else if (type.name().equals(Classes.LOCALDATETIME) || type.name().equals(Classes.SQL_TIMESTAMP)) {
+        } else if (type.name().equals(Classes.LOCALDATETIME) || type.name().equals(Classes.UTIL_DATE)
+                || type.name().equals(Classes.SQL_TIMESTAMP)) {
             return ISO_DATE_TIME;
         } else if (type.name().equals(Classes.OFFSETDATETIME)) {
             return ISO_OFFSET_DATE_TIME;


### PR DESCRIPTION
`java.util.Date` is mapped to DateTime, but `"yyyy-MM-dd"` is used as format. This PR changes the format to `"yyyy-MM-dd'T'HH:mm:ss"`.

There is no mention of `java.util.Date` in spec and no tests exist, so maybe this was intentionally, but I think the time-part shouldn't be omitted by default. 