### PR TITLE
Throw an exception if no Context is active

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/context/ContextNotActiveException.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/context/ContextNotActiveException.java
@@ -1,0 +1,4 @@
+package io.smallrye.graphql.execution.context;
+
+public class ContextNotActiveException extends RuntimeException {
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContext.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContext.java
@@ -45,7 +45,12 @@ public class SmallRyeContext implements Context {
     }
 
     public static Context getContext() {
-        return current.get();
+        SmallRyeContext context = current.get();
+        if (context != null) {
+            return context;
+        } else {
+            throw new ContextNotActiveException();
+        }
     }
 
     public static void remove() {


### PR DESCRIPTION
I think it could make sense to throw an exception rather than return null, if there is no active GraphQL request, and therefore no context available.
Because if someone uses the Context reference outside of a GraphQL request, it is 99,9% a programmer error.
WDYT?