### PR TITLE
Create output type for `@Source` arguments instead of input type

### DIFF
--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/OperationCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/OperationCreator.java
@@ -82,35 +82,11 @@ public class OperationCreator {
         // Arguments
         List<Type> parameters = methodInfo.parameters();
         for (short i = 0; i < parameters.size(); i++) {
-            Optional<Argument> maybeArgument = argumentCreator.createArgument(fieldType, methodInfo, i);
-            if (maybeArgument.isPresent()) {
-                Argument argument = maybeArgument.get();
-
-                // See if this is a @Source
-                Annotations annotationsForThisArgument = Annotations.getAnnotationsForArgument(methodInfo, i);
-                if (isSourceAnnotationOnSourceOperation(annotationsForThisArgument, operationType)) {
-                    argument.setSourceArgument(true);
-                }
-
-                operation.addArgument(argument);
-            }
-
+            Optional<Argument> maybeArgument = argumentCreator.createArgument(operationType, methodInfo, i);
+            maybeArgument.ifPresent(operation::addArgument);
         }
 
         return operation;
-    }
-
-    /**
-     * Source operation on types should remove the Source argument
-     * 
-     * @param annotationsForArgument
-     * @param operationType
-     * @return
-     */
-    private static boolean isSourceAnnotationOnSourceOperation(Annotations annotationsForArgument,
-            OperationType operationType) {
-        return operationType.equals(OperationType.Source) &&
-                annotationsForArgument.containsOneOfTheseAnnotations(Annotations.SOURCE);
     }
 
     private static void validateFieldType(MethodInfo methodInfo, OperationType operationType) {

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
@@ -94,6 +94,18 @@ public class ReferenceCreator {
     }
 
     /**
+     * Get a reference to a source argument type for an operation
+     * Direction is OUT on an argument.
+     *
+     * @param argumentType the java type
+     * @param annotationsForThisArgument annotations on this argument
+     * @return a reference to the argument
+     */
+    public Reference createReferenceForSourceArgument(Type argumentType, Annotations annotationsForThisArgument) {
+        return getReference(Direction.OUT, null, argumentType, annotationsForThisArgument);
+    }
+
+    /**
      * Get a reference to a field (method response) on an interface
      * 
      * Interfaces is only usable on Type, so the direction in OUT.


### PR DESCRIPTION
Currently, for each `@Source` argument an input type is created. If the method is not annotated with `@Query` and the input type is not used on an other query, the input type created is included in the schema but is not used and is empty, which causes errors with some tools.

With this PR, an output-type is created instead, which should exist anyway (otherwise is wouldn't be useable as as source-argument).