### PR TITLE
Add ctor for environments where CDI is unavailable

### DIFF
--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SchemaServlet.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/SchemaServlet.java
@@ -28,6 +28,13 @@ public class SchemaServlet extends HttpServlet {
     @Inject
     private SchemaPrinter schemaPrinter;
 
+    public SchemaServlet() {
+    }
+
+    public SchemaServlet(SchemaPrinter schemaPrinter) {
+        this.schemaPrinter = schemaPrinter;
+    }
+
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) {
         response.setContentType(CONTENT_TYPE);


### PR DESCRIPTION
If packaging the servlet implementation as part of the Liberty runtime, CDI injection is not available, so constructors are necessary.  This change should allow the servlet to work with or without CDI.