### PR TITLE
Add OpenTracing support to server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,8 @@
         <version.eclipse.microprofile.graphql>1.0.2</version.eclipse.microprofile.graphql>
         <version.eclipse.microprofile.metrics>2.3.1</version.eclipse.microprofile.metrics>
         <version.smallrye.metrics>2.4.1</version.smallrye.metrics>
-        
+        <version.opentracing>0.31.0</version.opentracing>
+
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/tck/target/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../tck/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <slf4j-jboss-logging.version>1.2.0.Final</slf4j-jboss-logging.version>
     </properties>
@@ -89,6 +90,14 @@
                 <artifactId>microprofile-metrics-api</artifactId>
                 <version>${version.eclipse.microprofile.metrics}</version>
             </dependency>
+
+            <!-- OpenTracing -->
+            <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-api</artifactId>
+                <version>${version.opentracing}</version>
+            </dependency>
+
 
             <!-- Dependencies provided by the project -->
             <dependency>

--- a/server/implementation-cdi/pom.xml
+++ b/server/implementation-cdi/pom.xml
@@ -41,7 +41,14 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
+        <!-- OpenTracing -->
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
              <groupId>junit</groupId>

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CdiLookupService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CdiLookupService.java
@@ -4,15 +4,17 @@ import javax.enterprise.inject.spi.CDI;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
+import io.opentracing.Tracer;
 import io.smallrye.graphql.spi.LookupService;
 import io.smallrye.graphql.spi.MetricsService;
+import io.smallrye.graphql.spi.OpenTracingService;
 
 /**
  * Lookup service that gets the beans via CDI
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
-public class CdiLookupService implements LookupService, MetricsService {
+public class CdiLookupService implements LookupService, MetricsService, OpenTracingService {
 
     @Override
     public String getName() {
@@ -33,6 +35,11 @@ public class CdiLookupService implements LookupService, MetricsService {
     @Override
     public MetricRegistry getMetricRegistry(MetricRegistry.Type type) {
         return CDI.current().select(MetricRegistry.class, new RegistryTypeLiteral(type)).get();
+    }
+
+    @Override
+    public Tracer getTracer() {
+        return CDI.current().select(Tracer.class).get();
     }
 
 }

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/ConfigKey.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/ConfigKey.java
@@ -10,6 +10,7 @@ public interface ConfigKey extends org.eclipse.microprofile.graphql.ConfigKey {
     public static final String PRINT_DATAFETCHER_EXCEPTION = "smallrye.graphql.printDataFetcherException";
     public static final String ALLOW_GET = "smallrye.graphql.allowGet";
     public static final String ENABLE_METRICS = "smallrye.graphql.metrics.enabled";
+    public static final String ENABLE_TRACING = "smallrye.graphql.tracing.enabled";
     public static final String SCHEMA_INCLUDE_SCALARS = "smallrye.graphql.schema.includeScalars";
     public static final String SCHEMA_INCLUDE_DEFINITION = "smallrye.graphql.schema.includeSchemaDefinition";
     public static final String SCHEMA_INCLUDE_DIRECTIVES = "smallrye.graphql.schema.includeDirectives";

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/GraphQLConfig.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/GraphQLConfig.java
@@ -131,6 +131,10 @@ public class GraphQLConfig implements Config {
         this.metricsEnabled = metricsEnabled;
     }
 
+    public void setTracingEnabled(final boolean tracingEnabled) {
+        this.tracingEnabled = tracingEnabled;
+    }
+
     public void setIncludeScalarsInSchema(boolean includeScalarsInSchema) {
         this.includeScalarsInSchema = includeScalarsInSchema;
     }

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/GraphQLConfig.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/GraphQLConfig.java
@@ -43,6 +43,10 @@ public class GraphQLConfig implements Config {
     private boolean metricsEnabled;
 
     @Inject
+    @ConfigProperty(name = ConfigKey.ENABLE_TRACING, defaultValue = "false")
+    private boolean tracingEnabled;
+
+    @Inject
     @ConfigProperty(name = ConfigKey.SCHEMA_INCLUDE_SCALARS, defaultValue = "true")
     private boolean includeScalarsInSchema;
 
@@ -80,6 +84,11 @@ public class GraphQLConfig implements Config {
 
     public boolean isMetricsEnabled() {
         return metricsEnabled;
+    }
+
+    @Override
+    public boolean isTracingEnabled() {
+        return tracingEnabled;
     }
 
     public boolean isIncludeDirectivesInSchema() {
@@ -137,4 +146,5 @@ public class GraphQLConfig implements Config {
     public void setIncludeIntrospectionTypesInSchema(boolean includeIntrospectionTypesInSchema) {
         this.includeIntrospectionTypesInSchema = includeIntrospectionTypesInSchema;
     }
+
 }

--- a/server/implementation-cdi/src/main/resources/META-INF/services/io.smallrye.graphql.spi.OpenTracingService
+++ b/server/implementation-cdi/src/main/resources/META-INF/services/io.smallrye.graphql.spi.OpenTracingService
@@ -1,0 +1,1 @@
+io.smallrye.graphql.cdi.CdiLookupService

--- a/server/implementation/pom.xml
+++ b/server/implementation/pom.xml
@@ -62,6 +62,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- OpenTracing -->
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/server/implementation/pom.xml
+++ b/server/implementation/pom.xml
@@ -91,6 +91,11 @@
             <version>1.0.7</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <version>${version.opentracing}</version>
+        </dependency>
         <!-- The model builder -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -2,7 +2,6 @@ package io.smallrye.graphql.bootstrap;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -36,6 +35,7 @@ import io.smallrye.graphql.execution.datafetcher.PropertyDataFetcher;
 import io.smallrye.graphql.execution.datafetcher.ReflectionDataFetcher;
 import io.smallrye.graphql.execution.datafetcher.decorator.DataFetcherDecorator;
 import io.smallrye.graphql.execution.datafetcher.decorator.MetricDecorator;
+import io.smallrye.graphql.execution.datafetcher.decorator.OpenTracingDecorator;
 import io.smallrye.graphql.execution.resolver.InterfaceOutputRegistry;
 import io.smallrye.graphql.execution.resolver.InterfaceResolver;
 import io.smallrye.graphql.json.JsonInputRegistry;
@@ -322,11 +322,12 @@ public class Bootstrap {
         GraphQLFieldDefinition graphQLFieldDefinition = fieldBuilder.build();
 
         // DataFetcher
-        Collection<DataFetcherDecorator> decorators;
+        Collection<DataFetcherDecorator> decorators = new ArrayList<>();
         if (config != null && config.isMetricsEnabled()) {
-            decorators = Collections.singletonList(new MetricDecorator());
-        } else {
-            decorators = Collections.emptyList();
+            decorators.add(new MetricDecorator());
+        }
+        if (config != null && config.isTracingEnabled()) {
+            decorators.add(new OpenTracingDecorator());
         }
         ReflectionDataFetcher datafetcher = new ReflectionDataFetcher(operation, decorators);
         codeRegistryBuilder.dataFetcher(FieldCoordinates.coordinates(operationTypeName,

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Config.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Config.java
@@ -49,4 +49,8 @@ public interface Config {
     default boolean isIncludeIntrospectionTypesInSchema() {
         return false;
     }
+
+    default boolean isTracingEnabled() {
+        return false;
+    };
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionDecorator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionDecorator.java
@@ -1,0 +1,18 @@
+package io.smallrye.graphql.execution;
+
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+
+public interface ExecutionDecorator {
+    default void before(ExecutionInput executionInput) {
+
+    }
+
+    default void after(ExecutionInput executionInput, ExecutionResult executionResult) {
+
+    }
+
+    default void onError(ExecutionInput executionInput, Throwable throwable) {
+
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/MetricNaming.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/MetricNaming.java
@@ -1,16 +1,14 @@
 package io.smallrye.graphql.execution;
 
-import graphql.schema.GraphQLList;
-import graphql.schema.GraphQLNamedType;
-import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLType;
+import io.smallrye.graphql.execution.datafetcher.helper.NameHelper;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.OperationType;
 
 public class MetricNaming {
 
     public static String fromTypeAndName(GraphQLType type, String name) {
-        return "mp_graphql_" + getName(type) + "_" + name;
+        return "mp_graphql_" + NameHelper.getName(type) + "_" + name;
     }
 
     public static String fromOperation(Operation operation) {
@@ -21,17 +19,6 @@ public class MetricNaming {
         } else {
             return "mp_graphql_" + operation.getContainingType().getName() + "_" + operation.getName();
         }
-    }
-
-    private static String getName(GraphQLType graphQLType) {
-        if (graphQLType instanceof GraphQLNamedType) {
-            return ((GraphQLNamedType) graphQLType).getName();
-        } else if (graphQLType instanceof GraphQLNonNull) {
-            return getName(((GraphQLNonNull) graphQLType).getWrappedType());
-        } else if (graphQLType instanceof GraphQLList) {
-            return getName(((GraphQLList) graphQLType).getWrappedType());
-        }
-        return "";
     }
 
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/OpenTracingExecutionDecorator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/OpenTracingExecutionDecorator.java
@@ -1,0 +1,65 @@
+package io.smallrye.graphql.execution;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.GraphQLContext;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.smallrye.graphql.spi.OpenTracingService;
+
+public class OpenTracingExecutionDecorator implements ExecutionDecorator {
+
+    private final Map<ExecutionInput, Scope> executionScopes = Collections.synchronizedMap(new IdentityHashMap<>());
+
+    OpenTracingService openTracingService = OpenTracingService.load();
+
+    public OpenTracingExecutionDecorator() {
+    }
+
+    @Override
+    public void before(final ExecutionInput executionInput) {
+        Tracer tracer = openTracingService.getTracer();
+
+        String operationName = "GraphQL";
+        if (executionInput.getOperationName() != null && !executionInput.getOperationName().isEmpty()) {
+            operationName = "GraphQL:" + executionInput.getOperationName();
+        }
+
+        Scope scope = tracer.buildSpan(operationName)
+                .asChildOf(tracer.activeSpan())
+                .withTag("graphql.executionId", executionInput.getExecutionId().toString())
+                .withTag("graphql.operationName", executionInput.getOperationName())
+                .startActive(true);
+
+        executionScopes.put(executionInput, scope);
+
+        ((GraphQLContext) executionInput.getContext()).put(Span.class, scope.span());
+    }
+
+    @Override
+    public void after(final ExecutionInput executionInput, final ExecutionResult executionResult) {
+        Scope scope = executionScopes.remove(executionInput);
+        if (scope != null) {
+            scope.close();
+        }
+    }
+
+    @Override
+    public void onError(final ExecutionInput executionInput, final Throwable throwable) {
+        Scope scope = executionScopes.remove(executionInput);
+        if (scope != null) {
+            Map<String, Object> error = new HashMap<>();
+            error.put("event.object", throwable);
+            error.put("event", "error");
+            scope.span().log(error);
+            scope.close();
+        }
+    }
+
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/OpenTracingExecutionDecorator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/OpenTracingExecutionDecorator.java
@@ -26,10 +26,7 @@ public class OpenTracingExecutionDecorator implements ExecutionDecorator {
     public void before(final ExecutionInput executionInput) {
         Tracer tracer = openTracingService.getTracer();
 
-        String operationName = "GraphQL";
-        if (executionInput.getOperationName() != null && !executionInput.getOperationName().isEmpty()) {
-            operationName = "GraphQL:" + executionInput.getOperationName();
-        }
+        String operationName = SpanNaming.getOperationName(executionInput);
 
         Scope scope = tracer.buildSpan(operationName)
                 .asChildOf(tracer.activeSpan())

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/SpanNaming.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/SpanNaming.java
@@ -1,0 +1,26 @@
+package io.smallrye.graphql.execution;
+
+import graphql.ExecutionInput;
+import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.execution.datafetcher.helper.NameHelper;
+
+public final class SpanNaming {
+
+    private static final String PREFIX = "GraphQL";
+
+    public static String getOperationName(final DataFetchingEnvironment env) {
+        String parent = NameHelper.getName(env.getParentType());
+
+        String name = PREFIX + ":" + parent + "." + env.getField().getName();
+
+        return name;
+    }
+
+    public static String getOperationName(ExecutionInput executionInput) {
+        if (executionInput.getOperationName() != null && !executionInput.getOperationName().isEmpty()) {
+            return PREFIX + ":" + executionInput.getOperationName();
+        }
+        return PREFIX;
+    }
+
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/ReflectionDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/ReflectionDataFetcher.java
@@ -88,16 +88,9 @@ public class ReflectionDataFetcher implements DataFetcher {
         Class<?> operationClass = classloadingService.loadClass(operation.getClassName());
         Object declaringObject = lookupService.getInstance(operationClass);
         try {
-            Class cdiClass = declaringObject.getClass();
-            Object resultFromMethodCall = null;
-            if (operation.hasArguments()) {
-                Method m = cdiClass.getMethod(operation.getMethodName(), getParameterClasses());
-                List transformedArguments = argumentHelper.getArguments(dfe);
-                resultFromMethodCall = m.invoke(declaringObject, transformedArguments.toArray());
-            } else {
-                Method m = cdiClass.getMethod(operation.getMethodName());
-                resultFromMethodCall = m.invoke(declaringObject);
-            }
+            Method m = operationClass.getMethod(operation.getMethodName(), getParameterClasses());
+            Object[] transformedArguments = argumentHelper.getArguments(dfe);
+            Object resultFromMethodCall = m.invoke(declaringObject, transformedArguments);
 
             // See if we need to transform on the way out
             return fieldHelper.transformResponse(resultFromMethodCall);

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/DataFetcherDecorator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/DataFetcherDecorator.java
@@ -1,11 +1,12 @@
 package io.smallrye.graphql.execution.datafetcher.decorator;
 
+import graphql.GraphQLContext;
 import graphql.schema.DataFetchingEnvironment;
 
 public interface DataFetcherDecorator {
 
     void before(DataFetchingEnvironment env);
 
-    void after(DataFetchingEnvironment env);
+    void after(DataFetchingEnvironment env, GraphQLContext newGraphQLContext);
 
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/MetricDecorator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/MetricDecorator.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
+import graphql.GraphQLContext;
 import graphql.schema.DataFetchingEnvironment;
 import io.smallrye.graphql.execution.MetricNaming;
 import io.smallrye.graphql.spi.MetricsService;
@@ -27,7 +28,7 @@ public class MetricDecorator implements DataFetcherDecorator {
     }
 
     @Override
-    public void after(DataFetchingEnvironment dfe) {
+    public void after(DataFetchingEnvironment dfe, GraphQLContext newGraphQLContext) {
         Long startTime = startTimes.remove(dfe);
         if (startTime != null) {
             long duration = System.nanoTime() - startTime;

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/OpenTracingDecorator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/OpenTracingDecorator.java
@@ -9,7 +9,7 @@ import graphql.schema.DataFetchingEnvironment;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
-import io.smallrye.graphql.execution.datafetcher.helper.DataFetchingEnvironmentHelper;
+import io.smallrye.graphql.execution.datafetcher.helper.NameHelper;
 import io.smallrye.graphql.spi.OpenTracingService;
 
 public class OpenTracingDecorator implements DataFetcherDecorator {
@@ -23,7 +23,7 @@ public class OpenTracingDecorator implements DataFetcherDecorator {
     public void before(final DataFetchingEnvironment env) {
         Tracer tracer = openTracingService.getTracer();
 
-        String parent = DataFetchingEnvironmentHelper.getName(env.getParentType());
+        String parent = NameHelper.getName(env.getParentType());
 
         String name = "GraphQL:" + parent + "." + env.getField().getName();
 
@@ -33,7 +33,7 @@ public class OpenTracingDecorator implements DataFetcherDecorator {
                 .asChildOf(parentSpan)
                 .withTag("graphql.executionId", env.getExecutionId().toString())
                 .withTag("graphql.operationName", env.getOperationDefinition().getName())
-                .withTag("graphql.parent", DataFetchingEnvironmentHelper.getName(env.getParentType()))
+                .withTag("graphql.parent", parent)
                 .withTag("graphql.field", env.getField().getName())
                 .withTag("graphql.path", env.getExecutionStepInfo().getPath().toString())
                 .startActive(true);

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/OpenTracingDecorator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/decorator/OpenTracingDecorator.java
@@ -1,0 +1,67 @@
+package io.smallrye.graphql.execution.datafetcher.decorator;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import graphql.GraphQLContext;
+import graphql.schema.DataFetchingEnvironment;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.smallrye.graphql.execution.datafetcher.helper.DataFetchingEnvironmentHelper;
+import io.smallrye.graphql.spi.OpenTracingService;
+
+public class OpenTracingDecorator implements DataFetcherDecorator {
+    private static final Object PARENT_SPAN_KEY = Span.class;
+
+    private final Map<DataFetchingEnvironment, Scope> scopes = Collections.synchronizedMap(new IdentityHashMap<>());
+
+    OpenTracingService openTracingService = OpenTracingService.load();
+
+    @Override
+    public void before(final DataFetchingEnvironment env) {
+        Tracer tracer = openTracingService.getTracer();
+
+        String parent = DataFetchingEnvironmentHelper.getName(env.getParentType());
+
+        String name = "GraphQL:" + parent + "." + env.getField().getName();
+
+        Span parentSpan = getParentSpan(tracer, env);
+
+        Scope scope = tracer.buildSpan(name)
+                .asChildOf(parentSpan)
+                .withTag("graphql.executionId", env.getExecutionId().toString())
+                .withTag("graphql.operationName", env.getOperationDefinition().getName())
+                .withTag("graphql.parent", DataFetchingEnvironmentHelper.getName(env.getParentType()))
+                .withTag("graphql.field", env.getField().getName())
+                .withTag("graphql.path", env.getExecutionStepInfo().getPath().toString())
+                .startActive(true);
+
+        scopes.put(env, scope);
+    }
+
+    private Span getParentSpan(Tracer tracer, final DataFetchingEnvironment env) {
+        final GraphQLContext localContext = env.getLocalContext();
+        if (localContext != null && localContext.hasKey(PARENT_SPAN_KEY)) {
+            return localContext.get(PARENT_SPAN_KEY);
+        }
+
+        final GraphQLContext rootContext = env.getContext();
+        if (rootContext != null && rootContext.hasKey(PARENT_SPAN_KEY)) {
+            return rootContext.get(PARENT_SPAN_KEY);
+        }
+
+        return tracer.activeSpan();
+    }
+
+    @Override
+    public void after(final DataFetchingEnvironment env, GraphQLContext newGraphQLContext) {
+        Scope scope = scopes.remove(env);
+        if (scope != null) {
+            scope.close();
+            newGraphQLContext.put(PARENT_SPAN_KEY, scope.span());
+        }
+    }
+
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
@@ -2,7 +2,6 @@ package io.smallrye.graphql.execution.datafetcher.helper;
 
 import java.text.ParseException;
 import java.time.DateTimeException;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -56,13 +55,14 @@ public class ArgumentHelper extends AbstractHelper {
      *
      * @throws GraphQLException
      */
-    public List getArguments(DataFetchingEnvironment dfe)
+    public Object[] getArguments(DataFetchingEnvironment dfe)
             throws GraphQLException, DateTimeException, ParseException, NumberFormatException {
-        List argumentObjects = new LinkedList();
+        Object[] argumentObjects = new Object[arguments.size()];
+        int idx = 0;
         for (Argument argument : arguments) {
-
             Object argumentValue = getArgument(dfe, argument);
-            argumentObjects.add(argumentValue);
+            argumentObjects[idx] = argumentValue;
+            idx++;
         }
 
         return argumentObjects;

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/DataFetchingEnvironmentHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/DataFetchingEnvironmentHelper.java
@@ -1,0 +1,29 @@
+package io.smallrye.graphql.execution.datafetcher.helper;
+
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNamedType;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLType;
+
+public class DataFetchingEnvironmentHelper {
+
+    /**
+     * Gets the name of a type.
+     * <p>
+     * If it's a list or a nonnull-type, the type is unwrapped first.
+     *
+     * @param graphQLType the type to unwrap
+     * @return the real name of the type.
+     */
+    public static String getName(GraphQLType graphQLType) {
+        if (graphQLType instanceof GraphQLNamedType) {
+            return ((GraphQLNamedType) graphQLType).getName();
+        } else if (graphQLType instanceof GraphQLNonNull) {
+            return getName(((GraphQLNonNull) graphQLType).getWrappedType());
+        } else if (graphQLType instanceof GraphQLList) {
+            return getName(((GraphQLList) graphQLType).getWrappedType());
+        }
+        return "";
+    }
+
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/NameHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/NameHelper.java
@@ -5,16 +5,8 @@ import graphql.schema.GraphQLNamedType;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLType;
 
-public class DataFetchingEnvironmentHelper {
+public class NameHelper {
 
-    /**
-     * Gets the name of a type.
-     * <p>
-     * If it's a list or a nonnull-type, the type is unwrapped first.
-     *
-     * @param graphQLType the type to unwrap
-     * @return the real name of the type.
-     */
     public static String getName(GraphQLType graphQLType) {
         if (graphQLType instanceof GraphQLNamedType) {
             return ((GraphQLNamedType) graphQLType).getName();

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/OpenTracingService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/OpenTracingService.java
@@ -32,7 +32,7 @@ public interface OpenTracingService {
 
         @Override
         public String getName() {
-            return "Unsupported Metrics Service";
+            return "Unsupported OpenTracing Service";
         }
 
         @Override

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/OpenTracingService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/OpenTracingService.java
@@ -1,0 +1,44 @@
+package io.smallrye.graphql.spi;
+
+import java.util.ServiceLoader;
+
+import org.jboss.logging.Logger;
+
+import io.opentracing.Tracer;
+
+public interface OpenTracingService {
+    static final Logger LOG = Logger.getLogger(OpenTracingService.class.getName());
+
+    public static OpenTracingService load() {
+        OpenTracingService openTracingService;
+        try {
+            ServiceLoader<OpenTracingService> sl = ServiceLoader.load(OpenTracingService.class);
+            openTracingService = sl.iterator().next();
+        } catch (Exception ex) {
+            openTracingService = new OpenTracingService.DefaultOpenTracingService();
+        }
+        LOG.debug("Using " + openTracingService.getName() + " lookup service");
+        return openTracingService;
+    }
+
+    String getName();
+
+    Tracer getTracer();
+
+    /**
+     * Default Metrics service that throws an UnsupportedOperationException.
+     */
+    class DefaultOpenTracingService implements OpenTracingService {
+
+        @Override
+        public String getName() {
+            return "Unsupported Metrics Service";
+        }
+
+        @Override
+        public Tracer getTracer() {
+            throw new UnsupportedOperationException("OpenTracing is not supported without CDI");
+        }
+
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/transformation/TransformException.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/transformation/TransformException.java
@@ -34,8 +34,8 @@ public class TransformException extends RuntimeException {
         }
     }
 
-    public DataFetcherResult<Object> getDataFetcherResult(DataFetchingEnvironment dfe) {
-
+    public DataFetcherResult.Builder<Object> appendDataFetcherResult(DataFetcherResult.Builder<Object> builder,
+            DataFetchingEnvironment dfe) {
         DataFetcherExceptionHandlerParameters handlerParameters = DataFetcherExceptionHandlerParameters
                 .newExceptionParameters()
                 .dataFetchingEnvironment(dfe)
@@ -51,9 +51,7 @@ public class TransformException extends RuntimeException {
                         + "'}' is not a valid '" + getScalarTypeName() + "'",
                 paths);
 
-        return DataFetcherResult.newResult()
-                .error(error)
-                .build();
+        return builder.error(error);
     }
 
     private String getScalarTypeName() {

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/OpenTracingExecutionDecoratorTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/OpenTracingExecutionDecoratorTest.java
@@ -1,0 +1,66 @@
+package io.smallrye.graphql.execution;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.GraphQLContext;
+import graphql.execution.ExecutionId;
+import io.opentracing.mock.MockSpan;
+import io.smallrye.graphql.opentracing.MockTracerOpenTracingService;
+
+public class OpenTracingExecutionDecoratorTest {
+
+    @Before
+    public void reset() {
+        MockTracerOpenTracingService.MOCK_TRACER.reset();
+    }
+
+    @Test
+    public void testExecutionTracing() {
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query("{}")
+                .context(GraphQLContext.newContext())
+                .executionId(ExecutionId.from("1"))
+                .build();
+
+        ExecutionResult executionResult = Mockito.mock(ExecutionResult.class);
+
+        OpenTracingExecutionDecorator openTracingExecutionDecorator = new OpenTracingExecutionDecorator();
+
+        openTracingExecutionDecorator.before(executionInput);
+        openTracingExecutionDecorator.after(executionInput, executionResult);
+
+        Assert.assertEquals("One span should be finished", 1, MockTracerOpenTracingService.MOCK_TRACER.finishedSpans().size());
+        MockSpan span = MockTracerOpenTracingService.MOCK_TRACER.finishedSpans().get(0);
+        Assert.assertEquals("GraphQL", span.operationName());
+        Assert.assertEquals("ExecutionId should be present in span", "1", span.tags().get("graphql.executionId"));
+    }
+
+    @Test
+    public void spanOperationNameShouldContainGraphQLOperationName() {
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query("{}")
+                .context(GraphQLContext.newContext())
+                .operationName("someOperation")
+                .executionId(ExecutionId.from("1"))
+                .build();
+
+        ExecutionResult executionResult = Mockito.mock(ExecutionResult.class);
+
+        OpenTracingExecutionDecorator openTracingExecutionDecorator = new OpenTracingExecutionDecorator();
+
+        openTracingExecutionDecorator.before(executionInput);
+        openTracingExecutionDecorator.after(executionInput, executionResult);
+
+        Assert.assertEquals("One span should be finished", 1, MockTracerOpenTracingService.MOCK_TRACER.finishedSpans().size());
+        MockSpan span = MockTracerOpenTracingService.MOCK_TRACER.finishedSpans().get(0);
+        Assert.assertEquals("GraphQL:someOperation", span.operationName());
+        Assert.assertEquals("operation name should be present in span", "someOperation",
+                span.tags().get("graphql.operationName"));
+    }
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/datafetcher/decorator/OpenTracingDecoratorTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/datafetcher/decorator/OpenTracingDecoratorTest.java
@@ -1,0 +1,86 @@
+package io.smallrye.graphql.execution.datafetcher.decorator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import graphql.GraphQLContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionPath;
+import graphql.execution.ExecutionStepInfo;
+import graphql.language.Field;
+import graphql.language.OperationDefinition;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLNamedType;
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.smallrye.graphql.opentracing.MockTracerOpenTracingService;
+
+public class OpenTracingDecoratorTest {
+
+    private DataFetchingEnvironment dfe;
+
+    @Before
+    public void reset() {
+        MockTracerOpenTracingService.MOCK_TRACER.reset();
+        this.dfe = dataFetchingEnvironment();
+    }
+
+    private DataFetchingEnvironment dataFetchingEnvironment() {
+        Field field = mock(Field.class);
+        when(field.getName()).thenReturn("myFastQuery");
+        GraphQLNamedType query = mock(GraphQLNamedType.class);
+        when(query.getName()).thenReturn("Query");
+        OperationDefinition operationDefinition = mock(OperationDefinition.class);
+        when(operationDefinition.getName()).thenReturn("someOperation");
+        ExecutionPath executionPath = mock(ExecutionPath.class);
+        when(executionPath.toString()).thenReturn("/Query/myFastQuery");
+        ExecutionStepInfo executionStepInfo = mock(ExecutionStepInfo.class);
+        when(executionStepInfo.getPath()).thenReturn(executionPath);
+
+        DataFetchingEnvironment dfe = mock(DataFetchingEnvironment.class);
+        when(dfe.getParentType()).thenReturn(query);
+        when(dfe.getField()).thenReturn(field);
+        when(dfe.getExecutionId()).thenReturn(ExecutionId.from("1"));
+        when(dfe.getOperationDefinition()).thenReturn(operationDefinition);
+        when(dfe.getExecutionStepInfo()).thenReturn(executionStepInfo);
+        return dfe;
+    }
+
+    @Test
+    public void testFetchTracing() {
+        OpenTracingDecorator openTracingDecorator = new OpenTracingDecorator();
+
+        openTracingDecorator.before(dfe);
+        openTracingDecorator.after(dfe, GraphQLContext.newContext().build());
+
+        Assert.assertEquals("One span should be finished", 1, MockTracerOpenTracingService.MOCK_TRACER.finishedSpans().size());
+        MockSpan span = MockTracerOpenTracingService.MOCK_TRACER.finishedSpans().get(0);
+        Assert.assertEquals("GraphQL:Query.myFastQuery", span.operationName());
+        Assert.assertEquals("ExecutionId should be present in span", "1", span.tags().get("graphql.executionId"));
+        Assert.assertEquals("field name should be present in span", "myFastQuery", span.tags().get("graphql.field"));
+        Assert.assertEquals("parent name should be present in span", "Query", span.tags().get("graphql.parent"));
+        Assert.assertEquals("path should be present in span", "/Query/myFastQuery", span.tags().get("graphql.path"));
+        Assert.assertEquals("operation name should be present in span", "someOperation",
+                span.tags().get("graphql.operationName"));
+    }
+
+    @Test
+    public void shouldAddSpanToContext() {
+        final GraphQLContext context = GraphQLContext.newContext().build();
+
+        OpenTracingDecorator openTracingDecorator = new OpenTracingDecorator();
+
+        openTracingDecorator.before(dfe);
+        openTracingDecorator.after(dfe, context);
+
+        Assert.assertEquals("One span should be finished", 1, MockTracerOpenTracingService.MOCK_TRACER.finishedSpans().size());
+        MockSpan span = MockTracerOpenTracingService.MOCK_TRACER.finishedSpans().get(0);
+        Span spanFromContext = context.get(Span.class);
+
+        Assert.assertEquals("Span should be added to context", spanFromContext, span);
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/metrics/MetricsTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/metrics/MetricsTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 
 import org.junit.Test;
 
+import graphql.GraphQLContext;
 import graphql.language.Field;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLNamedType;
@@ -66,13 +67,13 @@ public class MetricsTest {
         when(dfe.getField()).thenReturn(field);
 
         decorator.before(dfe);
-        decorator.after(dfe);
+        decorator.after(dfe, GraphQLContext.newContext().build());
 
         decorator.before(dfe);
-        decorator.after(dfe);
+        decorator.after(dfe, GraphQLContext.newContext().build());
 
         decorator.before(dfe);
-        decorator.after(dfe);
+        decorator.after(dfe, GraphQLContext.newContext().build());
 
         Field field2 = mock(Field.class);
         when(field2.getName()).thenReturn("myOtherQuery");
@@ -81,10 +82,10 @@ public class MetricsTest {
         when(dfe2.getParentType()).thenReturn(query);
 
         decorator.before(dfe2);
-        decorator.after(dfe2);
+        decorator.after(dfe2, GraphQLContext.newContext().build());
 
         decorator.before(dfe2);
-        decorator.after(dfe2);
+        decorator.after(dfe2, GraphQLContext.newContext().build());
 
         MockMetricsRegistry registry = TestMetricsServiceImpl.INSTANCE.vendorRegistry;
         assertEquals(2, registry.simpleTimers.size());

--- a/server/implementation/src/test/java/io/smallrye/graphql/opentracing/MockTracerOpenTracingService.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/opentracing/MockTracerOpenTracingService.java
@@ -1,0 +1,20 @@
+package io.smallrye.graphql.opentracing;
+
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
+import io.smallrye.graphql.spi.OpenTracingService;
+
+public class MockTracerOpenTracingService implements OpenTracingService {
+
+    public static final MockTracer MOCK_TRACER = new MockTracer();
+
+    @Override
+    public String getName() {
+        return "MockTracer";
+    }
+
+    @Override
+    public Tracer getTracer() {
+        return MOCK_TRACER;
+    }
+}

--- a/server/implementation/src/test/resources/META-INF/services/io.smallrye.graphql.spi.OpenTracingService
+++ b/server/implementation/src/test/resources/META-INF/services/io.smallrye.graphql.spi.OpenTracingService
@@ -1,0 +1,1 @@
+io.smallrye.graphql.opentracing.MockTracerOpenTracingService


### PR DESCRIPTION
A first try for OpenTracing support.

Tracing can be activated via `smallrye.graphql.tracing.enabled`.
The entire execution of a query and the fetching of the respective fields is then traced. Informations about current field, current Type, path to field etc are added to the span. Spans of `@Source' methods are added as children to the span of the respective parent object.



<img width="800" alt="jaeger_tracing_example" src="https://user-images.githubusercontent.com/11507418/81190388-13f81000-8fb8-11ea-8d38-b71150951672.png">

Currently, the SpanContext of the request is not yet used. If the GraphQL service is called by another service, it will not be assigned appropriately.

Comments are welcome!