### PR TITLE
Some metrics changes

### DIFF
--- a/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/DummyGraphQLApi.java
+++ b/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/DummyGraphQLApi.java
@@ -1,6 +1,7 @@
 package io.smallrye.graphql.tests.metrics;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
 
 @GraphQLApi
@@ -11,7 +12,7 @@ public class DummyGraphQLApi {
         return "foo";
     }
 
-    @Query(value = "mutate")
+    @Mutation(value = "mutate")
     public String mutation() {
         return "foo";
     }

--- a/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/MetricTest.java
+++ b/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/MetricTest.java
@@ -58,8 +58,8 @@ public class MetricTest {
     public void invokeApi() throws Exception {
         SimpleGraphQLClient client = new SimpleGraphQLClient(testingURL);
         client.query("{hello}");
-        client.query("{mutate}");
-        client.query("{mutate}");
+        client.query("mutation {mutate}");
+        client.query("mutation {mutate}");
     }
 
     @Test

--- a/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/MetricTest.java
+++ b/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/MetricTest.java
@@ -45,10 +45,10 @@ public class MetricTest {
     @Test
     @InSequence(99)
     public void verifyMetricsAreRegisteredEagerly() {
-        SimpleTimer metricForHelloQuery = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_hello"));
+        SimpleTimer metricForHelloQuery = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_Query_hello"));
         Assert.assertNotNull("Metric should be registered eagerly", metricForHelloQuery);
 
-        SimpleTimer metricForMutation = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_mutate"));
+        SimpleTimer metricForMutation = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_Mutation_mutate"));
         Assert.assertNotNull("Metric should be registered eagerly", metricForMutation);
     }
 
@@ -65,13 +65,13 @@ public class MetricTest {
     @Test
     @InSequence(101)
     public void verifyMetricsAreUpdated() {
-        SimpleTimer metricForHelloQuery = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_hello"));
+        SimpleTimer metricForHelloQuery = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_Query_hello"));
         Assert.assertEquals("The query was called once, this should be reflected in metric value",
                 1, metricForHelloQuery.getCount());
         Assert.assertTrue("Total elapsed time for query should be greater than zero",
                 metricForHelloQuery.getElapsedTime().toNanos() > 0);
 
-        SimpleTimer metricForHelloMutation = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_mutate"));
+        SimpleTimer metricForHelloMutation = metricRegistry.getSimpleTimers().get(new MetricID("mp_graphql_Mutation_mutate"));
         Assert.assertEquals("The query was called twice, this should be reflected in metric value",
                 2, metricForHelloMutation.getCount());
         Assert.assertTrue("Total elapsed time for query should be greater than zero",

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
@@ -21,6 +21,7 @@ import io.smallrye.graphql.schema.creator.type.InputTypeCreator;
 import io.smallrye.graphql.schema.creator.type.InterfaceCreator;
 import io.smallrye.graphql.schema.creator.type.TypeCreator;
 import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.OperationType;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Schema;
@@ -176,10 +177,10 @@ public class SchemaBuilder {
         for (MethodInfo methodInfo : methodInfoList) {
             Annotations annotationsForMethod = Annotations.getAnnotationsForMethod(methodInfo);
             if (annotationsForMethod.containsOneOfTheseAnnotations(Annotations.QUERY)) {
-                Operation query = operationCreator.createOperation(methodInfo, OperationType.Query);
+                Operation query = operationCreator.createOperation(methodInfo, OperationType.Query, null);
                 schema.addQuery(query);
             } else if (annotationsForMethod.containsOneOfTheseAnnotations(Annotations.MUTATION)) {
-                Operation mutation = operationCreator.createOperation(methodInfo, OperationType.Mutation);
+                Operation mutation = operationCreator.createOperation(methodInfo, OperationType.Mutation, null);
                 schema.addMutation(mutation);
             }
         }

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ArgumentCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ArgumentCreator.java
@@ -6,7 +6,6 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 
 import io.smallrye.graphql.schema.Annotations;
-import io.smallrye.graphql.schema.OperationType;
 import io.smallrye.graphql.schema.SchemaBuilderException;
 import io.smallrye.graphql.schema.helper.DefaultValueHelper;
 import io.smallrye.graphql.schema.helper.DescriptionHelper;
@@ -16,6 +15,7 @@ import io.smallrye.graphql.schema.helper.IgnoreHelper;
 import io.smallrye.graphql.schema.helper.MethodHelper;
 import io.smallrye.graphql.schema.helper.NonNullHelper;
 import io.smallrye.graphql.schema.model.Argument;
+import io.smallrye.graphql.schema.model.OperationType;
 import io.smallrye.graphql.schema.model.Reference;
 
 /**

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
@@ -16,6 +16,7 @@ import io.smallrye.graphql.schema.helper.IgnoreHelper;
 import io.smallrye.graphql.schema.helper.MethodHelper;
 import io.smallrye.graphql.schema.helper.NonNullHelper;
 import io.smallrye.graphql.schema.model.Field;
+import io.smallrye.graphql.schema.model.InterfaceType;
 import io.smallrye.graphql.schema.model.Reference;
 
 /**
@@ -36,9 +37,10 @@ public class FieldCreator {
      * This is used in the case of an interface
      * 
      * @param methodInfo the java method
+     * @param interfaceType
      * @return a Field model object
      */
-    public Optional<Field> createFieldForInterface(MethodInfo methodInfo) {
+    public Optional<Field> createFieldForInterface(MethodInfo methodInfo, final InterfaceType interfaceType) {
         Annotations annotationsForMethod = Annotations.getAnnotationsForInterfaceField(methodInfo);
 
         if (!IgnoreHelper.shouldIgnore(annotationsForMethod)) {

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/OperationCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/OperationCreator.java
@@ -8,7 +8,6 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 
 import io.smallrye.graphql.schema.Annotations;
-import io.smallrye.graphql.schema.OperationType;
 import io.smallrye.graphql.schema.SchemaBuilderException;
 import io.smallrye.graphql.schema.helper.DefaultValueHelper;
 import io.smallrye.graphql.schema.helper.DescriptionHelper;
@@ -18,6 +17,7 @@ import io.smallrye.graphql.schema.helper.MethodHelper;
 import io.smallrye.graphql.schema.helper.NonNullHelper;
 import io.smallrye.graphql.schema.model.Argument;
 import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.OperationType;
 import io.smallrye.graphql.schema.model.Reference;
 
 /**
@@ -42,9 +42,11 @@ public class OperationCreator {
      * 
      * @param methodInfo the java method
      * @param operationType the type of operation (Query / Mutation)
+     * @param type
      * @return a Operation that defines this GraphQL Operation
      */
-    public Operation createOperation(MethodInfo methodInfo, OperationType operationType) {
+    public Operation createOperation(MethodInfo methodInfo, OperationType operationType,
+            final io.smallrye.graphql.schema.model.Type type) {
         Annotations annotationsForMethod = Annotations.getAnnotationsForMethod(methodInfo);
         Type fieldType = methodInfo.returnType();
 
@@ -63,7 +65,11 @@ public class OperationCreator {
                 MethodHelper.getPropertyName(Direction.OUT, methodInfo.name()),
                 name,
                 maybeDescription.orElse(null),
-                reference);
+                reference,
+                operationType);
+        if (type != null) {
+            operation.setContainingType(new Reference(type));
+        }
 
         // NotNull
         if (NonNullHelper.markAsNonNull(fieldType, annotationsForMethod)) {

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InterfaceCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InterfaceCreator.java
@@ -75,7 +75,7 @@ public class InterfaceCreator implements Creator<InterfaceType> {
 
         for (MethodInfo methodInfo : allMethods) {
             if (MethodHelper.isPropertyMethod(Direction.OUT, methodInfo.name())) {
-                fieldCreator.createFieldForInterface(methodInfo)
+                fieldCreator.createFieldForInterface(methodInfo, interfaceType)
                         .ifPresent(interfaceType::addField);
             }
         }

--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/TypeCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/TypeCreator.java
@@ -13,7 +13,6 @@ import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.logging.Logger;
 
 import io.smallrye.graphql.schema.Annotations;
-import io.smallrye.graphql.schema.OperationType;
 import io.smallrye.graphql.schema.ScanningContext;
 import io.smallrye.graphql.schema.creator.FieldCreator;
 import io.smallrye.graphql.schema.creator.OperationCreator;
@@ -24,6 +23,7 @@ import io.smallrye.graphql.schema.helper.MethodHelper;
 import io.smallrye.graphql.schema.helper.SourceOperationHelper;
 import io.smallrye.graphql.schema.helper.TypeNameHelper;
 import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.OperationType;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Type;
@@ -111,7 +111,7 @@ public class TypeCreator implements Creator<Type> {
             List<MethodParameterInfo> methodParameterInfos = sourceFields.get(classInfo.name());
             for (MethodParameterInfo methodParameterInfo : methodParameterInfos) {
                 MethodInfo methodInfo = methodParameterInfo.method();
-                Operation operation = operationCreator.createOperation(methodInfo, OperationType.Source);
+                Operation operation = operationCreator.createOperation(methodInfo, OperationType.Source, type);
                 type.addOperation(operation);
             }
         }

--- a/schema-model/src/main/java/io/smallrye/graphql/schema/model/Field.java
+++ b/schema-model/src/main/java/io/smallrye/graphql/schema/model/Field.java
@@ -33,6 +33,7 @@ public class Field implements Serializable {
         this.name = name;
         this.description = description;
         this.reference = reference;
+
     }
 
     public String getMethodName() {
@@ -118,4 +119,5 @@ public class Field implements Serializable {
     public boolean hasDefaultValue() {
         return this.defaultValue != null;
     }
+
 }

--- a/schema-model/src/main/java/io/smallrye/graphql/schema/model/Operation.java
+++ b/schema-model/src/main/java/io/smallrye/graphql/schema/model/Operation.java
@@ -18,13 +18,18 @@ public final class Operation extends Field {
 
     private List<Argument> arguments = new LinkedList<>();
 
+    private OperationType operationType;
+
+    private Reference containingType;
+
     public Operation() {
     }
 
     public Operation(String className, String methodName, String propertyName, String name, String description,
-            Reference reference) {
+            Reference reference, final OperationType operationType) {
         super(methodName, propertyName, name, description, reference);
         this.className = className;
+        this.operationType = operationType;
     }
 
     public void setClassName(String className) {
@@ -49,5 +54,21 @@ public final class Operation extends Field {
 
     public boolean hasArguments() {
         return !this.arguments.isEmpty();
+    }
+
+    public void setOperationType(final OperationType operationType) {
+        this.operationType = operationType;
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    public Reference getContainingType() {
+        return containingType;
+    }
+
+    public void setContainingType(final Reference containingType) {
+        this.containingType = containingType;
     }
 }

--- a/schema-model/src/main/java/io/smallrye/graphql/schema/model/OperationType.java
+++ b/schema-model/src/main/java/io/smallrye/graphql/schema/model/OperationType.java
@@ -1,4 +1,4 @@
-package io.smallrye.graphql.schema;
+package io.smallrye.graphql.schema.model;
 
 /**
  * To indicate the type of operation

--- a/schema-model/src/main/java/io/smallrye/graphql/schema/model/Reference.java
+++ b/schema-model/src/main/java/io/smallrye/graphql/schema/model/Reference.java
@@ -23,6 +23,12 @@ public class Reference implements Serializable {
         this.type = type;
     }
 
+    public Reference(final Reference reference) {
+        this.className = reference.className;
+        this.name = reference.name;
+        this.type = reference.type;
+    }
+
     /**
      * This represent the Java Class Name
      * 


### PR DESCRIPTION
* include all queries/fields which are updated by MetricDecorator in initial registration
* include type-name in metric-name, prevents a single metric for multiple fields
* fix the test which tested metrics on mutations