### PR TITLE
Make builder factory static

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContext.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContext.java
@@ -191,5 +191,5 @@ public class SmallRyeContext implements Context {
         return field.getQualifiedName().contains("/");
     }
 
-    private final JsonBuilderFactory jsonbuilder = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory jsonbuilder = Json.createBuilderFactory(null);
 }


### PR DESCRIPTION
This avoids the performance penalty of creating a new builder factory on
each init.

Fixes #350 