### PR TITLE
Remove dependency on SmallRye Metrics

### DIFF
--- a/implementation-cdi/pom.xml
+++ b/implementation-cdi/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CdiLookupService.java
+++ b/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CdiLookupService.java
@@ -2,6 +2,8 @@ package io.smallrye.graphql.cdi;
 
 import javax.enterprise.inject.spi.CDI;
 
+import org.eclipse.microprofile.metrics.MetricRegistry;
+
 import io.smallrye.graphql.lookup.LookupService;
 
 /**
@@ -25,6 +27,11 @@ public class CdiLookupService implements LookupService {
     @Override
     public Object getInstance(Class<?> declaringClass) {
         return CDI.current().select(declaringClass).get();
+    }
+
+    @Override
+    public MetricRegistry getMetricRegistry(MetricRegistry.Type type) {
+        return CDI.current().select(MetricRegistry.class, new RegistryTypeLiteral(type)).get();
     }
 
 }

--- a/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/RegistryTypeLiteral.java
+++ b/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/RegistryTypeLiteral.java
@@ -1,0 +1,20 @@
+package io.smallrye.graphql.cdi;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+
+public class RegistryTypeLiteral extends AnnotationLiteral<RegistryType> implements RegistryType {
+
+    private final MetricRegistry.Type type;
+
+    public RegistryTypeLiteral(MetricRegistry.Type type) {
+        this.type = type;
+    }
+
+    @Override
+    public MetricRegistry.Type type() {
+        return type;
+    }
+}

--- a/implementation-servlet/pom.xml
+++ b/implementation-servlet/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>microprofile-config-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- Servlet -->
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLProducer.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLProducer.java
@@ -3,10 +3,13 @@ package io.smallrye.graphql.servlet;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
+import org.eclipse.microprofile.metrics.MetricRegistry;
+
 import graphql.schema.GraphQLSchema;
 import io.smallrye.graphql.bootstrap.Bootstrap;
 import io.smallrye.graphql.execution.ExecutionService;
 import io.smallrye.graphql.execution.SchemaPrinter;
+import io.smallrye.graphql.lookup.LookupService;
 import io.smallrye.graphql.schema.model.Schema;
 
 /**
@@ -24,7 +27,8 @@ public class GraphQLProducer {
     public void initializeGraphQL(GraphQLConfig config, Schema schema) {
         this.graphQLSchema = Bootstrap.bootstrap(schema, config);
         if (config.isMetricsEnabled()) {
-            Bootstrap.registerMetrics(schema);
+            MetricRegistry vendorRegistry = LookupService.load().getMetricRegistry(MetricRegistry.Type.VENDOR);
+            Bootstrap.registerMetrics(schema, vendorRegistry);
         }
         this.executionService = new ExecutionService(config, graphQLSchema);
         this.schemaPrinter = new SchemaPrinter(config);

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -86,13 +86,7 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- SmallRye -->
-        <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-metrics</artifactId>
-            <version>${version.smallrye.metrics}</version>
-            <scope>provided</scope>
-        </dependency>
+
     </dependencies>
 
     <build>

--- a/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -50,7 +50,6 @@ import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Schema;
 import io.smallrye.graphql.schema.model.Type;
-import io.smallrye.metrics.MetricRegistries;
 
 /**
  * Bootstrap MicroProfile GraphQL
@@ -85,7 +84,7 @@ public class Bootstrap {
         }
     }
 
-    public static void registerMetrics(Schema schema) {
+    public static void registerMetrics(Schema schema, MetricRegistry metricRegistry) {
         Stream.concat(schema.getQueries().stream(), schema.getMutations().stream())
                 .forEach(operation -> {
                     Metadata metadata = Metadata.builder()
@@ -93,7 +92,7 @@ public class Bootstrap {
                             .withType(MetricType.SIMPLE_TIMER)
                             .withDescription("Call statistics for the query '" + operation.getName() + "'")
                             .build();
-                    MetricRegistries.get(MetricRegistry.Type.VENDOR).simpleTimer(metadata);
+                    metricRegistry.simpleTimer(metadata);
                 });
     }
 

--- a/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/MetricDecorator.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/MetricDecorator.java
@@ -9,11 +9,17 @@ import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.graphql.lookup.LookupService;
 
 public class MetricDecorator implements DataFetcherDecorator {
 
-    private Map<DataFetchingEnvironment, Long> startTimes = Collections.synchronizedMap(new IdentityHashMap<>());
+    private final Map<DataFetchingEnvironment, Long> startTimes = Collections.synchronizedMap(new IdentityHashMap<>());
+
+    private final MetricRegistry metricRegistry;
+
+    public MetricDecorator() {
+        metricRegistry = LookupService.load().getMetricRegistry(MetricRegistry.Type.VENDOR);
+    }
 
     @Override
     public void before(DataFetchingEnvironment dfe) {
@@ -26,7 +32,7 @@ public class MetricDecorator implements DataFetcherDecorator {
         if (startTime != null) {
             long duration = System.nanoTime() - startTime;
             MetricID metricID = new MetricID("mp_graphql_" + dfe.getField().getName());
-            MetricRegistries.get(MetricRegistry.Type.VENDOR).simpleTimer(metricID.getName(), metricID.getTagsAsArray())
+            metricRegistry.simpleTimer(metricID.getName(), metricID.getTagsAsArray())
                     .update(Duration.ofNanos(duration));
         }
 

--- a/implementation/src/main/java/io/smallrye/graphql/lookup/LookupService.java
+++ b/implementation/src/main/java/io/smallrye/graphql/lookup/LookupService.java
@@ -6,6 +6,7 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ServiceLoader;
 
+import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.logging.Logger;
 
 import io.smallrye.graphql.execution.Classes;
@@ -37,6 +38,8 @@ public interface LookupService {
     Class<?> getClass(Class<?> declaringClass);
 
     Object getInstance(Class<?> declaringClass);
+
+    MetricRegistry getMetricRegistry(MetricRegistry.Type type);
 
     default Object getInstance(String declaringClass) {
         Class<?> loadedClass = loadClass(declaringClass);
@@ -94,6 +97,11 @@ public interface LookupService {
                     | IllegalArgumentException | InvocationTargetException ex) {
                 throw new RuntimeException("Could not get Instance using the default lookup service", ex);
             }
+        }
+
+        @Override
+        public MetricRegistry getMetricRegistry(MetricRegistry.Type type) {
+            throw new UnsupportedOperationException("Metrics are not supported without CDI");
         }
     }
 }


### PR DESCRIPTION
Unfortunately now we can't obtain a `MetricRegistry` directly without using CDI, so this needs some stuff had to be moved to modules with a CDI dependency. If anyone has a better idea how to do this, that would be welcome.. 

Fixes #182 