### PR TITLE
Preparing gradle plugin release

### DIFF
--- a/tools/gradle-plugin/build.gradle
+++ b/tools/gradle-plugin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.plugin-publish' version '0.11.0'
+    id 'com.gradle.plugin-publish' version '0.12.0'
     id 'java-gradle-plugin'
 }
 if (JavaVersion.current().isJava9Compatible()) {
@@ -49,7 +49,7 @@ pluginBundle {
 
 gradlePlugin {
     plugins {
-        quarkusPlugin {
+        smallryeGraphQLPlugin {
             id = 'io.smallrye.graphql'
             implementationClass = 'io.smallrye.graphql.gradle.SmallRyeGraphQLPlugin'
             displayName = 'SmallRye: MicroProfile GraphQL Gradle Plugin'

--- a/tools/gradle-plugin/gradle.properties
+++ b/tools/gradle-plugin/gradle.properties
@@ -1,0 +1,1 @@
+version = 1.0.2-SNAPSHOT

--- a/tools/gradle-plugin/gradle.properties
+++ b/tools/gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.0.2-SNAPSHOT
+version = 1.0.4-SNAPSHOT

--- a/tools/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/tools/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is only a part of getting the Gradle plugin being published to the Gradle Plugin Portal.

This PR:

- Updates the Gradle version
- Updates the Gradle plugin-publish plugin version
- Added version to gradle.properties --> __this might be error prone as the version is also specified in the main pom.xml__ (Quarkus build setup has same issue I think)

What still needs to be done:

- Add the `gradle publishPlugins -Pgradle.publish.key=<key> -Pgradle.publish.secret=<secret>` step to Github release action
- Create an account on the Gradle Plugin Portal: See https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/#create_an_account_on_the_gradle_plugin_portal
- Secure the key and secret

I've never looked into Github actions so I'm not sure I'm the best person to do this.
I think also creating the Gradle Plugin Portal account and key/secret might be better done by someone from SmallRye team itself. 