### PR TITLE
Refactor MetricsService to own interface

### DIFF
--- a/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CdiLookupService.java
+++ b/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CdiLookupService.java
@@ -5,13 +5,14 @@ import javax.enterprise.inject.spi.CDI;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
 import io.smallrye.graphql.lookup.LookupService;
+import io.smallrye.graphql.metrics.MetricsService;
 
 /**
  * Lookup service that gets the beans via CDI
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
-public class CdiLookupService implements LookupService {
+public class CdiLookupService implements LookupService, MetricsService {
 
     @Override
     public String getName() {

--- a/implementation-cdi/src/main/resources/META-INF/services/io.smallrye.graphql.metrics.MetricsService
+++ b/implementation-cdi/src/main/resources/META-INF/services/io.smallrye.graphql.metrics.MetricsService
@@ -1,0 +1,1 @@
+io.smallrye.graphql.cdi.CdiLookupService

--- a/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLProducer.java
+++ b/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/GraphQLProducer.java
@@ -9,7 +9,7 @@ import graphql.schema.GraphQLSchema;
 import io.smallrye.graphql.bootstrap.Bootstrap;
 import io.smallrye.graphql.execution.ExecutionService;
 import io.smallrye.graphql.execution.SchemaPrinter;
-import io.smallrye.graphql.lookup.LookupService;
+import io.smallrye.graphql.metrics.MetricsService;
 import io.smallrye.graphql.schema.model.Schema;
 
 /**
@@ -27,7 +27,7 @@ public class GraphQLProducer {
     public void initializeGraphQL(GraphQLConfig config, Schema schema) {
         this.graphQLSchema = Bootstrap.bootstrap(schema, config);
         if (config.isMetricsEnabled()) {
-            MetricRegistry vendorRegistry = LookupService.load().getMetricRegistry(MetricRegistry.Type.VENDOR);
+            MetricRegistry vendorRegistry = MetricsService.load().getMetricRegistry(MetricRegistry.Type.VENDOR);
             Bootstrap.registerMetrics(schema, vendorRegistry);
         }
         this.executionService = new ExecutionService(config, graphQLSchema);

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,20 +17,20 @@
     </properties>
 
     <dependencies>
-        
+
         <!-- The API -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>smallrye-graphql-api</artifactId>
         </dependency>
-        
+
         <!-- The model -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>smallrye-graphql-schema-model</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
+
         <!-- What we use from MicroProfile -->
         <dependency>
             <groupId>jakarta.json.bind</groupId>
@@ -64,9 +64,15 @@
 
         <!-- Testing -->
         <dependency>
-             <groupId>junit</groupId>
-             <artifactId>junit</artifactId>
-             <scope>test</scope>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
@@ -118,5 +124,4 @@
             </build>
         </profile>
     </profiles>
-    
 </project>

--- a/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/MetricDecorator.java
+++ b/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/MetricDecorator.java
@@ -9,7 +9,7 @@ import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.smallrye.graphql.lookup.LookupService;
+import io.smallrye.graphql.metrics.MetricsService;
 
 public class MetricDecorator implements DataFetcherDecorator {
 
@@ -18,7 +18,7 @@ public class MetricDecorator implements DataFetcherDecorator {
     private final MetricRegistry metricRegistry;
 
     public MetricDecorator() {
-        metricRegistry = LookupService.load().getMetricRegistry(MetricRegistry.Type.VENDOR);
+        metricRegistry = MetricsService.load().getMetricRegistry(MetricRegistry.Type.VENDOR);
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/graphql/lookup/LookupService.java
+++ b/implementation/src/main/java/io/smallrye/graphql/lookup/LookupService.java
@@ -6,7 +6,6 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ServiceLoader;
 
-import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.logging.Logger;
 
 import io.smallrye.graphql.execution.Classes;
@@ -38,8 +37,6 @@ public interface LookupService {
     Class<?> getClass(Class<?> declaringClass);
 
     Object getInstance(Class<?> declaringClass);
-
-    MetricRegistry getMetricRegistry(MetricRegistry.Type type);
 
     default Object getInstance(String declaringClass) {
         Class<?> loadedClass = loadClass(declaringClass);
@@ -97,11 +94,6 @@ public interface LookupService {
                     | IllegalArgumentException | InvocationTargetException ex) {
                 throw new RuntimeException("Could not get Instance using the default lookup service", ex);
             }
-        }
-
-        @Override
-        public MetricRegistry getMetricRegistry(MetricRegistry.Type type) {
-            throw new UnsupportedOperationException("Metrics are not supported without CDI");
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/graphql/metrics/MetricsService.java
+++ b/implementation/src/main/java/io/smallrye/graphql/metrics/MetricsService.java
@@ -1,0 +1,45 @@
+package io.smallrye.graphql.metrics;
+
+import java.util.ServiceLoader;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.jboss.logging.Logger;
+
+/**
+ * Service that allows containers to plug in their own MP Metrics implementation.
+ */
+public interface MetricsService {
+    static final Logger LOG = Logger.getLogger(MetricsService.class.getName());
+
+    public static MetricsService load() {
+        MetricsService metricsService;
+        try {
+            ServiceLoader<MetricsService> sl = ServiceLoader.load(MetricsService.class);
+            metricsService = sl.iterator().next();
+        } catch (Exception ex) {
+            metricsService = new DefaultMetricsService();
+        }
+        LOG.debug("Using " + metricsService.getName() + " lookup service");
+        return metricsService;
+    }
+
+    String getName();
+
+    MetricRegistry getMetricRegistry(MetricRegistry.Type type);
+
+    /**
+     * Default Metrics service that throws an UnsupportedOperationException.
+     */
+    class DefaultMetricsService implements MetricsService {
+
+        @Override
+        public String getName() {
+            return "Unsupported Metrics Service";
+        }
+
+        @Override
+        public MetricRegistry getMetricRegistry(MetricRegistry.Type type) {
+            throw new UnsupportedOperationException("Metrics are not supported without CDI");
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/graphql/metrics/MetricsTest.java
+++ b/implementation/src/test/java/io/smallrye/graphql/metrics/MetricsTest.java
@@ -1,0 +1,84 @@
+package io.smallrye.graphql.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import graphql.language.Field;
+import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.bootstrap.Bootstrap;
+import io.smallrye.graphql.execution.datafetcher.decorator.MetricDecorator;
+import io.smallrye.graphql.metrics.TestMetricsServiceImpl.MockMetricsRegistry;
+import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.Schema;
+
+public class MetricsTest {
+
+    @Test
+    public void testCanLoadMetricsService() throws Exception {
+        MetricsService service = MetricsService.load();
+        assertNotNull(service);
+        assertTrue(service instanceof TestMetricsServiceImpl);
+    }
+
+    @Test
+    public void testMetricsServiceRegisteredInBootstrap() throws Exception {
+        Operation query = new Operation();
+        query.setName("myQuery");
+        Operation mutation = new Operation();
+        mutation.setName("myMutation");
+
+        Schema schema = new Schema();
+        schema.setQueries(Collections.singleton(query));
+        schema.setMutations(Collections.singleton(mutation));
+
+        TestMetricsServiceImpl metricServiceImpl = new TestMetricsServiceImpl();
+        MockMetricsRegistry metricRegistry = metricServiceImpl.vendorRegistry;
+        Bootstrap.registerMetrics(schema, metricRegistry);
+
+        assertEquals(2, metricServiceImpl.vendorRegistry.simpleTimeMetadatas.size());
+        assertEquals("mp_graphql_myQuery", metricServiceImpl.vendorRegistry.simpleTimeMetadatas.get(0).getDisplayName());
+        assertEquals("mp_graphql_myMutation",
+                metricServiceImpl.vendorRegistry.simpleTimeMetadatas.get(1).getDisplayName());
+    }
+
+    @Test
+    public void testSimpleTimerCountWorks() throws Exception {
+        MetricDecorator decorator = new MetricDecorator();
+        Field field = mock(Field.class);
+        when(field.getName()).thenReturn("myFastQuery");
+        DataFetchingEnvironment dfe = mock(DataFetchingEnvironment.class);
+        when(dfe.getField()).thenReturn(field);
+
+        decorator.before(dfe);
+        decorator.after(dfe);
+
+        decorator.before(dfe);
+        decorator.after(dfe);
+
+        decorator.before(dfe);
+        decorator.after(dfe);
+
+        Field field2 = mock(Field.class);
+        when(field2.getName()).thenReturn("myOtherQuery");
+        DataFetchingEnvironment dfe2 = mock(DataFetchingEnvironment.class);
+        when(dfe2.getField()).thenReturn(field2);
+
+        decorator.before(dfe2);
+        decorator.after(dfe2);
+
+        decorator.before(dfe2);
+        decorator.after(dfe2);
+
+        MockMetricsRegistry registry = TestMetricsServiceImpl.INSTANCE.vendorRegistry;
+        assertEquals(2, registry.simpleTimers.size());
+        assertEquals(3, registry.simpleTimers.get("mp_graphql_myFastQuery").getCount());
+        assertEquals(2, registry.simpleTimers.get("mp_graphql_myOtherQuery").getCount());
+    }
+}

--- a/implementation/src/test/java/io/smallrye/graphql/metrics/TestMetricsServiceImpl.java
+++ b/implementation/src/test/java/io/smallrye/graphql/metrics/TestMetricsServiceImpl.java
@@ -1,0 +1,331 @@
+package io.smallrye.graphql.metrics;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.concurrent.Callable;
+
+import org.eclipse.microprofile.metrics.ConcurrentGauge;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricFilter;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricRegistry.Type;
+import org.eclipse.microprofile.metrics.SimpleTimer;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.Timer;
+
+public class TestMetricsServiceImpl implements MetricsService {
+
+    static TestMetricsServiceImpl INSTANCE;
+    final MockMetricsRegistry vendorRegistry = new MockMetricsRegistry();
+
+    @Override
+    public String getName() {
+        return "Test MetricsServiceImpl";
+    }
+
+    @Override
+    public MetricRegistry getMetricRegistry(Type type) {
+        if (INSTANCE == null) {
+            INSTANCE = this;
+        }
+        if (type.equals(Type.VENDOR)) {
+            return vendorRegistry;
+        }
+        return null;
+    }
+
+    public static class MockMetricsRegistry extends MetricRegistry {
+
+        final List<Metadata> simpleTimeMetadatas = new ArrayList<>();
+        final Map<String, SimpleTimer> simpleTimers = new HashMap<>();
+
+        @Override
+        public <T extends Metric> T register(String name, T metric) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public <T extends Metric> T register(Metadata metadata, T metric) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public <T extends Metric> T register(Metadata metadata, T metric, Tag... tags) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Counter counter(String name) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Counter counter(String name, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Counter counter(Metadata metadata) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Counter counter(Metadata metadata, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public ConcurrentGauge concurrentGauge(String name) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public ConcurrentGauge concurrentGauge(String name, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public ConcurrentGauge concurrentGauge(Metadata metadata) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public ConcurrentGauge concurrentGauge(Metadata metadata, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Histogram histogram(String name) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Histogram histogram(String name, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Histogram histogram(Metadata metadata) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Histogram histogram(Metadata metadata, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Meter meter(String name) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Meter meter(String name, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Meter meter(Metadata metadata) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Meter meter(Metadata metadata, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Timer timer(String name) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Timer timer(String name, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Timer timer(Metadata metadata) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Timer timer(Metadata metadata, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SimpleTimer simpleTimer(String name) {
+            return simpleTimers.computeIfAbsent(name, k -> new MockSimpleTimer());
+        }
+
+        @Override
+        public SimpleTimer simpleTimer(String name, Tag... tags) {
+            return simpleTimers.computeIfAbsent(name, k -> new MockSimpleTimer());
+        }
+
+        @Override
+        public SimpleTimer simpleTimer(Metadata metadata) {
+            simpleTimeMetadatas.add(metadata);
+            return simpleTimers.computeIfAbsent(metadata.getName(), k -> new MockSimpleTimer());
+        }
+
+        @Override
+        public SimpleTimer simpleTimer(Metadata metadata, Tag... tags) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public boolean remove(String name) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public boolean remove(MetricID metricID) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public void removeMatching(MetricFilter filter) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedSet<String> getNames() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedSet<MetricID> getMetricIDs() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, Gauge> getGauges() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, Gauge> getGauges(MetricFilter filter) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, Counter> getCounters() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, Counter> getCounters(MetricFilter filter) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, ConcurrentGauge> getConcurrentGauges() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, ConcurrentGauge> getConcurrentGauges(MetricFilter filter) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, Histogram> getHistograms() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, Histogram> getHistograms(MetricFilter filter) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, Meter> getMeters() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, Meter> getMeters(MetricFilter filter) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, Timer> getTimers() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, Timer> getTimers(MetricFilter filter) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, SimpleTimer> getSimpleTimers() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public SortedMap<MetricID, SimpleTimer> getSimpleTimers(MetricFilter filter) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Map<MetricID, Metric> getMetrics() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Map<String, Metadata> getMetadata() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+    }
+
+    static class MockSimpleTimer implements SimpleTimer {
+
+        Duration totalDuration = Duration.ZERO;
+        long count = 0;
+
+        @Override
+        public synchronized void update(Duration duration) {
+            totalDuration = totalDuration.plus(duration);
+            count++;
+        }
+
+        @Override
+        public <T> T time(Callable<T> event) throws Exception {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public void time(Runnable event) {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Context time() {
+            throw new UnsupportedOperationException("unimplemented");
+        }
+
+        @Override
+        public Duration getElapsedTime() {
+            return totalDuration;
+        }
+
+        @Override
+        public long getCount() {
+            return count;
+        }
+    }
+}

--- a/implementation/src/test/resources/META-INF/services/io.smallrye.graphql.metrics.MetricsService
+++ b/implementation/src/test/resources/META-INF/services/io.smallrye.graphql.metrics.MetricsService
@@ -1,0 +1,1 @@
+io.smallrye.graphql.metrics.TestMetricsServiceImpl


### PR DESCRIPTION
- refactored MetricRegistry into it's own service (from LookupService)
- req'd changes in CDI implementation module and impl
- new test cases

These changes should make it easier for containers (like Open Liberty) to separate out the Metrics implementation.  