### PR TITLE
i18n for server implementation module

### DIFF
--- a/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/CdiExecutionTest.java
+++ b/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/CdiExecutionTest.java
@@ -32,8 +32,8 @@ import io.smallrye.graphql.schema.model.Schema;
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
-public class ExecutionTest {
-    private static final Logger LOG = Logger.getLogger(ExecutionTest.class.getName());
+public class CdiExecutionTest {
+    private static final Logger LOG = Logger.getLogger(CdiExecutionTest.class.getName());
 
     private ExecutionService executionService;
 

--- a/server/implementation/pom.xml
+++ b/server/implementation/pom.xml
@@ -104,6 +104,19 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- i18n -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/SmallRyeGraphQLServerLogging.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/SmallRyeGraphQLServerLogging.java
@@ -1,0 +1,77 @@
+package io.smallrye.graphql;
+
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+@MessageLogger(projectCode = "SRGQL")
+public interface SmallRyeGraphQLServerLogging {
+
+    SmallRyeGraphQLServerLogging log = Logger.getMessageLogger(SmallRyeGraphQLServerLogging.class,
+            SmallRyeGraphQLServerLogging.class.getPackage().getName());
+
+    /* 10000-10999: bootstrap related logs */
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 10000, value = "Schema is null, or it has no operations. Not bootstrapping SmallRye GraphQL")
+    void emptyOrNullSchema();
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 10001, value = "No GraphQL methods found. Try annotating your methods with @Query or @Mutation")
+    void noGraphQLMethodsFound();
+
+    /* 11000-11999: query related logs */
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 11000, value = "We got a String as input for Variables, not sure what to do with that [%s]")
+    void stringInputForVariables(String stringVars);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 11001, value = "Retrieved from cache: %s")
+    void retrievedFromCache(String query);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 11002, value = "Added to cache: %s")
+    void addedToCache(String query);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 11003, value = "Cannot use the no-arg constructor to build instances of type %s")
+    void noArgConstructorMissing(String typeName);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 11004, value = "Returning argument as is, because we did not know how to handle it [%s]")
+    void dontKnowHoToHandleArgument(String name);
+
+    /* 12000-12999: data fetching related logs */
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 12000, value = "Data Fetching Error")
+    void dataFetchingError(@Cause Throwable cause);
+
+    /* 13000-13999: service related logs (CDI, Tracing, Metrics,...) */
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 13001, value = "Using %s lookup service for metrics")
+    void usingMetricsService(String name);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 13002, value = "Using %s lookup service for tracing")
+    void usingTracingService(String name);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 13003, value = "Using %s service for object lookups")
+    void usingLookupService(String name);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 13004, value = "Using %s service for class loading")
+    void usingClassLoadingService(String name);
+
+    /* 14000-14999: data transforming related logs */
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 14000, value = "Unable to transform data")
+    void transformError(@Cause Throwable t);
+
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/SmallRyeGraphQLServerMessages.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/SmallRyeGraphQLServerMessages.java
@@ -1,0 +1,70 @@
+package io.smallrye.graphql;
+
+import java.time.DateTimeException;
+
+import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageBundle;
+
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import io.smallrye.graphql.execution.datafetcher.DataFetcherException;
+import io.smallrye.graphql.execution.resolver.ConcreteImplementationNotFoundException;
+import io.smallrye.graphql.schema.model.Operation;
+
+@MessageBundle(projectCode = "SRGQL")
+public interface SmallRyeGraphQLServerMessages {
+
+    SmallRyeGraphQLServerMessages msg = Messages.getBundle(SmallRyeGraphQLServerMessages.class);
+
+    @Message(id = 0, value = "No concrete class named [%s] found for interface [%s]")
+    ConcreteImplementationNotFoundException concreteClassNotFoundForInterface(String clazz, String iface);
+
+    @Message(id = 1, value = "Unknown primitive type [%s]")
+    ClassNotFoundException unknownPrimitiveType(String name);
+
+    @Message(id = 2, value = "Data fetching failed for operation [%s]")
+    DataFetcherException dataFetcherException(Operation operation, @Cause Throwable cause);
+
+    @Message(id = 5, value = "Could not get Instance using the default lookup service")
+    RuntimeException countNotGetInstance(@Cause Throwable t);
+
+    @Message(id = 6, value = "Metrics are not supported without CDI")
+    UnsupportedOperationException metricsNotSupportedWithoutCDI();
+
+    @Message(id = 8, value = "OpenTracing is not supported without CDI")
+    UnsupportedOperationException openTracingNotSupportedWithoutCDI();
+
+    @Message(id = 9, value = "Can not load class [%s]")
+    RuntimeException canNotLoadClass(String className, @Cause Exception cause);
+
+    @Message(id = 10, value = "[%s] is not a valid number type")
+    RuntimeException notAValidNumberType(String typeClassName);
+
+    @Message(id = 11, value = "Can not parse a number from [%s]")
+    NumberFormatException numberFormatException(String input);
+
+    @Message(id = 12, value = "Expected type [%s] but was [%s].")
+    CoercingSerializeException coercingSerializeException(String expectedType, String actualType, @Cause Exception cause);
+
+    @Message(id = 13, value = "Expected type [%s] but was [%s].")
+    CoercingParseValueException coercingParseValueException(String expectedType, String actualType, @Cause Exception cause);
+
+    @Message(id = 14, value = "Expected value to be in the %s range but it was '%s'")
+    CoercingParseLiteralException coercingParseLiteralException(String expectedRange, String actual);
+
+    @Message(id = 15, value = "Expected AST type 'IntValue' or 'StringValue' but was '%s'.")
+    CoercingParseLiteralException coercingParseLiteralException(String actualType);
+
+    @Message(id = 16, value = "Can't parse [%s] into [%s]")
+    RuntimeException cantParseDate(String inputTypeName, String targetClassName);
+
+    @Message(id = 17, value = "[%s] is no valid date or time-type")
+    RuntimeException notValidDateOrTimeType(String className);
+
+    @Message(id = 18, value = "Unknown date format [%s]")
+    DateTimeException unknownDateFormat(String input);
+
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -18,7 +18,6 @@ import javax.json.bind.JsonbBuilder;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
-import org.jboss.logging.Logger;
 
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
@@ -38,6 +37,7 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLTypeReference;
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
 import io.smallrye.graphql.execution.MetricNaming;
 import io.smallrye.graphql.execution.datafetcher.AsyncDataFetcher;
 import io.smallrye.graphql.execution.datafetcher.PropertyDataFetcher;
@@ -70,7 +70,6 @@ import io.smallrye.graphql.spi.ClassloadingService;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class Bootstrap {
-    private static final Logger LOG = Logger.getLogger(Bootstrap.class.getName());
 
     private final Schema schema;
     private final Config config;
@@ -90,7 +89,7 @@ public class Bootstrap {
             Bootstrap graphQLBootstrap = new Bootstrap(schema, config);
             return graphQLBootstrap.generateGraphQLSchema();
         } else {
-            LOG.warn("Schema is null, or it has no operations. Not bootstrapping SmallRye GraphQL");
+            SmallRyeGraphQLServerLogging.log.emptyOrNullSchema();
             return null;
         }
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/Classes.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/Classes.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
+
 /**
  * Class helper
  * 
@@ -66,7 +68,7 @@ public class Classes {
         if (isPrimitive(primitiveName)) {
             return PRIMITIVE_CLASSES.get(primitiveName);
         }
-        throw new ClassNotFoundException("Unknown primative type [" + primitiveName + "]");
+        throw SmallRyeGraphQLServerMessages.msg.unknownPrimitiveType(primitiveName);
     }
 
     public static boolean isNumberLikeType(String className) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -18,14 +18,13 @@ import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbConfig;
 
-import org.jboss.logging.Logger;
-
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.GraphQLError;
 import graphql.execution.ExecutionId;
 import graphql.schema.GraphQLSchema;
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
 import io.smallrye.graphql.bootstrap.Config;
 import io.smallrye.graphql.execution.error.ExceptionHandler;
 import io.smallrye.graphql.execution.error.ExecutionErrorsService;
@@ -36,7 +35,6 @@ import io.smallrye.graphql.execution.error.ExecutionErrorsService;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class ExecutionService {
-    private static final Logger LOG = Logger.getLogger(ExecutionService.class.getName());
 
     private static final JsonBuilderFactory jsonObjectFactory = Json.createBuilderFactory(null);
     private static final JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
@@ -100,8 +98,7 @@ public class ExecutionService {
 
             return returnObjectBuilder.build();
         } else {
-            LOG.warn("Are you sure you have annotated your methods with @Query or @Mutation ?");
-            LOG.warn("\t" + query);
+            SmallRyeGraphQLServerLogging.log.noGraphQLMethodsFound();
             return null;
         }
     }
@@ -173,7 +170,7 @@ public class ExecutionService {
                         .preparsedDocumentProvider(queryCache)
                         .build();
             } else {
-                LOG.warn("No GraphQL methods found. Try annotating your methods with @Query or @Mutation");
+                SmallRyeGraphQLServerLogging.log.noGraphQLMethodsFound();
             }
         }
         return this.graphQL;

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/GraphQLVariables.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/GraphQLVariables.java
@@ -13,7 +13,7 @@ import javax.json.JsonObject;
 import javax.json.JsonString;
 import javax.json.JsonValue;
 
-import org.jboss.logging.Logger;
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
 
 /**
  * The variables on the GraphQL Operation
@@ -21,7 +21,6 @@ import org.jboss.logging.Logger;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class GraphQLVariables {
-    private static final Logger LOG = Logger.getLogger(GraphQLVariables.class.getName());
 
     public Optional<Map<String, Object>> getVariables(JsonObject jsonInput) {
         if (!jsonInput.containsKey(VARIABLES)
@@ -34,7 +33,7 @@ public class GraphQLVariables {
 
         if (valueType.equals(JsonValue.ValueType.STRING)) {
             String stringVars = jsonInput.getString(VARIABLES);
-            LOG.warn("We got a String as input for Variables, not sure what to do with that [" + stringVars + "]");
+            SmallRyeGraphQLServerLogging.log.stringInputForVariables(stringVars);
             return Optional.empty();
         } else {
             JsonValue jvariables = jsonInput.get(VARIABLES);

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
@@ -14,6 +14,7 @@ import graphql.execution.ExecutionPath;
 import graphql.language.SourceLocation;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 import io.smallrye.graphql.execution.datafetcher.decorator.DataFetcherDecorator;
 import io.smallrye.graphql.execution.datafetcher.helper.ArgumentHelper;
 import io.smallrye.graphql.execution.datafetcher.helper.FieldHelper;
@@ -133,7 +134,7 @@ public abstract class AbstractDataFetcher<T> implements DataFetcher<T> {
         try {
             return operationClass.getMethod(operation.getMethodName(), getParameterClasses());
         } catch (NoSuchMethodException e) {
-            throw new DataFetcherException(operation, e);
+            throw SmallRyeGraphQLServerMessages.msg.dataFetcherException(operation, e);
         }
     }
 
@@ -151,7 +152,7 @@ public abstract class AbstractDataFetcher<T> implements DataFetcher<T> {
             } else if (throwable instanceof Exception) {
                 throw (Exception) throwable;
             } else {
-                throw new DataFetcherException(operation, ex);
+                throw SmallRyeGraphQLServerMessages.msg.dataFetcherException(operation, throwable);
             }
         }
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AsyncDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AsyncDataFetcher.java
@@ -12,6 +12,7 @@ import org.eclipse.microprofile.graphql.GraphQLException;
 import graphql.GraphQLContext;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 import io.smallrye.graphql.execution.datafetcher.decorator.DataFetcherDecorator;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.transformation.TransformException;
@@ -79,7 +80,7 @@ public class AsyncDataFetcher extends AbstractDataFetcher<CompletionStage<DataFe
                         GraphQLException graphQLException = (GraphQLException) throwable;
                         appendPartialResult(resultBuilder, dfe, graphQLException);
                     } else if (throwable instanceof Exception) {
-                        throw new DataFetcherException(operation, (Exception) throwable);
+                        throw SmallRyeGraphQLServerMessages.msg.dataFetcherException(operation, throwable);
                     } else if (throwable instanceof Error) {
                         throw ((Error) throwable);
                     }
@@ -101,7 +102,7 @@ public class AsyncDataFetcher extends AbstractDataFetcher<CompletionStage<DataFe
             appendPartialResult(resultBuilder, dfe, graphQLException);
         } catch (SecurityException | IllegalAccessException | IllegalArgumentException ex) {
             //m.invoke failed
-            throw new DataFetcherException(operation, ex);
+            throw SmallRyeGraphQLServerMessages.msg.dataFetcherException(operation, ex);
         }
 
         return CompletableFuture.completedFuture(resultBuilder.build());

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/CollectionCreator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/CollectionCreator.java
@@ -6,8 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.jboss.logging.Logger;
-
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
 import io.smallrye.graphql.spi.ClassloadingService;
 
 /**
@@ -20,7 +19,6 @@ import io.smallrye.graphql.spi.ClassloadingService;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class CollectionCreator {
-    private static final Logger LOG = Logger.getLogger(CollectionCreator.class.getName());
 
     private static ClassloadingService classloadingService = ClassloadingService.load();
 
@@ -40,7 +38,7 @@ public class CollectionCreator {
         try {
             return (Collection<?>) type.getDeclaredConstructor().newInstance();
         } catch (Exception ex) {
-            LOG.debug("Cannot create no-arg instance of [" + (type == null ? "null" : type.getName()) + "]", ex);
+            SmallRyeGraphQLServerLogging.log.noArgConstructorMissing(type == null ? "null" : type.getName());
         }
         if (Set.class.isAssignableFrom(type)) {
             return new HashSet<>();

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/DataFetcherException.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/DataFetcherException.java
@@ -14,6 +14,13 @@ import io.smallrye.graphql.schema.model.Operation;
 public class DataFetcherException extends RuntimeException {
     private static final Jsonb JSONB = JsonbBuilder.create(new JsonbConfig().withFormatting(true));
 
+    public DataFetcherException() {
+    }
+
+    public DataFetcherException(Operation operation) {
+        super("Problem while fetching data for operation \n" + JSONB.toJson(operation));
+    }
+
     public DataFetcherException(Operation operation, Exception ex) {
         super("Problem while fetching data for operation \n" + JSONB.toJson(operation), ex);
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/PropertyDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/PropertyDataFetcher.java
@@ -1,8 +1,7 @@
 package io.smallrye.graphql.execution.datafetcher;
 
-import org.jboss.logging.Logger;
-
 import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
 import io.smallrye.graphql.execution.datafetcher.helper.FieldHelper;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.transformation.TransformException;
@@ -13,7 +12,6 @@ import io.smallrye.graphql.transformation.TransformException;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class PropertyDataFetcher extends graphql.schema.PropertyDataFetcher {
-    private static final Logger LOG = Logger.getLogger(ReflectionDataFetcher.class.getName());
 
     private final FieldHelper fieldHelper;
 
@@ -29,7 +27,7 @@ public class PropertyDataFetcher extends graphql.schema.PropertyDataFetcher {
             // See if we need to transform
             return fieldHelper.transformResponse(resultFromMethodCall);
         } catch (TransformException ex) {
-            LOG.warn(ex.getMessage());
+            SmallRyeGraphQLServerLogging.log.transformError(ex);
             return resultFromMethodCall;
         }
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/ReflectionDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/ReflectionDataFetcher.java
@@ -8,6 +8,7 @@ import org.eclipse.microprofile.graphql.GraphQLException;
 import graphql.GraphQLContext;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 import io.smallrye.graphql.execution.datafetcher.decorator.DataFetcherDecorator;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.transformation.TransformException;
@@ -80,7 +81,7 @@ public class ReflectionDataFetcher extends AbstractDataFetcher<DataFetcherResult
             appendPartialResult(resultBuilder, dfe, graphQLException);
         } catch (SecurityException | IllegalAccessException | IllegalArgumentException ex) {
             //m.invoke failed
-            throw new DataFetcherException(operation, ex);
+            throw SmallRyeGraphQLServerMessages.msg.dataFetcherException(operation, ex);
         }
 
         return resultBuilder.build();

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
@@ -6,9 +6,8 @@ import java.util.Map;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbException;
 
-import org.jboss.logging.Logger;
-
 import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
 import io.smallrye.graphql.execution.Classes;
 import io.smallrye.graphql.json.InputTransformFields;
 import io.smallrye.graphql.json.JsonBCreator;
@@ -26,7 +25,6 @@ import io.smallrye.graphql.transformation.Transformer;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class ArgumentHelper extends AbstractHelper {
-    private static final Logger LOG = Logger.getLogger(ArgumentHelper.class.getName());
 
     private final List<Argument> arguments;
 
@@ -154,8 +152,7 @@ public class ArgumentHelper extends AbstractHelper {
             // This happens with @DefaultValue and Transformable (Passthrough) Scalars
             return correctComplexObjectFromJsonString(argumentValue.toString(), field);
         } else {
-            LOG.warn("Returning argument as is, because we did not know how to handle it.\n\t"
-                    + "[" + field.getMethodName() + "]");
+            SmallRyeGraphQLServerLogging.log.dontKnowHoToHandleArgument(field.getMethodName());
             return argumentValue;
         }
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExceptionHandler.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExceptionHandler.java
@@ -1,13 +1,12 @@
 package io.smallrye.graphql.execution.error;
 
-import org.jboss.logging.Logger;
-
 import graphql.ExceptionWhileDataFetching;
 import graphql.execution.DataFetcherExceptionHandler;
 import graphql.execution.DataFetcherExceptionHandlerParameters;
 import graphql.execution.DataFetcherExceptionHandlerResult;
 import graphql.execution.ExecutionPath;
 import graphql.language.SourceLocation;
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
 import io.smallrye.graphql.bootstrap.Config;
 
 /**
@@ -16,7 +15,6 @@ import io.smallrye.graphql.bootstrap.Config;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class ExceptionHandler implements DataFetcherExceptionHandler {
-    private static final Logger LOG = Logger.getLogger(ExceptionHandler.class.getName());
 
     private final Config config;
     private final ExceptionLists exceptionLists;
@@ -34,7 +32,7 @@ public class ExceptionHandler implements DataFetcherExceptionHandler {
         ExceptionWhileDataFetching error = getExceptionWhileDataFetching(throwable, sourceLocation, path);
 
         if (config.isPrintDataFetcherException()) {
-            LOG.log(Logger.Level.ERROR, "Data Fetching Error", throwable);
+            SmallRyeGraphQLServerLogging.log.dataFetchingError(throwable);
         }
 
         return DataFetcherExceptionHandlerResult.newResult().error(error).build();

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/resolver/InterfaceResolver.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/resolver/InterfaceResolver.java
@@ -3,6 +3,7 @@ package io.smallrye.graphql.execution.resolver;
 import graphql.TypeResolutionEnvironment;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.TypeResolver;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 import io.smallrye.graphql.schema.model.InterfaceType;
 
 /**
@@ -21,17 +22,15 @@ public class InterfaceResolver implements TypeResolver {
     @Override
     public GraphQLObjectType getType(TypeResolutionEnvironment tre) {
 
-        String concreateClassName = tre.getObject().getClass().getName();
+        String concreteClassName = tre.getObject().getClass().getName();
 
         GraphQLObjectType graphQLObjectType = InterfaceOutputRegistry.getGraphQLObjectType(interfaceType.getClassName(),
-                concreateClassName);
+                concreteClassName);
         if (graphQLObjectType != null) {
             return graphQLObjectType;
         } else {
-            throw new ConcreteImplementationNotFoundException(
-                    "No concrete class named [" + concreateClassName + "] found for interface ["
-                            + interfaceType.getClassName() + "]");
-
+            throw SmallRyeGraphQLServerMessages.msg.concreteClassNotFoundForInterface(concreteClassName,
+                    interfaceType.getClassName());
         }
     }
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/number/NumberCoercing.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/number/NumberCoercing.java
@@ -7,9 +7,7 @@ import graphql.language.FloatValue;
 import graphql.language.IntValue;
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
-import graphql.schema.CoercingParseLiteralException;
-import graphql.schema.CoercingParseValueException;
-import graphql.schema.CoercingSerializeException;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 
 /**
  * The Coercing used by numbers
@@ -42,7 +40,7 @@ public class NumberCoercing implements Coercing {
         } else if (input instanceof String) {
             return input;
         } else {
-            throw new NumberFormatException("" + input);
+            throw SmallRyeGraphQLServerMessages.msg.numberFormatException(input.toString());
         }
 
     }
@@ -54,8 +52,7 @@ public class NumberCoercing implements Coercing {
         try {
             return convertImpl(input);
         } catch (NumberFormatException e) {
-            throw new CoercingSerializeException(
-                    "Expected type '" + name + "' but was '" + input.getClass().getSimpleName() + "'.", e);
+            throw SmallRyeGraphQLServerMessages.msg.coercingSerializeException(name, input.getClass().getSimpleName(), e);
         }
     }
 
@@ -64,8 +61,7 @@ public class NumberCoercing implements Coercing {
         try {
             return convertImpl(input);
         } catch (NumberFormatException e) {
-            throw new CoercingParseValueException(
-                    "Expected type '" + name + "' but was '" + input.getClass().getSimpleName() + "'.");
+            throw SmallRyeGraphQLServerMessages.msg.coercingParseValueException(name, input.getClass().getSimpleName(), e);
         }
     }
 
@@ -85,8 +81,7 @@ public class NumberCoercing implements Coercing {
         } else if (input instanceof IntValue) {
             BigInteger value = ((IntValue) input).getValue();
             if (!converter.isInRange(value)) {
-                throw new CoercingParseLiteralException(
-                        "Expected value to be in the " + name + " range but it was '" + value.toString() + "'");
+                throw SmallRyeGraphQLServerMessages.msg.coercingParseLiteralException(name, value.toString());
             }
             return converter.fromBigInteger(value);
 
@@ -94,7 +89,6 @@ public class NumberCoercing implements Coercing {
             BigDecimal value = ((FloatValue) input).getValue();
             return converter.fromBigDecimal(value);
         }
-        throw new CoercingParseLiteralException(
-                "Expected AST type 'IntValue' or 'StringValue' but was '" + input.getClass().getSimpleName() + "'.");
+        throw SmallRyeGraphQLServerMessages.msg.coercingParseLiteralException(input.getClass().getSimpleName());
     }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/time/DateCoercing.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/time/DateCoercing.java
@@ -4,9 +4,7 @@ import java.time.DateTimeException;
 
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
-import graphql.schema.CoercingParseLiteralException;
-import graphql.schema.CoercingParseValueException;
-import graphql.schema.CoercingSerializeException;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 
 /**
  * The Coercing used by dates
@@ -33,7 +31,7 @@ public class DateCoercing implements Coercing {
         if (input instanceof String) {
             return input;
         } else {
-            throw new DateTimeException("" + input);
+            throw SmallRyeGraphQLServerMessages.msg.unknownDateFormat(input.toString());
         }
     }
 
@@ -45,8 +43,7 @@ public class DateCoercing implements Coercing {
         try {
             return convertImpl(input);
         } catch (DateTimeException e) {
-            throw new CoercingSerializeException(
-                    "Expected type '" + name + "' but was '" + input.getClass().getSimpleName() + "'.", e);
+            throw SmallRyeGraphQLServerMessages.msg.coercingSerializeException(name, input.getClass().getSimpleName(), e);
         }
     }
 
@@ -55,8 +52,7 @@ public class DateCoercing implements Coercing {
         try {
             return convertImpl(input);
         } catch (DateTimeException e) {
-            throw new CoercingParseValueException(
-                    "Expected type '" + name + "' but was '" + input.getClass().getSimpleName() + "'.");
+            throw SmallRyeGraphQLServerMessages.msg.coercingParseValueException(name, input.getClass().getSimpleName(), e);
         }
     }
 
@@ -69,8 +65,7 @@ public class DateCoercing implements Coercing {
             // We need to get a String value of this date
             return ((StringValue) input).getValue();
         } else {
-            throw new CoercingParseLiteralException(
-                    "Expected AST type 'StringValue' but was '" + input.getClass().getSimpleName() + "'.");
+            throw SmallRyeGraphQLServerMessages.msg.coercingParseLiteralException(input.getClass().getSimpleName());
         }
 
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/ClassloadingService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/ClassloadingService.java
@@ -5,8 +5,8 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ServiceLoader;
 
-import org.jboss.logging.Logger;
-
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 import io.smallrye.graphql.execution.Classes;
 
 /**
@@ -17,9 +17,8 @@ import io.smallrye.graphql.execution.Classes;
  * @author Andy McCright (andymc@us.ibm.com)
  */
 public interface ClassloadingService {
-    static final Logger LOG = Logger.getLogger(ClassloadingService.class.getName());
 
-    public static ClassloadingService load() {
+    static ClassloadingService load() {
         ClassloadingService classloadingService;
         try {
             ServiceLoader<ClassloadingService> sl = ServiceLoader.load(ClassloadingService.class);
@@ -27,7 +26,7 @@ public interface ClassloadingService {
         } catch (Exception ex) {
             classloadingService = new DefaultClassloadingService();
         }
-        LOG.debug("Using " + classloadingService.getName() + " classloading service");
+        SmallRyeGraphQLServerLogging.log.usingClassLoadingService(classloadingService.getName());
         return classloadingService;
     }
 
@@ -51,7 +50,7 @@ public interface ClassloadingService {
                 });
             }
         } catch (PrivilegedActionException | ClassNotFoundException pae) {
-            throw new RuntimeException("Can not load class [" + className + "]", pae);
+            throw SmallRyeGraphQLServerMessages.msg.canNotLoadClass(className, pae);
         }
     }
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/LookupService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/LookupService.java
@@ -3,7 +3,8 @@ package io.smallrye.graphql.spi;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ServiceLoader;
 
-import org.jboss.logging.Logger;
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 
 /**
  * Lookup service that allows multiple DI frameworks to use this.
@@ -13,9 +14,8 @@ import org.jboss.logging.Logger;
  * @author Andy McCright (andymc@us.ibm.com)
  */
 public interface LookupService {
-    static final Logger LOG = Logger.getLogger(LookupService.class.getName());
 
-    public static LookupService load() {
+    static LookupService load() {
         LookupService lookupService;
         try {
             ServiceLoader<LookupService> sl = ServiceLoader.load(LookupService.class);
@@ -23,7 +23,7 @@ public interface LookupService {
         } catch (Exception ex) {
             lookupService = new DefaultLookupService();
         }
-        LOG.debug("Using " + lookupService.getName() + " lookup service");
+        SmallRyeGraphQLServerLogging.log.usingLookupService(lookupService.getName());
         return lookupService;
     }
 
@@ -55,7 +55,7 @@ public interface LookupService {
                 return declaringClass.getConstructor().newInstance();
             } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException
                     | IllegalArgumentException | InvocationTargetException ex) {
-                throw new RuntimeException("Could not get Instance using the default lookup service", ex);
+                throw SmallRyeGraphQLServerMessages.msg.countNotGetInstance(ex);
             }
         }
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/MetricsService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/MetricsService.java
@@ -3,15 +3,16 @@ package io.smallrye.graphql.spi;
 import java.util.ServiceLoader;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.jboss.logging.Logger;
+
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 
 /**
  * Service that allows containers to plug in their own MP Metrics implementation.
  */
 public interface MetricsService {
-    static final Logger LOG = Logger.getLogger(MetricsService.class.getName());
 
-    public static MetricsService load() {
+    static MetricsService load() {
         MetricsService metricsService;
         try {
             ServiceLoader<MetricsService> sl = ServiceLoader.load(MetricsService.class);
@@ -19,7 +20,7 @@ public interface MetricsService {
         } catch (Exception ex) {
             metricsService = new DefaultMetricsService();
         }
-        LOG.debug("Using " + metricsService.getName() + " lookup service");
+        SmallRyeGraphQLServerLogging.log.usingMetricsService(metricsService.getName());
         return metricsService;
     }
 
@@ -39,7 +40,7 @@ public interface MetricsService {
 
         @Override
         public MetricRegistry getMetricRegistry(MetricRegistry.Type type) {
-            throw new UnsupportedOperationException("Metrics are not supported without CDI");
+            throw SmallRyeGraphQLServerMessages.msg.metricsNotSupportedWithoutCDI();
         }
     }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/OpenTracingService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/OpenTracingService.java
@@ -2,14 +2,13 @@ package io.smallrye.graphql.spi;
 
 import java.util.ServiceLoader;
 
-import org.jboss.logging.Logger;
-
 import io.opentracing.Tracer;
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 
 public interface OpenTracingService {
-    static final Logger LOG = Logger.getLogger(OpenTracingService.class.getName());
 
-    public static OpenTracingService load() {
+    static OpenTracingService load() {
         OpenTracingService openTracingService;
         try {
             ServiceLoader<OpenTracingService> sl = ServiceLoader.load(OpenTracingService.class);
@@ -17,7 +16,7 @@ public interface OpenTracingService {
         } catch (Exception ex) {
             openTracingService = new OpenTracingService.DefaultOpenTracingService();
         }
-        LOG.debug("Using " + openTracingService.getName() + " lookup service");
+        SmallRyeGraphQLServerLogging.log.usingTracingService(openTracingService.getName());
         return openTracingService;
     }
 
@@ -37,7 +36,7 @@ public interface OpenTracingService {
 
         @Override
         public Tracer getTracer() {
-            throw new UnsupportedOperationException("OpenTracing is not supported without CDI");
+            throw SmallRyeGraphQLServerMessages.msg.openTracingNotSupportedWithoutCDI();
         }
 
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/transformation/DateTransformer.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/transformation/DateTransformer.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.TransformInfo;
 
@@ -45,7 +46,7 @@ public class DateTransformer implements Transformer {
         TemporalQuery<?> temporalAccessor = TEMPORAL_QUERYS.get(targetClassName);
 
         if (temporalAccessor == null || dateTimeFormatter == null) {
-            throw new RuntimeException(String.format("[%s] as no valid date or time-type", targetClassName));
+            throw SmallRyeGraphQLServerMessages.msg.notValidDateOrTimeType(targetClassName);
         }
 
         return (Temporal) dateTimeFormatter.parse(o.toString(), temporalAccessor);

--- a/server/implementation/src/main/java/io/smallrye/graphql/transformation/FormattedNumberTransformer.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/transformation/FormattedNumberTransformer.java
@@ -6,6 +6,7 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
 
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.TransformInfo;
 
@@ -49,7 +50,6 @@ public class FormattedNumberTransformer implements Transformer {
             Number number = (Number) object;
             return this.numberFormat.format(number);
         }
-        throw new RuntimeException(String.format("[%s] is no valid number-type", object.getClass()));
-
+        throw SmallRyeGraphQLServerMessages.msg.notAValidNumberType(object.getClass().getName());
     }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/transformation/LegacyDateTransformer.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/transformation/LegacyDateTransformer.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 import io.smallrye.graphql.schema.model.Field;
 
 /**
@@ -48,8 +49,7 @@ public class LegacyDateTransformer implements Transformer {
             LocalDateTime localdatetime = (LocalDateTime) dateTransformer.in(o);
             return Date.from(localdatetime.atZone(ZoneId.systemDefault()).toInstant());
         }
-        throw new RuntimeException("Can't parse [" + o.getClass().getName() + "] to [" + targetClassName + "]");
-
+        throw SmallRyeGraphQLServerMessages.msg.cantParseDate(o.getClass().getName(), targetClassName);
     }
 
     @Override
@@ -67,7 +67,7 @@ public class LegacyDateTransformer implements Transformer {
             Date casted = (Date) dateType;
             return dateTransformer.out(casted.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
         }
-        throw new RuntimeException("Can't format [" + dateType.getClass().getName() + "] from [" + targetClassName + "]");
+        throw SmallRyeGraphQLServerMessages.msg.cantParseDate(dateType.getClass().getName(), targetClassName);
     }
 
     private static Map<String, String> createClassMappings() {

--- a/server/implementation/src/main/java/io/smallrye/graphql/transformation/NumberTransformer.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/transformation/NumberTransformer.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.ParseException;
 
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 import io.smallrye.graphql.schema.model.Field;
 
 /**
@@ -60,7 +61,7 @@ public class NumberTransformer implements Transformer {
             return (new BigDecimal(input));
         }
 
-        throw new RuntimeException(String.format("[%s] is no valid number-type", typeClassName));
+        throw SmallRyeGraphQLServerMessages.msg.notAValidNumberType(typeClassName);
     }
 
     public Object out(final Object object) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/transformation/Transformer.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/transformation/Transformer.java
@@ -1,7 +1,6 @@
 package io.smallrye.graphql.transformation;
 
-import org.jboss.logging.Logger;
-
+import io.smallrye.graphql.SmallRyeGraphQLServerLogging;
 import io.smallrye.graphql.execution.Classes;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.TransformInfo;
@@ -11,8 +10,6 @@ import io.smallrye.graphql.schema.model.TransformInfo;
  * TODO: Caching?
  */
 public interface Transformer {
-
-    Logger LOG = Logger.getLogger(Transformer.class);
 
     PassThroughTransformer PASS_THROUGH_TRANSFORMER = new PassThroughTransformer();
     UuidTransformer UUID_TRANSFORMER = new UuidTransformer();
@@ -26,7 +23,7 @@ public interface Transformer {
             Transformer transformer = Transformer.transformer(field);
             return transformer.out(object);
         } catch (Exception e) {
-            LOG.error(null, e);
+            SmallRyeGraphQLServerLogging.log.transformError(e);
             throw new TransformException(e, field, object);
         }
     }
@@ -36,7 +33,7 @@ public interface Transformer {
             Transformer transformer = Transformer.transformer(field);
             return transformer.in(object);
         } catch (Exception e) {
-            LOG.error(null, e);
+            SmallRyeGraphQLServerLogging.log.transformError(e);
             throw new TransformException(e, field, object);
         }
     }


### PR DESCRIPTION
Only `server/implementation` for now
I hope this does not mess anything up, especially handling of exceptions which are meant to be handled programmatically and transformed into client-side messages - in these cases I tried to not internationalize them, because it does not make much sense and only makes things complicated and error-prone.