### PR TITLE
[#187] First pass at QueryCache

### DIFF
--- a/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -138,10 +138,13 @@ public class ExecutionService {
         if (this.graphQL == null) {
             ExceptionHandler exceptionHandler = new ExceptionHandler(config);
             if (graphQLSchema != null) {
+                QueryCache queryCache = new QueryCache();
                 this.graphQL = GraphQL
                         .newGraphQL(graphQLSchema)
                         .queryExecutionStrategy(new QueryExecutionStrategy(exceptionHandler))
                         .mutationExecutionStrategy(new MutationExecutionStrategy(exceptionHandler))
+                        .instrumentation(queryCache)
+                        .preparsedDocumentProvider(queryCache)
                         .build();
             } else {
                 LOG.warn("No GraphQL methods found. Try annotating your methods with @Query or @Mutation");

--- a/implementation/src/main/java/io/smallrye/graphql/execution/LRUCache.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/LRUCache.java
@@ -1,0 +1,98 @@
+package io.smallrye.graphql.execution;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class LRUCache<K, V> {
+
+    private final int maxSize;
+    private final Map<K, Entry<V>> cache = new HashMap<>();
+    private Entry<V> start;
+    private Entry<V> end;
+
+    LRUCache(int maxSize) {
+        this.maxSize = maxSize;
+    }
+
+    V get(K key) {
+        Entry<V> entry = cache.computeIfPresent(key, this::moveEntryToStart);
+        return entry == null ? null : entry.value;
+    }
+
+    V put(K key, V value) {
+        Entry<V> entry = cache.get(key);
+        V oldValue = null;
+        if (entry == null) {
+            entry = cachePutNew(key, value);
+        } else {
+            entry = removeEntry(entry);
+            oldValue = entry.value;
+            entry.value = value;
+        }
+        entry = addToStart(entry);
+        return oldValue;
+    }
+
+    V computeIfAbsent(K key, Function<K, V> valueFunction) {
+        Entry<V> entry = cache.get(key);
+        if (entry == null) {
+            entry = cachePutNew(key, valueFunction.apply(key));
+        } else {
+            entry = removeEntry(entry);
+        }
+        entry = addToStart(entry);
+        return entry.value;
+    }
+
+    private Entry<V> cachePutNew(K key, V value) {
+        Entry<V> entry = new Entry<V>(key, value);
+        cache.put(key, entry);
+        if (cache.size() > maxSize) {
+            cache.remove(end.key);
+            removeEntry(end);
+        }
+        return entry;
+    }
+
+    private synchronized Entry<V> moveEntryToStart(K key, Entry<V> entry) {
+        return addToStart(removeEntry(entry));
+    }
+
+    private synchronized Entry<V> removeEntry(Entry<V> entry) {
+        if (entry.left != null) {
+            entry.left.right = entry.right;
+        }
+        if (entry.right != null) {
+            entry.right.left = entry.left;
+        } else {
+            end = entry.left;
+        }
+        return entry;
+    }
+
+    private synchronized Entry<V> addToStart(Entry<V> entry) {
+        entry.right = start;
+        entry.left = null;
+        if (start != null) {
+            start.left = entry;
+        }
+        start = entry;
+        if (end == null) {
+            end = start;
+        }
+        return entry;
+    }
+
+    private class Entry<V> {
+        final K key;
+        V value;
+        Entry<V> left;
+        Entry<V> right;
+
+        Entry(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/graphql/execution/LRUCache.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/LRUCache.java
@@ -1,13 +1,13 @@
 package io.smallrye.graphql.execution;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 public class LRUCache<K, V> {
 
     private final int maxSize;
-    private final Map<K, Entry<V>> cache = new HashMap<>();
+    private final Map<K, Entry<V>> cache = new ConcurrentHashMap<>();
     private Entry<V> start;
     private Entry<V> end;
 
@@ -48,9 +48,11 @@ public class LRUCache<K, V> {
     private Entry<V> cachePutNew(K key, V value) {
         Entry<V> entry = new Entry<V>(key, value);
         cache.put(key, entry);
-        if (cache.size() > maxSize) {
-            cache.remove(end.key);
-            removeEntry(end);
+        synchronized (cache) {
+            if (cache.size() > maxSize) {
+                cache.remove(end.key);
+                removeEntry(end);
+            }
         }
         return entry;
     }

--- a/implementation/src/main/java/io/smallrye/graphql/execution/QueryCache.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/QueryCache.java
@@ -1,0 +1,102 @@
+package io.smallrye.graphql.execution;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.jboss.logging.Logger;
+
+import graphql.ExecutionInput;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
+import graphql.execution.preparsed.PreparsedDocumentEntry;
+import graphql.execution.preparsed.PreparsedDocumentProvider;
+import graphql.validation.ValidationError;
+
+public class QueryCache extends SimpleInstrumentation implements PreparsedDocumentProvider {
+    private static final Logger LOG = Logger.getLogger(QueryCache.class);
+    private static final int MAX_CACHE_SIZE = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
+        return Integer.getInteger("io.smallrye.graphql.execution.queryCacheMaxSize", 2048);
+    });
+
+    private final LRUCache<String, PreparsedDocumentEntry> cache = new LRUCache<>(MAX_CACHE_SIZE);
+    private final Map<String, ExecutionFunction> functionCache = new HashMap<>();
+    private final ThreadLocal<ExecutionFunction> executionFunctionTL = new ThreadLocal<>();
+
+    @Override
+    public PreparsedDocumentEntry getDocument(ExecutionInput executionInput,
+            Function<ExecutionInput, PreparsedDocumentEntry> computeFunction) {
+        String query = executionInput.getQuery();
+        PreparsedDocumentEntry entry = cache.get(query);
+        if (entry == null) {
+            ExecutionFunction executionFunction = new ExecutionFunction(computeFunction, executionInput);
+            functionCache.putIfAbsent(query, executionFunction);
+            executionFunctionTL.set(executionFunction);
+            entry = computeFunction.apply(executionInput);
+        } else if (LOG.isDebugEnabled()) {
+            LOG.debug("Retrieved from cache: " + query);
+        }
+        return entry;
+    }
+
+    @Override
+    public InstrumentationContext<List<ValidationError>> beginValidation(
+            InstrumentationValidationParameters parameters) {
+
+        ExecutionFunction executionFunction = executionFunctionTL.get();
+        if (executionFunction != null) {
+            executionFunctionTL.remove();
+            return new ValidationInstrumentationContext(executionFunction);
+        }
+        return super.beginValidation(parameters);
+    }
+
+    private static class ExecutionFunction implements Function<String, PreparsedDocumentEntry> {
+        private final Function<ExecutionInput, PreparsedDocumentEntry> function;
+        private final ExecutionInput executionInput;
+
+        ExecutionFunction(Function<ExecutionInput, PreparsedDocumentEntry> function, ExecutionInput executionInput) {
+            this.function = function;
+            this.executionInput = executionInput;
+        }
+
+        @Override
+        public PreparsedDocumentEntry apply(String s) {
+            return function.apply(executionInput);
+        }
+
+        String getQuery() {
+            return executionInput.getQuery();
+        }
+    }
+
+    private class ValidationInstrumentationContext implements InstrumentationContext<List<ValidationError>> {
+        private final ExecutionFunction executionFunction;
+
+        ValidationInstrumentationContext(ExecutionFunction executionFunction) {
+            this.executionFunction = executionFunction;
+        }
+
+        @Override
+        public void onDispatched(CompletableFuture<List<ValidationError>> result) {
+            // no-op
+        }
+
+        @Override
+        public void onCompleted(List<ValidationError> validationErrors, Throwable t) {
+            // at this point, we know the validation is complete - go ahead and add it to the cache if no errors
+            if (executionFunction != null && validationErrors == null || validationErrors.isEmpty()) {
+                // valid, uncached query - add to cache
+                cache.computeIfAbsent(executionFunction.getQuery(), executionFunction);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Added to cache: " + executionFunction.getQuery());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
LRU-based cache with a default size of 2048 queries/mutations, but can be changed by setting the system property `io.smallrye.graphql.execution.queryCacheMaxSize=4096`.

The cache allows a query that has been validated to skip validation - since the validation does not check variables, that is the ideal use case (or repeated invocations of the same query with the same arguments).

Invalid queries are not cached, but queries or mutations that result in an exception will still be cached.  My reasoning for this is that some exceptions are point-in-time-related - for example, suppose I want to buy a new guitar that costs $500, so I invoke `mutation withdraw(500.00)`, but since I only have $100 in my account, the server throws an InsufficientFundsException.  Fortunately today is a pay day, and my company deposits $500 into my account, so when I go back and call `mutation withdraw(500.00)`, it succeeds - and that operation was cached! :-)

Please don't merge just yet - while the code changes don't break anything, I'm not convinced that they improve performance much, so I'd like to hear back from some benchmark tests before merging.  Thanks!

Fixes #187