### PR TITLE
Handle referenced types correctly

### DIFF
--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
@@ -130,7 +130,8 @@ public class SchemaBuilder {
     }
 
     private <T> void createAndAddToSchema(ReferenceType referenceType, Creator creator, Consumer<T> consumer) {
-        for (Reference reference : ReferenceCreator.values(referenceType)) {
+        while (!ReferenceCreator.values(referenceType).isEmpty()) {
+            Reference reference = ReferenceCreator.values(referenceType).poll();
             ClassInfo classInfo = ScanningContext.getIndex().getClassByName(DotName.createSimple(reference.getClassName()));
             consumer.accept((T) creator.create(classInfo));
         }
@@ -141,7 +142,8 @@ public class SchemaBuilder {
 
         boolean allDone = true;
         // Let's see what still needs to be done.
-        for (Reference reference : ReferenceCreator.values(referenceType)) {
+        while (!ReferenceCreator.values(referenceType).isEmpty()) {
+            Reference reference = ReferenceCreator.values(referenceType).poll();
             ClassInfo classInfo = ScanningContext.getIndex().getClassByName(DotName.createSimple(reference.getClassName()));
             if (!contains.test(reference.getName())) {
                 consumer.accept((T) creator.create(classInfo));


### PR DESCRIPTION
If an Type/Input references other pojos, a ConcurrentModificationException is thrown while iterating over the referenceMaps, this PR adds extra queues for iteration. 

Same where fixed in smallrye/smallrye-graphql#104 for the old schema-generation, test cases exist in the MP-graphql-tck.