### PR TITLE
Do not wrap security exceptions in DataFetcherException.

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/ReflectionDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/ReflectionDataFetcher.java
@@ -91,7 +91,7 @@ public class ReflectionDataFetcher<T> implements DataFetcher<T> {
         } catch (SecurityException | IllegalAccessException | IllegalArgumentException ex) {
             //m.invoke failed
             EventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), ex);
-            throw msg.dataFetcherException(operation, ex);
+            throw ex;
         } finally {
             EventEmitter.fireAfterDataFetch();
         }
@@ -143,7 +143,7 @@ public class ReflectionDataFetcher<T> implements DataFetcher<T> {
         } catch (SecurityException | IllegalAccessException | IllegalArgumentException ex) {
             //m.invoke failed
             EventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), ex);
-            throw msg.dataFetcherException(operation, ex);
+            throw ex;
         } finally {
             EventEmitter.fireAfterDataFetch();
         }

--- a/server/tck/src/test/resources/META-INF/microprofile-config.properties
+++ b/server/tck/src/test/resources/META-INF/microprofile-config.properties
@@ -2,3 +2,4 @@ smallrye.graphql.printDataFetcherException=true
 smallrye.graphql.tracing.enabled=true
 smallrye.graphql.allowGet=true
 smallrye.graphql.logPayload=true
+mp.graphql.showErrorMessage=java.security.AccessControlException

--- a/server/tck/src/test/resources/tests/errors/securityException/output.json
+++ b/server/tck/src/test/resources/tests/errors/securityException/output.json
@@ -14,7 +14,7 @@
             "extensions": {
                 "exception": "java.security.AccessControlException",
                 "classification": "DataFetchingException",
-                "code": "data-fetcher"
+                "code": "access-control"
             }
         }
     ],


### PR DESCRIPTION
Fix #334
@velias - You will have to add `mp.graphql.showErrorMessage=java.security.AccessControlException` to your config, as AccessControlException is a RuntimeException, but that should give you the output you had before.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>