### PR TITLE
Ensure schema generation can occur on multiple apps concurrently

### DIFF
--- a/schema-builder/pom.xml
+++ b/schema-builder/pom.xml
@@ -45,6 +45,11 @@
             <version>1.0.7</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.graphql</groupId>
+            <artifactId>microprofile-graphql-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ArgumentCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ArgumentCreator.java
@@ -23,7 +23,10 @@ import io.smallrye.graphql.schema.model.Reference;
  */
 public class ArgumentCreator {
 
-    private ArgumentCreator() {
+    private final ReferenceCreator referenceCreator;
+
+    public ArgumentCreator(ReferenceCreator referenceCreator) {
+        this.referenceCreator = referenceCreator;
     }
 
     /**
@@ -34,7 +37,7 @@ public class ArgumentCreator {
      * @param position the argument position
      * @return an Argument
      */
-    public static Optional<Argument> createArgument(Type argumentType, MethodInfo methodInfo, short position) {
+    public Optional<Argument> createArgument(Type argumentType, MethodInfo methodInfo, short position) {
         Annotations annotationsForThisArgument = Annotations.getAnnotationsForArgument(methodInfo, position);
 
         if (!IgnoreHelper.shouldIgnore(annotationsForThisArgument)) {
@@ -52,7 +55,7 @@ public class ArgumentCreator {
             Optional<String> maybeDescription = DescriptionHelper.getDescriptionForField(annotationsForThisArgument,
                     argumentType);
 
-            Reference reference = ReferenceCreator.createReferenceForOperationArgument(argumentType,
+            Reference reference = referenceCreator.createReferenceForOperationArgument(argumentType,
                     annotationsForThisArgument);
 
             Argument argument = new Argument(defaultName,

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
@@ -25,7 +25,10 @@ import io.smallrye.graphql.schema.model.Reference;
  */
 public class FieldCreator {
 
-    private FieldCreator() {
+    private final ReferenceCreator referenceCreator;
+
+    public FieldCreator(ReferenceCreator referenceCreator) {
+        this.referenceCreator = referenceCreator;
     }
 
     /**
@@ -35,7 +38,7 @@ public class FieldCreator {
      * @param methodInfo the java method
      * @return a Field model object
      */
-    public static Optional<Field> createFieldForInterface(MethodInfo methodInfo) {
+    public Optional<Field> createFieldForInterface(MethodInfo methodInfo) {
         Annotations annotationsForMethod = Annotations.getAnnotationsForInterfaceField(methodInfo);
 
         if (!IgnoreHelper.shouldIgnore(annotationsForMethod)) {
@@ -49,7 +52,7 @@ public class FieldCreator {
 
             // Field Type
             validateFieldType(Direction.OUT, methodInfo);
-            Reference reference = ReferenceCreator.createReferenceForInterfaceField(returnType, annotationsForMethod);
+            Reference reference = referenceCreator.createReferenceForInterfaceField(returnType, annotationsForMethod);
 
             Field field = new Field(methodInfo.name(),
                     MethodHelper.getPropertyName(Direction.OUT, methodInfo.name()),
@@ -85,7 +88,7 @@ public class FieldCreator {
      * @param methodInfo the java method
      * @return a Field model object
      */
-    public static Optional<Field> createFieldForPojo(Direction direction, FieldInfo fieldInfo, MethodInfo methodInfo) {
+    public Optional<Field> createFieldForPojo(Direction direction, FieldInfo fieldInfo, MethodInfo methodInfo) {
         Annotations annotationsForPojo = Annotations.getAnnotationsForPojo(direction, fieldInfo, methodInfo);
 
         if (!IgnoreHelper.shouldIgnore(annotationsForPojo)) {
@@ -101,7 +104,7 @@ public class FieldCreator {
             validateFieldType(direction, methodInfo);
             Type fieldType = getFieldType(fieldInfo, methodType);
 
-            Reference reference = ReferenceCreator.createReferenceForPojoField(direction, fieldType, methodType,
+            Reference reference = referenceCreator.createReferenceForPojoField(direction, fieldType, methodType,
                     annotationsForPojo);
 
             Field field = new Field(methodInfo.name(),

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/OperationCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/OperationCreator.java
@@ -27,7 +27,12 @@ import io.smallrye.graphql.schema.model.Reference;
  */
 public class OperationCreator {
 
-    private OperationCreator() {
+    private final ReferenceCreator referenceCreator;
+    private final ArgumentCreator argumentCreator;
+
+    public OperationCreator(ReferenceCreator referenceCreator, ArgumentCreator argumentCreator) {
+        this.referenceCreator = referenceCreator;
+        this.argumentCreator = argumentCreator;
     }
 
     /**
@@ -39,7 +44,7 @@ public class OperationCreator {
      * @param operationType the type of operation (Query / Mutation)
      * @return a Operation that defines this GraphQL Operation
      */
-    public static Operation createOperation(MethodInfo methodInfo, OperationType operationType) {
+    public Operation createOperation(MethodInfo methodInfo, OperationType operationType) {
         Annotations annotationsForMethod = Annotations.getAnnotationsForMethod(methodInfo);
         Type fieldType = methodInfo.returnType();
 
@@ -51,7 +56,7 @@ public class OperationCreator {
 
         // Field Type
         validateFieldType(methodInfo, operationType);
-        Reference reference = ReferenceCreator.createReferenceForOperationField(fieldType, annotationsForMethod);
+        Reference reference = referenceCreator.createReferenceForOperationField(fieldType, annotationsForMethod);
 
         Operation operation = new Operation(methodInfo.declaringClass().name().toString(),
                 methodInfo.name(),
@@ -77,7 +82,7 @@ public class OperationCreator {
         // Arguments
         List<Type> parameters = methodInfo.parameters();
         for (short i = 0; i < parameters.size(); i++) {
-            Optional<Argument> maybeArgument = ArgumentCreator.createArgument(fieldType, methodInfo, i);
+            Optional<Argument> maybeArgument = argumentCreator.createArgument(fieldType, methodInfo, i);
             if (maybeArgument.isPresent()) {
                 Argument argument = maybeArgument.get();
 

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
@@ -30,25 +30,22 @@ import io.smallrye.graphql.schema.model.Scalars;
 public class ReferenceCreator {
     private static final Logger LOG = Logger.getLogger(ReferenceCreator.class.getName());
 
-    private static final Queue<Reference> inputReferenceQueue = new ArrayDeque<>();
-    private static final Queue<Reference> typeReferenceQueue = new ArrayDeque<>();
-    private static final Queue<Reference> enumReferenceQueue = new ArrayDeque<>();
-    private static final Queue<Reference> interfaceReferenceQueue = new ArrayDeque<>();
+    private final Queue<Reference> inputReferenceQueue = new ArrayDeque<>();
+    private final Queue<Reference> typeReferenceQueue = new ArrayDeque<>();
+    private final Queue<Reference> enumReferenceQueue = new ArrayDeque<>();
+    private final Queue<Reference> interfaceReferenceQueue = new ArrayDeque<>();
 
     // Some maps we populate during scanning
-    private static final Map<String, Reference> inputReferenceMap = new HashMap<>();
-    private static final Map<String, Reference> typeReferenceMap = new HashMap<>();
-    private static final Map<String, Reference> enumReferenceMap = new HashMap<>();
-    private static final Map<String, Reference> interfaceReferenceMap = new HashMap<>();
-
-    private ReferenceCreator() {
-    }
+    private final Map<String, Reference> inputReferenceMap = new HashMap<>();
+    private final Map<String, Reference> typeReferenceMap = new HashMap<>();
+    private final Map<String, Reference> enumReferenceMap = new HashMap<>();
+    private final Map<String, Reference> interfaceReferenceMap = new HashMap<>();
 
     /**
      * Clear the scanned references. This is done when we created all references and do not need to
      * remember what to scan.
      */
-    public static void clear() {
+    public void clear() {
         inputReferenceMap.clear();
         typeReferenceMap.clear();
         enumReferenceMap.clear();
@@ -66,7 +63,7 @@ public class ReferenceCreator {
      * @param referenceType the type
      * @return the references
      */
-    public static Queue<Reference> values(ReferenceType referenceType) {
+    public Queue<Reference> values(ReferenceType referenceType) {
         return getReferenceQueue(referenceType);
     }
 
@@ -79,7 +76,7 @@ public class ReferenceCreator {
      * @param annotationsForMethod annotation on this operations method
      * @return a reference to the type
      */
-    public static Reference createReferenceForOperationField(Type fieldType, Annotations annotationsForMethod) {
+    public Reference createReferenceForOperationField(Type fieldType, Annotations annotationsForMethod) {
         return getReference(Direction.OUT, null, fieldType, annotationsForMethod);
     }
 
@@ -92,7 +89,7 @@ public class ReferenceCreator {
      * @param annotationsForThisArgument annotations on this argument
      * @return a reference to the argument
      */
-    public static Reference createReferenceForOperationArgument(Type argumentType, Annotations annotationsForThisArgument) {
+    public Reference createReferenceForOperationArgument(Type argumentType, Annotations annotationsForThisArgument) {
         return getReference(Direction.IN, null, argumentType, annotationsForThisArgument);
     }
 
@@ -105,7 +102,7 @@ public class ReferenceCreator {
      * @param annotationsForThisMethod annotations on this method
      * @return a reference to the type
      */
-    public static Reference createReferenceForInterfaceField(Type methodType, Annotations annotationsForThisMethod) {
+    public Reference createReferenceForInterfaceField(Type methodType, Annotations annotationsForThisMethod) {
         return getReference(Direction.OUT, null, methodType, annotationsForThisMethod);
     }
 
@@ -119,7 +116,7 @@ public class ReferenceCreator {
      * @param annotations the annotations on the field and method
      * @return a reference to the type
      */
-    public static Reference createReferenceForPojoField(Direction direction, Type fieldType, Type methodType,
+    public Reference createReferenceForPojoField(Direction direction, Type fieldType, Type methodType,
             Annotations annotations) {
         return getReference(direction, fieldType, methodType, annotations);
     }
@@ -132,7 +129,7 @@ public class ReferenceCreator {
      * @param classInfo the Java class
      * @return a reference
      */
-    public static Reference createReference(Direction direction, ClassInfo classInfo) {
+    public Reference createReference(Direction direction, ClassInfo classInfo) {
         // Get the initial reference type. It's either Type or Input depending on the direction. This might change it 
         // we figure out this is actually an enum or interface
         ReferenceType referenceType = getCorrectReferenceType(direction);
@@ -164,7 +161,7 @@ public class ReferenceCreator {
         return reference;
     }
 
-    private static Reference getReference(Direction direction,
+    private Reference getReference(Direction direction,
             Type fieldType,
             Type methodType,
             Annotations annotations) {
@@ -194,7 +191,7 @@ public class ReferenceCreator {
         } else if (fieldType.kind().equals(Type.Kind.CLASS)) {
             ClassInfo classInfo = ScanningContext.getIndex().getClassByName(fieldType.name());
             if (classInfo != null) {
-                return ReferenceCreator.createReference(direction, classInfo);
+                return createReference(direction, classInfo);
             } else {
                 LOG.warn("Class [" + fieldType.name()
                         + "] in not indexed in Jandex. Can not scan Object Type, defaulting to String Scalar");
@@ -206,7 +203,7 @@ public class ReferenceCreator {
         }
     }
 
-    private static void putIfAbsent(String key, Reference reference, ReferenceType referenceType) {
+    private void putIfAbsent(String key, Reference reference, ReferenceType referenceType) {
         Map<String, Reference> map = getReferenceMap(referenceType);
         Queue<Reference> queue = getReferenceQueue(referenceType);
         if (!map.containsKey(key)) {
@@ -215,7 +212,7 @@ public class ReferenceCreator {
         }
     }
 
-    private static Map<String, Reference> getReferenceMap(ReferenceType referenceType) {
+    private Map<String, Reference> getReferenceMap(ReferenceType referenceType) {
         switch (referenceType) {
             case ENUM:
                 return enumReferenceMap;
@@ -230,7 +227,7 @@ public class ReferenceCreator {
         }
     }
 
-    private static Queue<Reference> getReferenceQueue(ReferenceType referenceType) {
+    private Queue<Reference> getReferenceQueue(ReferenceType referenceType) {
         switch (referenceType) {
             case ENUM:
                 return enumReferenceQueue;

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
@@ -31,6 +31,12 @@ import io.smallrye.graphql.schema.model.ReferenceType;
 public class InputTypeCreator implements Creator<InputType> {
     private static final Logger LOG = Logger.getLogger(InputTypeCreator.class.getName());
 
+    private final FieldCreator fieldCreator;
+
+    public InputTypeCreator(FieldCreator fieldCreator) {
+        this.fieldCreator = fieldCreator;
+    }
+
     @Override
     public InputType create(ClassInfo classInfo) {
         LOG.debug("Creating Input from " + classInfo.name().toString());
@@ -72,7 +78,7 @@ public class InputTypeCreator implements Creator<InputType> {
             if (MethodHelper.isPropertyMethod(Direction.IN, methodInfo.name())) {
                 String fieldName = MethodHelper.getPropertyName(Direction.IN, methodInfo.name());
                 FieldInfo fieldInfo = allFields.get(fieldName);
-                FieldCreator.createFieldForPojo(Direction.IN, fieldInfo, methodInfo)
+                fieldCreator.createFieldForPojo(Direction.IN, fieldInfo, methodInfo)
                         .ifPresent(inputType::addField);
 
             }

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InterfaceCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InterfaceCreator.java
@@ -31,6 +31,14 @@ import io.smallrye.graphql.schema.model.ReferenceType;
 public class InterfaceCreator implements Creator<InterfaceType> {
     private static final Logger LOG = Logger.getLogger(InputTypeCreator.class.getName());
 
+    private final ReferenceCreator referenceCreator;
+    private final FieldCreator fieldCreator;
+
+    public InterfaceCreator(ReferenceCreator referenceCreator, FieldCreator fieldCreator) {
+        this.referenceCreator = referenceCreator;
+        this.fieldCreator = fieldCreator;
+    }
+
     @Override
     public InterfaceType create(ClassInfo classInfo) {
         LOG.debug("Creating Interface from " + classInfo.name().toString());
@@ -67,7 +75,7 @@ public class InterfaceCreator implements Creator<InterfaceType> {
 
         for (MethodInfo methodInfo : allMethods) {
             if (MethodHelper.isPropertyMethod(Direction.OUT, methodInfo.name())) {
-                FieldCreator.createFieldForInterface(methodInfo)
+                fieldCreator.createFieldForInterface(methodInfo)
                         .ifPresent(interfaceType::addField);
             }
         }
@@ -80,7 +88,7 @@ public class InterfaceCreator implements Creator<InterfaceType> {
             if (!interfaceName.toString().startsWith(JAVA_DOT)) {
                 ClassInfo c = ScanningContext.getIndex().getClassByName(interfaceName);
                 if (c != null) {
-                    Reference interfaceRef = ReferenceCreator.createReference(Direction.OUT, classInfo);
+                    Reference interfaceRef = referenceCreator.createReference(Direction.OUT, classInfo);
                     interfaceType.addInterface(interfaceRef);
                 }
             }

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/TypeCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/TypeCreator.java
@@ -40,6 +40,16 @@ import io.smallrye.graphql.schema.model.Type;
 public class TypeCreator implements Creator<Type> {
     private static final Logger LOG = Logger.getLogger(TypeCreator.class.getName());
 
+    private final ReferenceCreator referenceCreator;
+    private final FieldCreator fieldCreator;
+    private final OperationCreator operationCreator;
+
+    public TypeCreator(ReferenceCreator referenceCreator, FieldCreator fieldCreator, OperationCreator operationCreator) {
+        this.referenceCreator = referenceCreator;
+        this.fieldCreator = fieldCreator;
+        this.operationCreator = operationCreator;
+    }
+
     @Override
     public Type create(ClassInfo classInfo) {
         LOG.debug("Creating Type from " + classInfo.name().toString());
@@ -88,7 +98,7 @@ public class TypeCreator implements Creator<Type> {
                 String fieldName = MethodHelper.getPropertyName(Direction.OUT, methodInfo.name());
                 FieldInfo fieldInfo = allFields.get(fieldName);
 
-                FieldCreator.createFieldForPojo(Direction.OUT, fieldInfo, methodInfo)
+                fieldCreator.createFieldForPojo(Direction.OUT, fieldInfo, methodInfo)
                         .ifPresent(type::addField);
             }
         }
@@ -101,7 +111,7 @@ public class TypeCreator implements Creator<Type> {
             List<MethodParameterInfo> methodParameterInfos = sourceFields.get(classInfo.name());
             for (MethodParameterInfo methodParameterInfo : methodParameterInfos) {
                 MethodInfo methodInfo = methodParameterInfo.method();
-                Operation operation = OperationCreator.createOperation(methodInfo, OperationType.Source);
+                Operation operation = operationCreator.createOperation(methodInfo, OperationType.Source);
                 type.addOperation(operation);
             }
         }
@@ -114,7 +124,7 @@ public class TypeCreator implements Creator<Type> {
             if (!interfaceName.toString().startsWith(JAVA_DOT)) {
                 ClassInfo interfaceInfo = ScanningContext.getIndex().getClassByName(interfaceName);
                 if (interfaceInfo != null) {
-                    Reference interfaceRef = ReferenceCreator.createReference(Direction.OUT, interfaceInfo);
+                    Reference interfaceRef = referenceCreator.createReference(Direction.OUT, interfaceInfo);
                     type.addInterface(interfaceRef);
                 }
             }

--- a/schema-builder/src/test/java/io/smallrye/graphql/index/app/Movie.java
+++ b/schema-builder/src/test/java/io/smallrye/graphql/index/app/Movie.java
@@ -1,0 +1,44 @@
+package io.smallrye.graphql.index.app;
+
+import java.util.Date;
+import java.util.Set;
+
+public class Movie {
+
+    String title;
+    Date releaseDate;
+    Person director;
+    Set<Person> topBilledCast;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Date getReleaseDate() {
+        return releaseDate;
+    }
+
+    public void setReleaseDate(Date releaseDate) {
+        this.releaseDate = releaseDate;
+    }
+
+    public Person getDirector() {
+        return director;
+    }
+
+    public void setDirector(Person director) {
+        this.director = director;
+    }
+
+    public Set<Person> getTopBilledCast() {
+        return topBilledCast;
+    }
+
+    public void setTopBilledCast(Set<Person> topBilledCast) {
+        this.topBilledCast = topBilledCast;
+    }
+}

--- a/schema-builder/src/test/java/io/smallrye/graphql/index/app/MovieTriviaController.java
+++ b/schema-builder/src/test/java/io/smallrye/graphql/index/app/MovieTriviaController.java
@@ -1,0 +1,38 @@
+package io.smallrye.graphql.index.app;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class MovieTriviaController {
+
+    Set<Movie> movies = new HashSet<>();
+
+    @Mutation
+    public Movie newMovie(Movie movie) {
+        movies.add(movie);
+        return movie;
+    }
+
+    @Query
+    public Set<Movie> movies() {
+        return movies;
+    }
+
+    @Query
+    public Set<Movie> moviesDirectedBy(@Name("director") Person director) {
+        return movies.stream().filter(m -> m.getDirector().equals(director)).collect(Collectors.toSet());
+    }
+
+    @Query
+    public Set<Movie> moviesReleasedAfter(@Name("date") Date d) {
+        return movies.stream().filter(m -> m.getReleaseDate().after(d)).collect(Collectors.toSet());
+    }
+}

--- a/schema-builder/src/test/java/io/smallrye/graphql/index/app/Person.java
+++ b/schema-builder/src/test/java/io/smallrye/graphql/index/app/Person.java
@@ -1,0 +1,28 @@
+package io.smallrye.graphql.index.app;
+
+public class Person {
+    String firstName;
+    String lastName;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o != null && o instanceof Person && firstName.equals(((Person) o).firstName)
+                && lastName.equals(((Person) o).lastName);
+    }
+}


### PR DESCRIPTION
- removes static variables in schema building classes
- adds unit test that concurrently generates schemas for three apps

Fixes #170 