### PR TITLE
Use `@Name` if it is placed on field

### DIFF
--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
@@ -173,18 +173,24 @@ public class FieldCreator {
     }
 
     private static String getOutputNameForField(Annotations annotationsForThisField, String fieldName) {
+        //Scan method-annotations first, if none exists use all
         return annotationsForThisField.getOneOfTheseMethodAnnotationsValue(
-                Annotations.NAME)
+                Annotations.NAME,
+                Annotations.JSONB_PROPERTY)
                 .orElse(annotationsForThisField.getOneOfTheseAnnotationsValue(
+                        Annotations.NAME,
                         Annotations.QUERY,
                         Annotations.JSONB_PROPERTY)
                         .orElse(MethodHelper.getFieldName(Direction.OUT, fieldName)));
     }
 
     private static String getInputNameForField(Annotations annotationsForThisField, String fieldName) {
+        //Scan method-annotations first, if none exists use all
         return annotationsForThisField.getOneOfTheseMethodAnnotationsValue(
-                Annotations.NAME)
+                Annotations.NAME,
+                Annotations.JSONB_PROPERTY)
                 .orElse(annotationsForThisField.getOneOfTheseAnnotationsValue(
+                        Annotations.NAME,
                         Annotations.JSONB_PROPERTY)
                         .orElse(MethodHelper.getFieldName(Direction.IN, fieldName)));
     }


### PR DESCRIPTION
Currently, `@Name`/`@JsonbProperty` are ignored, if they are only placed on a field and not a method, this PR fixes this.

One failing tests exists in MP graphql, more are added with eclipse/microprofile-graphql#216