### PR TITLE
Include scalars in schema

### DIFF
--- a/implementation-cdi/src/test/java/io/smallrye/graphql/execution/SchemaTest.java
+++ b/implementation-cdi/src/test/java/io/smallrye/graphql/execution/SchemaTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import graphql.schema.GraphQLSchema;
 import io.smallrye.graphql.bootstrap.Bootstrap;
+import io.smallrye.graphql.bootstrap.Config;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Schema;
 
@@ -37,7 +38,8 @@ public class SchemaTest {
     public void testSchemaModelCreation() throws IOException {
         GraphQLSchema graphQLSchema = Bootstrap.bootstrap(schema);
         Assert.assertNotNull(graphQLSchema);
-        String schemaString = SchemaPrinter.print(graphQLSchema);
+        String schemaString = new SchemaPrinter(new Config() {
+        }).print(graphQLSchema);
         Assert.assertNotNull(schemaString);
 
         LOG.info(schemaString);

--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLConfig.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLConfig.java
@@ -48,6 +48,23 @@ public class GraphQLConfig implements Config {
     @ConfigProperty(name = "smallrye.graphql.metrics.enabled", defaultValue = "false")
     private boolean metricsEnabled;
 
+    @Inject
+    @ConfigProperty(name = "smallrye.graphql.schema.includeScalars", defaultValue = "true")
+    private boolean includeScalarsInSchema;
+
+    @Inject
+    @ConfigProperty(name = "smallrye.graphql.schema.includeDirectives", defaultValue = "false")
+    private boolean includeDirectivesInSchema;
+
+    @Inject
+    @ConfigProperty(name = "smallrye.graphql.schema.includeSchemaDefinition", defaultValue = "false")
+    private boolean includeSchemaDefinitionInSchema;
+
+    @Inject
+    @ConfigProperty(name = "smallrye.graphql.schema.includeIntrospectionTypes", defaultValue = "false")
+    private boolean includeIntrospectionTypesInSchema;
+
+
     public String getDefaultErrorMessage() {
         return defaultErrorMessage;
     }
@@ -77,4 +94,21 @@ public class GraphQLConfig implements Config {
     public boolean isMetricsEnabled() {
         return metricsEnabled;
     }
+
+    public boolean isIncludeDirectivesInSchema() {
+        return includeDirectivesInSchema;
+    }
+
+    public boolean isIncludeSchemaDefinitionInSchema() {
+        return includeSchemaDefinitionInSchema;
+    }
+
+    public boolean isIncludeIntrospectionTypesInSchema() {
+        return includeIntrospectionTypesInSchema;
+    }
+
+    public boolean isIncludeScalarsInSchema() {
+        return includeScalarsInSchema;
+    }
+
 }

--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLConfig.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLConfig.java
@@ -64,7 +64,6 @@ public class GraphQLConfig implements Config {
     @ConfigProperty(name = "smallrye.graphql.schema.includeIntrospectionTypes", defaultValue = "false")
     private boolean includeIntrospectionTypesInSchema;
 
-
     public String getDefaultErrorMessage() {
         return defaultErrorMessage;
     }

--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLProducer.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLProducer.java
@@ -6,6 +6,7 @@ import javax.enterprise.inject.Produces;
 import graphql.schema.GraphQLSchema;
 import io.smallrye.graphql.bootstrap.Bootstrap;
 import io.smallrye.graphql.execution.ExecutionService;
+import io.smallrye.graphql.execution.SchemaPrinter;
 import io.smallrye.graphql.schema.model.Schema;
 
 /**
@@ -18,6 +19,7 @@ public class GraphQLProducer {
 
     private GraphQLSchema graphQLSchema;
     private ExecutionService executionService;
+    private SchemaPrinter schemaPrinter;
 
     public void initializeGraphQL(GraphQLConfig config, Schema schema) {
         this.graphQLSchema = Bootstrap.bootstrap(schema, config);
@@ -25,6 +27,7 @@ public class GraphQLProducer {
             Bootstrap.registerMetrics(schema);
         }
         this.executionService = new ExecutionService(config, graphQLSchema);
+        this.schemaPrinter = new SchemaPrinter(config);
     }
 
     @Produces
@@ -35,5 +38,10 @@ public class GraphQLProducer {
     @Produces
     public ExecutionService getExecutionService() {
         return executionService;
+    }
+
+    @Produces
+    public SchemaPrinter getSchemaPrinter() {
+        return schemaPrinter;
     }
 }

--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SchemaServlet.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SchemaServlet.java
@@ -3,6 +3,7 @@ package io.smallrye.graphql.servlet;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import javax.inject.Inject;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -24,12 +25,15 @@ public class SchemaServlet extends HttpServlet {
 
     public static final String SCHEMA_PROP = "io.smallrye.graphql.servlet.bootstrap";
 
+    @Inject
+    private SchemaPrinter schemaPrinter;
+
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) {
         response.setContentType(CONTENT_TYPE);
         try (PrintWriter out = response.getWriter()) {
             GraphQLSchema schema = (GraphQLSchema) request.getServletContext().getAttribute(SCHEMA_PROP);
-            out.print(SchemaPrinter.print(schema));
+            out.print(schemaPrinter.print(schema));
             out.flush();
         } catch (IOException ex) {
             LOG.log(Logger.Level.ERROR, null, ex);

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/Config.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/Config.java
@@ -32,4 +32,20 @@ public interface Config {
     default boolean isMetricsEnabled() {
         return false;
     }
+
+    default boolean isIncludeScalarsInSchema() {
+        return false;
+    }
+
+    default boolean isIncludeDirectivesInSchema() {
+        return false;
+    }
+
+    default boolean isIncludeSchemaDefinitionInSchema() {
+        return false;
+    }
+
+    default boolean isIncludeIntrospectionTypesInSchema() {
+        return false;
+    }
 }

--- a/implementation/src/main/java/io/smallrye/graphql/execution/SchemaPrinter.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/SchemaPrinter.java
@@ -23,7 +23,7 @@ public class SchemaPrinter {
         options = options.includeDirectives(false);
         options = options.includeExtendedScalarTypes(false);
         options = options.includeIntrospectionTypes(false);
-        options = options.includeScalarTypes(false);
+        options = options.includeScalarTypes(true);
         options = options.includeSchemaDefinition(false);
         options = options.useAstDefinitions(false);
         SCHEMAPRINTER = new graphql.schema.idl.SchemaPrinter(options);

--- a/implementation/src/main/java/io/smallrye/graphql/execution/SchemaPrinter.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/SchemaPrinter.java
@@ -1,6 +1,7 @@
 package io.smallrye.graphql.execution;
 
 import graphql.schema.GraphQLSchema;
+import io.smallrye.graphql.bootstrap.Config;
 
 /**
  * Printing the schema
@@ -9,23 +10,25 @@ import graphql.schema.GraphQLSchema;
  */
 public class SchemaPrinter {
 
-    private SchemaPrinter() {
+    private final graphql.schema.idl.SchemaPrinter schemaPrinter;
+
+    public SchemaPrinter(final Config config) {
+        this.schemaPrinter = createSchemaPrinter(config);
     }
 
-    public static String print(GraphQLSchema schema) {
-        return SCHEMAPRINTER.print(schema);
+    public String print(GraphQLSchema schema) {
+        return schemaPrinter.print(schema);
     }
 
-    private static final graphql.schema.idl.SchemaPrinter SCHEMAPRINTER;
-    static {
+    private graphql.schema.idl.SchemaPrinter createSchemaPrinter(Config config) {
         graphql.schema.idl.SchemaPrinter.Options options = graphql.schema.idl.SchemaPrinter.Options.defaultOptions();
         options = options.descriptionsAsHashComments(false);
-        options = options.includeDirectives(false);
-        options = options.includeExtendedScalarTypes(false);
-        options = options.includeIntrospectionTypes(false);
-        options = options.includeScalarTypes(true);
-        options = options.includeSchemaDefinition(false);
+        options = options.includeDirectives(config.isIncludeDirectivesInSchema());
+        options = options.includeExtendedScalarTypes(config.isIncludeScalarsInSchema());
+        options = options.includeIntrospectionTypes(config.isIncludeIntrospectionTypesInSchema());
+        options = options.includeScalarTypes(config.isIncludeScalarsInSchema());
+        options = options.includeSchemaDefinition(config.isIncludeSchemaDefinitionInSchema());
         options = options.useAstDefinitions(false);
-        SCHEMAPRINTER = new graphql.schema.idl.SchemaPrinter(options);
+        return new graphql.schema.idl.SchemaPrinter(options);
     }
 }


### PR DESCRIPTION
Currently, scalars such as 'Date' are not included in the schema, and therefore some tools cannot validate it, eg the GraphQL plugin for Intellij.

This PR adds scalars to the schema.