### PR TITLE
Reintroduce Metrics support

### DIFF
--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLProducer.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLProducer.java
@@ -20,7 +20,10 @@ public class GraphQLProducer {
     private ExecutionService executionService;
 
     public void initializeGraphQL(GraphQLConfig config, Schema schema) {
-        this.graphQLSchema = Bootstrap.bootstrap(schema);
+        this.graphQLSchema = Bootstrap.bootstrap(schema, config);
+        if (config.isMetricsEnabled()) {
+            Bootstrap.registerMetrics(schema);
+        }
         this.executionService = new ExecutionService(config, graphQLSchema);
     }
 

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -42,7 +42,12 @@
             <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- GraphQL Java -->
         <dependency>
             <groupId>com.graphql-java</groupId>
@@ -79,6 +84,14 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>smallrye-graphql-schema-builder</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- SmallRye -->
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-metrics</artifactId>
+            <version>${version.smallrye.metrics}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -1,12 +1,18 @@
 package io.smallrye.graphql.bootstrap;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
 import org.jboss.logging.Logger;
 
 import graphql.schema.FieldCoordinates;
@@ -27,6 +33,8 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLTypeReference;
 import io.smallrye.graphql.execution.datafetcher.PropertyDataFetcher;
 import io.smallrye.graphql.execution.datafetcher.ReflectionDataFetcher;
+import io.smallrye.graphql.execution.datafetcher.decorator.DataFetcherDecorator;
+import io.smallrye.graphql.execution.datafetcher.decorator.MetricDecorator;
 import io.smallrye.graphql.execution.resolver.InterfaceOutputRegistry;
 import io.smallrye.graphql.execution.resolver.InterfaceResolver;
 import io.smallrye.graphql.json.JsonInputRegistry;
@@ -42,6 +50,7 @@ import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Schema;
 import io.smallrye.graphql.schema.model.Type;
+import io.smallrye.metrics.MetricRegistries;
 
 /**
  * Bootstrap MicroProfile GraphQL
@@ -53,6 +62,7 @@ public class Bootstrap {
     private static final Logger LOG = Logger.getLogger(Bootstrap.class.getName());
 
     private final Schema schema;
+    private final Config config;
     private final GraphQLCodeRegistry.Builder codeRegistryBuilder = GraphQLCodeRegistry.newCodeRegistry();
 
     private final Map<String, GraphQLScalarType> scalarMap = GraphQLScalarTypes.getScalarMap();
@@ -62,8 +72,12 @@ public class Bootstrap {
     private final Map<String, GraphQLObjectType> typeMap = new HashMap<>();
 
     public static GraphQLSchema bootstrap(Schema schema) {
+        return bootstrap(schema, null);
+    }
+
+    public static GraphQLSchema bootstrap(Schema schema, Config config) {
         if (schema != null && (schema.hasQueries() || schema.hasMutations())) {
-            Bootstrap graphQLBootstrap = new Bootstrap(schema);
+            Bootstrap graphQLBootstrap = new Bootstrap(schema, config);
             return graphQLBootstrap.generateGraphQLSchema();
         } else {
             LOG.warn("Schema is null, or it has no operations. Not bootstrapping SmallRye GraphQL");
@@ -71,8 +85,21 @@ public class Bootstrap {
         }
     }
 
-    private Bootstrap(Schema schema) {
+    public static void registerMetrics(Schema schema) {
+        Stream.concat(schema.getQueries().stream(), schema.getMutations().stream())
+                .forEach(operation -> {
+                    Metadata metadata = Metadata.builder()
+                            .withName("mp_graphql_" + operation.getName())
+                            .withType(MetricType.SIMPLE_TIMER)
+                            .withDescription("Call statistics for the query '" + operation.getName() + "'")
+                            .build();
+                    MetricRegistries.get(MetricRegistry.Type.VENDOR).simpleTimer(metadata);
+                });
+    }
+
+    private Bootstrap(Schema schema, Config config) {
         this.schema = schema;
+        this.config = config;
     }
 
     private GraphQLSchema generateGraphQLSchema() {
@@ -274,7 +301,13 @@ public class Bootstrap {
         GraphQLFieldDefinition graphQLFieldDefinition = fieldBuilder.build();
 
         // DataFetcher
-        ReflectionDataFetcher datafetcher = new ReflectionDataFetcher(operation);
+        Collection<DataFetcherDecorator> decorators;
+        if (config != null && config.isMetricsEnabled()) {
+            decorators = Collections.singletonList(new MetricDecorator());
+        } else {
+            decorators = Collections.emptyList();
+        }
+        ReflectionDataFetcher datafetcher = new ReflectionDataFetcher(operation, decorators);
         codeRegistryBuilder.dataFetcher(FieldCoordinates.coordinates(operationTypeName,
                 graphQLFieldDefinition.getName()), datafetcher);
 

--- a/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/DataFetcherDecorator.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/DataFetcherDecorator.java
@@ -1,0 +1,11 @@
+package io.smallrye.graphql.execution.datafetcher.decorator;
+
+import graphql.schema.DataFetchingEnvironment;
+
+public interface DataFetcherDecorator {
+
+    void before(DataFetchingEnvironment env);
+
+    void after(DataFetchingEnvironment env);
+
+}

--- a/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/MetricDecorator.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/MetricDecorator.java
@@ -1,0 +1,35 @@
+package io.smallrye.graphql.execution.datafetcher.decorator;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.metrics.MetricRegistries;
+
+public class MetricDecorator implements DataFetcherDecorator {
+
+    private Map<DataFetchingEnvironment, Long> startTimes = Collections.synchronizedMap(new IdentityHashMap<>());
+
+    @Override
+    public void before(DataFetchingEnvironment dfe) {
+        startTimes.put(dfe, System.nanoTime());
+    }
+
+    @Override
+    public void after(DataFetchingEnvironment dfe) {
+        Long startTime = startTimes.remove(dfe);
+        if (startTime != null) {
+            long duration = System.nanoTime() - startTime;
+            MetricID metricID = new MetricID("mp_graphql_" + dfe.getField().getName());
+            MetricRegistries.get(MetricRegistry.Type.VENDOR).simpleTimer(metricID.getName(), metricID.getTagsAsArray())
+                    .update(Duration.ofNanos(duration));
+        }
+
+    }
+
+}

--- a/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/MetricTest.java
+++ b/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/MetricTest.java
@@ -8,19 +8,25 @@ import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.SimpleTimer;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import io.smallrye.graphql.tests.SimpleGraphQLClient;
 
-//@RunWith(Arquillian.class)
+@RunWith(Arquillian.class)
 public class MetricTest {
 
-    //@Deployment
+    @Deployment
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class, "metrics-test.war")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
@@ -36,8 +42,8 @@ public class MetricTest {
     @ArquillianResource
     URL testingURL;
 
-    //@Test
-    //@InSequence(99)
+    @Test
+    @InSequence(99)
     public void verifyMetricsAreRegisteredEagerly() {
         SimpleTimer metricForHelloQuery = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_hello"));
         Assert.assertNotNull("Metric should be registered eagerly", metricForHelloQuery);
@@ -46,9 +52,9 @@ public class MetricTest {
         Assert.assertNotNull("Metric should be registered eagerly", metricForMutation);
     }
 
-    //@Test
-    //@RunAsClient
-    //@InSequence(100)
+    @Test
+    @RunAsClient
+    @InSequence(100)
     public void invokeApi() throws Exception {
         SimpleGraphQLClient client = new SimpleGraphQLClient(testingURL);
         client.query("{hello}");
@@ -56,8 +62,8 @@ public class MetricTest {
         client.query("{mutate}");
     }
 
-    //@Test
-    //@InSequence(101)
+    @Test
+    @InSequence(101)
     public void verifyMetricsAreUpdated() {
         SimpleTimer metricForHelloQuery = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_hello"));
         Assert.assertEquals("The query was called once, this should be reflected in metric value",


### PR DESCRIPTION
Metrics are separated into an `DataFetcherDecorator` implementation. Decorators are custom-baked, not  CDI decorators. It's not THAT separated from the implementation, but is the best that I could come up with right now without using CDI.

Metric registration is now a separate operation of the `Bootstrap` class, so we will have better control over when it is performed. This should work in Quarkus and it can be performed in a recorder.

If you like this I can move the test to the TCK module if you insist on that