### PR TITLE
Fail immediately if an InputType's class does not have a public no-ar…

### DIFF
--- a/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
+++ b/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
@@ -1,5 +1,6 @@
 package io.smallrye.graphql.schema.creator.type;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +40,13 @@ public class InputTypeCreator implements Creator<InputType> {
 
     @Override
     public InputType create(ClassInfo classInfo) {
+        if (!classInfo.hasNoArgsConstructor() ||
+                !Modifier.isPublic(classInfo.method("<init>").flags())) {
+            throw new IllegalArgumentException(
+                    "Class " + classInfo.name().toString()
+                            + " is used as input, but does not have a public default constructor");
+        }
+
         LOG.debug("Creating Input from " + classInfo.name().toString());
 
         Annotations annotations = Annotations.getAnnotationsForClass(classInfo);


### PR DESCRIPTION
…g constructor

Without this fix, the first chance to detect such error is when you submit a query and you get this useless error response as result:

```
{
  "errors": [
    {
      "message": "Validation error of type WrongType: argument 'person' with value 'StringValue{value='\n{\n    \"gender\": \"OTHER\",\n    \"name\": \"Frunubucator\"\n}'}' is not a valid 'Unknown Scalar Type [org.example.graphql.model.Person]' @ 'create'",
      "locations": [
        {
          "line": 2,
          "column": 10
        }
      ],
      "extensions": {
        "description": "argument 'person' with value 'StringValue{value='\n{\n    \"gender\": \"OTHER\",\n    \"name\": \"Frunubucator\"\n}'}' is not a valid 'Unknown Scalar Type [org.example.graphql.model.Person]'",
        "validationErrorType": "WrongType",
        "queryPath": [
          "create"
        ],
        "classification": "ValidationError"
      }
    }
  ],
  "data": {
    "create": null
  }
}
```