### PR TITLE
#281 - support for generics

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
@@ -177,7 +177,7 @@ public class SchemaBuilder {
         while (!referenceCreator.values(referenceType).isEmpty()) {
             Reference reference = referenceCreator.values(referenceType).poll();
             ClassInfo classInfo = ScanningContext.getIndex().getClassByName(DotName.createSimple(reference.getClassName()));
-            consumer.accept((T) creator.create(classInfo));
+            consumer.accept((T) creator.create(classInfo, reference));
         }
     }
 
@@ -190,7 +190,7 @@ public class SchemaBuilder {
             Reference reference = referenceCreator.values(referenceType).poll();
             ClassInfo classInfo = ScanningContext.getIndex().getClassByName(DotName.createSimple(reference.getClassName()));
             if (!contains.test(reference.getName())) {
-                consumer.accept((T) creator.create(classInfo));
+                consumer.accept((T) creator.create(classInfo, reference));
                 allDone = false;
             }
         }

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
@@ -40,7 +40,7 @@ public class FieldCreator {
      * @param methodInfo the java method
      * @return a Field model object
      */
-    public Optional<Field> createFieldForInterface(MethodInfo methodInfo) {
+    public Optional<Field> createFieldForInterface(MethodInfo methodInfo, Reference parentObjectReference) {
         Annotations annotationsForMethod = Annotations.getAnnotationsForInterfaceField(methodInfo);
 
         if (!IgnoreHelper.shouldIgnore(annotationsForMethod)) {
@@ -54,7 +54,8 @@ public class FieldCreator {
 
             // Field Type
             validateFieldType(Direction.OUT, methodInfo);
-            Reference reference = referenceCreator.createReferenceForInterfaceField(returnType, annotationsForMethod);
+            Reference reference = referenceCreator.createReferenceForInterfaceField(returnType, annotationsForMethod,
+                    parentObjectReference);
 
             Field field = new Field(methodInfo.name(),
                     MethodHelper.getPropertyName(Direction.OUT, methodInfo.name()),
@@ -93,7 +94,8 @@ public class FieldCreator {
      * @param methodInfo the java method
      * @return a Field model object
      */
-    public Optional<Field> createFieldForPojo(Direction direction, FieldInfo fieldInfo, MethodInfo methodInfo) {
+    public Optional<Field> createFieldForPojo(Direction direction, FieldInfo fieldInfo, MethodInfo methodInfo,
+            Reference parentObjectReference) {
         Annotations annotationsForPojo = Annotations.getAnnotationsForPojo(direction, fieldInfo, methodInfo);
 
         if (!IgnoreHelper.shouldIgnore(annotationsForPojo, fieldInfo)) {
@@ -110,7 +112,7 @@ public class FieldCreator {
             Type fieldType = getFieldType(fieldInfo, methodType);
 
             Reference reference = referenceCreator.createReferenceForPojoField(direction, fieldType, methodType,
-                    annotationsForPojo);
+                    annotationsForPojo, parentObjectReference);
 
             Field field = new Field(methodInfo.name(),
                     MethodHelper.getPropertyName(direction, methodInfo.name()),
@@ -148,7 +150,7 @@ public class FieldCreator {
      * @param fieldInfo the java property
      * @return a Field model object
      */
-    public Optional<Field> createFieldForPojo(Direction direction, FieldInfo fieldInfo) {
+    public Optional<Field> createFieldForPojo(Direction direction, FieldInfo fieldInfo, Reference parentObjectReference) {
         if (Modifier.isPublic(fieldInfo.flags())) {
             Annotations annotationsForPojo = Annotations.getAnnotationsForPojo(direction, fieldInfo);
 
@@ -164,7 +166,7 @@ public class FieldCreator {
                 Optional<String> maybeDescription = DescriptionHelper.getDescriptionForField(annotationsForPojo, fieldType);
 
                 Reference reference = referenceCreator.createReferenceForPojoField(direction, fieldType, fieldType,
-                        annotationsForPojo);
+                        annotationsForPojo, parentObjectReference);
 
                 Field field = new Field(fieldInfo.name(),
                         MethodHelper.getPropertyName(direction, fieldInfo.name()),

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/Creator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/Creator.java
@@ -2,6 +2,8 @@ package io.smallrye.graphql.schema.creator.type;
 
 import org.jboss.jandex.ClassInfo;
 
+import io.smallrye.graphql.schema.model.Reference;
+
 /**
  * Something that can create object types on the schema
  * 
@@ -10,5 +12,5 @@ import org.jboss.jandex.ClassInfo;
  */
 public interface Creator<T> {
 
-    public T create(ClassInfo classInfo);
+    public T create(ClassInfo classInfo, Reference reference);
 }

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
@@ -14,6 +14,7 @@ import io.smallrye.graphql.schema.helper.Direction;
 import io.smallrye.graphql.schema.helper.IgnoreHelper;
 import io.smallrye.graphql.schema.helper.TypeNameHelper;
 import io.smallrye.graphql.schema.model.EnumType;
+import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 
 /**
@@ -25,7 +26,7 @@ public class EnumCreator implements Creator<EnumType> {
     private static final Logger LOG = Logger.getLogger(EnumCreator.class.getName());
 
     @Override
-    public EnumType create(ClassInfo classInfo) {
+    public EnumType create(ClassInfo classInfo, Reference reference) {
         LOG.debug("Creating enum from " + classInfo.name().toString());
 
         Annotations annotations = Annotations.getAnnotationsForClass(classInfo);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InterfaceCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InterfaceCreator.java
@@ -40,13 +40,14 @@ public class InterfaceCreator implements Creator<InterfaceType> {
     }
 
     @Override
-    public InterfaceType create(ClassInfo classInfo) {
+    public InterfaceType create(ClassInfo classInfo, Reference reference) {
         LOG.debug("Creating Interface from " + classInfo.name().toString());
 
         Annotations annotations = Annotations.getAnnotationsForClass(classInfo);
 
         // Name
-        String name = TypeNameHelper.getAnyTypeName(ReferenceType.INTERFACE, classInfo, annotations);
+        String name = TypeNameHelper.getAnyTypeName(ReferenceType.INTERFACE, classInfo, annotations,
+                TypeNameHelper.createParametrizedTypeNameExtension(reference));
 
         // Description
         String description = DescriptionHelper.getDescriptionForType(annotations).orElse(null);
@@ -54,7 +55,7 @@ public class InterfaceCreator implements Creator<InterfaceType> {
         InterfaceType interfaceType = new InterfaceType(classInfo.name().toString(), name, description);
 
         // Fields
-        addFields(interfaceType, classInfo);
+        addFields(interfaceType, classInfo, reference);
 
         // Interfaces
         addInterfaces(interfaceType, classInfo);
@@ -62,7 +63,7 @@ public class InterfaceCreator implements Creator<InterfaceType> {
         return interfaceType;
     }
 
-    private void addFields(InterfaceType interfaceType, ClassInfo classInfo) {
+    private void addFields(InterfaceType interfaceType, ClassInfo classInfo, Reference reference) {
         // Fields
         List<MethodInfo> allMethods = new ArrayList<>();
 
@@ -75,7 +76,7 @@ public class InterfaceCreator implements Creator<InterfaceType> {
 
         for (MethodInfo methodInfo : allMethods) {
             if (MethodHelper.isPropertyMethod(Direction.OUT, methodInfo.name())) {
-                fieldCreator.createFieldForInterface(methodInfo)
+                fieldCreator.createFieldForInterface(methodInfo, reference)
                         .ifPresent(interfaceType::addField);
             }
         }

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/FormatHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/FormatHelper.java
@@ -87,9 +87,11 @@ public class FormatHelper {
     }
 
     private static Optional<TransformInfo> getNumberFormat(Annotations annotations) {
-        Optional<AnnotationInstance> numberFormatAnnotation = getNumberFormatAnnotation(annotations);
-        if (numberFormatAnnotation.isPresent()) {
-            return getNumberFormat(numberFormatAnnotation.get());
+        if (annotations != null) {
+            Optional<AnnotationInstance> numberFormatAnnotation = getNumberFormatAnnotation(annotations);
+            if (numberFormatAnnotation.isPresent()) {
+                return getNumberFormat(numberFormatAnnotation.get());
+            }
         }
         return Optional.empty();
     }
@@ -108,11 +110,12 @@ public class FormatHelper {
     }
 
     private static Optional<TransformInfo> getDateFormat(Annotations annotations) {
-        Optional<AnnotationInstance> dateFormatAnnotation = getDateFormatAnnotation(annotations);
-        if (dateFormatAnnotation.isPresent()) {
-            return getDateFormat(dateFormatAnnotation.get());
+        if (annotations != null) {
+            Optional<AnnotationInstance> dateFormatAnnotation = getDateFormatAnnotation(annotations);
+            if (dateFormatAnnotation.isPresent()) {
+                return getDateFormat(dateFormatAnnotation.get());
+            }
         }
-
         return Optional.empty();
     }
 

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/MappingHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/MappingHelper.java
@@ -102,7 +102,7 @@ public class MappingHelper {
     }
 
     private static Type getMapTo(Annotations annotations) {
-        if (annotations.containsOneOfTheseAnnotations(Annotations.TO_SCALAR)) {
+        if (annotations != null && annotations.containsOneOfTheseAnnotations(Annotations.TO_SCALAR)) {
             AnnotationValue annotationValue = annotations.getAnnotationValue(Annotations.TO_SCALAR);
             if (annotationValue != null) {
                 return annotationValue.asClass();

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/TypeNameHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/TypeNameHelper.java
@@ -1,12 +1,17 @@
 package io.smallrye.graphql.schema.helper;
 
+import java.util.List;
+
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
 import org.jboss.logging.Logger;
 
 import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.Classes;
+import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 
 /**
@@ -30,16 +35,22 @@ public class TypeNameHelper {
      * @param annotationsForThisClass annotations on this class
      * @return name of this type
      */
-    public static String getAnyTypeName(ReferenceType referenceType, ClassInfo classInfo,
-            Annotations annotationsForThisClass) {
+    public static String getAnyTypeName(ReferenceType referenceType, ClassInfo classInfo, Annotations annotationsForThisClass) {
+        return getAnyTypeName(referenceType, classInfo, annotationsForThisClass, null);
+    }
+
+    public static String getAnyTypeName(ReferenceType referenceType, ClassInfo classInfo, Annotations annotationsForThisClass,
+            String parametrizedTypeNameExtension) {
         if (Classes.isEnum(classInfo)) {
-            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.ENUM);
+            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.ENUM, parametrizedTypeNameExtension);
         } else if (Classes.isInterface(classInfo)) {
-            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.INTERFACE);
+            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.INTERFACE,
+                    parametrizedTypeNameExtension);
         } else if (referenceType.equals(ReferenceType.TYPE)) {
-            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.TYPE);
+            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.TYPE, parametrizedTypeNameExtension);
         } else if (referenceType.equals(ReferenceType.INPUT)) {
-            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.INPUT, INPUT);
+            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.INPUT, parametrizedTypeNameExtension,
+                    INPUT);
         } else if (referenceType.equals(ReferenceType.SCALAR)) {
             return classInfo.name().withoutPackagePrefix();
         } else {
@@ -48,11 +59,13 @@ public class TypeNameHelper {
         }
     }
 
-    private static String getNameForClassType(ClassInfo classInfo, Annotations annotations, DotName typeName) {
-        return getNameForClassType(classInfo, annotations, typeName, EMPTY);
+    private static String getNameForClassType(ClassInfo classInfo, Annotations annotations, DotName typeName,
+            String parametrizedTypeNameExtension) {
+        return getNameForClassType(classInfo, annotations, typeName, parametrizedTypeNameExtension, null);
     }
 
-    private static String getNameForClassType(ClassInfo classInfo, Annotations annotations, DotName typeName, String postFix) {
+    private static String getNameForClassType(ClassInfo classInfo, Annotations annotations, DotName typeName,
+            String parametrizedTypeNameExtension, String postFix) {
         if (annotations.containsKeyAndValidValue(typeName)) {
             AnnotationValue annotationValue = annotations.getAnnotationValue(typeName);
             return annotationValue.asString().trim();
@@ -60,9 +73,46 @@ public class TypeNameHelper {
             return annotations.getAnnotationValue(Annotations.NAME).asString().trim();
         }
 
-        return classInfo.name().local() + postFix;
+        StringBuilder sb = new StringBuilder();
+        sb.append(classInfo.name().local());
+
+        if (parametrizedTypeNameExtension != null)
+            sb.append(parametrizedTypeNameExtension);
+        if (postFix != null)
+            sb.append(postFix);
+        return sb.toString();
+    }
+
+    public static String createParametrizedTypeNameExtension(List<Type> parametrizedTypeArguments) {
+        if (parametrizedTypeArguments == null || parametrizedTypeArguments.isEmpty())
+            return null;
+        StringBuilder sb = new StringBuilder();
+        for (Type gp : parametrizedTypeArguments) {
+            appendParametrizedArgumet(sb, gp);
+        }
+        return sb.toString();
+    }
+
+    public static String createParametrizedTypeNameExtension(Reference reference) {
+        if (reference.getParametrizedTypeArguments() == null || reference.getParametrizedTypeArguments().isEmpty())
+            return null;
+        StringBuilder sb = new StringBuilder();
+        for (Reference gp : reference.getParametrizedTypeArguments().values()) {
+            sb.append("_");
+            sb.append(gp.getName());
+        }
+        return sb.toString();
+    }
+
+    private static final void appendParametrizedArgumet(StringBuilder sb, Type gp) {
+        sb.append("_");
+        sb.append(gp.name().local());
+        if (gp.kind().equals(Kind.PARAMETERIZED_TYPE)) {
+            for (Type t : gp.asParameterizedType().arguments()) {
+                appendParametrizedArgumet(sb, t);
+            }
+        }
     }
 
     private static final String INPUT = "Input";
-    private static final String EMPTY = "";
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -97,7 +97,7 @@ public class SchemaBuilderTest {
         assertFalse(movieSchemaString.contains("org.eclipse.microprofile.graphql.tck.apps.superhero"));
     }
 
-    static String toString(Schema schema) {
+    public static String toString(Schema schema) {
 
         JsonbConfig config = new JsonbConfig()
                 .withFormatting(true);

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/ArrayCreatorTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/ArrayCreatorTest.java
@@ -3,54 +3,117 @@ package io.smallrye.graphql.schema.creator;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.schema.Classes;
+import io.smallrye.graphql.schema.ScanningContext;
 
 //TODO: Junit 5: use parametrized tests to merge methods
 public class ArrayCreatorTest {
 
     public static final Type STRING_TYPE = Type.create(DotName.createSimple(String.class.getName()), Type.Kind.CLASS);
 
+    public static final DotName SET = DotName.createSimple(Set.class.getName());
+    public static final DotName LINKED_LIST = DotName.createSimple(LinkedList.class.getName());
+
+    @BeforeAll
+    public static void intitJandexIndex() {
+        Indexer indexer = new Indexer();
+        // SchemaBuilderTest.indexBasicJavaClasses(indexer);
+
+        IndexView index = indexer.complete();
+        ScanningContext.register(index);
+    }
+
+    @AfterAll
+    public static void clearJandexIndex() {
+        ScanningContext.remove();
+    }
+
     @Test
-    public void shouldNotCreateArrayForCompletableFuture() {
-        final ParameterizedType completableFuture = ParameterizedType.create(Classes.COMPLETABLE_FUTURE,
+    public void shouldCreateArrayForJavaArray() {
+        final ArrayType type = ArrayType.create(STRING_TYPE, 1);
+
+        assertTrue(ArrayCreator.createArray(type).isPresent());
+    }
+
+    @Test
+    public void shouldCreateArrayForCollection() {
+        final ParameterizedType type = ParameterizedType.create(Classes.COLLECTION,
                 new Type[] { STRING_TYPE }, null);
 
-        assertFalse(ArrayCreator.createArray(completableFuture).isPresent());
+        assertTrue(ArrayCreator.createArray(type).isPresent());
+    }
+
+    @Test
+    public void shouldCreateArrayForSet() {
+        final ParameterizedType type = ParameterizedType.create(SET,
+                new Type[] { STRING_TYPE }, null);
+
+        assertTrue(ArrayCreator.createArray(type).isPresent());
+    }
+
+    @Test
+    public void shouldCreateArrayForLinkedList() {
+        final ParameterizedType type = ParameterizedType.create(LINKED_LIST,
+                new Type[] { STRING_TYPE }, null);
+
+        assertTrue(ArrayCreator.createArray(type).isPresent());
+    }
+
+    @Test
+    public void shouldNotCreateArrayForOptional() {
+        final ParameterizedType type = ParameterizedType.create(Classes.OPTIONAL,
+                new Type[] { STRING_TYPE }, null);
+
+        assertFalse(ArrayCreator.createArray(type).isPresent());
+    }
+
+    @Test
+    public void shouldNotCreateArrayForCompletableFuture() {
+        final ParameterizedType type = ParameterizedType.create(Classes.COMPLETABLE_FUTURE,
+                new Type[] { STRING_TYPE }, null);
+
+        assertFalse(ArrayCreator.createArray(type).isPresent());
     }
 
     @Test
     public void shouldNotCreateArrayForCompletionStage() {
-        final ParameterizedType completionStage = ParameterizedType.create(Classes.COMPLETION_STAGE, new Type[] { STRING_TYPE },
+        final ParameterizedType type = ParameterizedType.create(Classes.COMPLETION_STAGE, new Type[] { STRING_TYPE },
                 null);
 
-        assertFalse(ArrayCreator.createArray(completionStage).isPresent());
+        assertFalse(ArrayCreator.createArray(type).isPresent());
     }
 
     @Test
     public void shouldCreateArrayForCompletionStageOfList() {
         final ParameterizedType stringList = ParameterizedType.create(DotName.createSimple(List.class.getName()),
                 new Type[] { STRING_TYPE }, null);
-        final ParameterizedType completionStage = ParameterizedType.create(Classes.COMPLETION_STAGE, new Type[] { stringList },
+        final ParameterizedType type = ParameterizedType.create(Classes.COMPLETION_STAGE, new Type[] { stringList },
                 null);
 
-        assertTrue(ArrayCreator.createArray(completionStage).isPresent());
+        assertTrue(ArrayCreator.createArray(type).isPresent());
     }
 
     @Test
     public void shouldCreateArrayForCompletionStageOfArray() {
         final ArrayType stringArray = ArrayType.create(STRING_TYPE, 1);
-        final ParameterizedType completionStage = ParameterizedType.create(Classes.COMPLETION_STAGE, new Type[] { stringArray },
+        final ParameterizedType type = ParameterizedType.create(Classes.COMPLETION_STAGE, new Type[] { stringArray },
                 null);
 
-        assertTrue(ArrayCreator.createArray(completionStage).isPresent());
+        assertTrue(ArrayCreator.createArray(type).isPresent());
     }
 
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ClassWithOneGenericsParam.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ClassWithOneGenericsParam.java
@@ -1,0 +1,12 @@
+package io.smallrye.graphql.schema.test_generics;
+
+public class ClassWithOneGenericsParam<T> {
+
+    public T getParam1() {
+        return null;
+    }
+
+    public String getName() {
+        return null;
+    }
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ClassWithOneGenericsParamToString.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ClassWithOneGenericsParamToString.java
@@ -1,0 +1,8 @@
+package io.smallrye.graphql.schema.test_generics;
+
+public class ClassWithOneGenericsParamToString extends ClassWithOneGenericsParam<String> {
+
+    public int getAge() {
+        return 99;
+    }
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ClassWithOneGenericsParamToString2.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ClassWithOneGenericsParamToString2.java
@@ -1,0 +1,8 @@
+package io.smallrye.graphql.schema.test_generics;
+
+public class ClassWithOneGenericsParamToString2 extends ClassWithOneGenericsParamToString {
+
+    public String getMe() {
+        return null;
+    }
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ClassWithTwoGenericsParams.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ClassWithTwoGenericsParams.java
@@ -1,0 +1,17 @@
+package io.smallrye.graphql.schema.test_generics;
+
+public class ClassWithTwoGenericsParams<T, V> {
+
+    public T getParam1() {
+        return null;
+    }
+
+    public V getParam2() {
+        return null;
+    }
+
+    public String getName() {
+        return null;
+    }
+
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ClassWithoutGenerics.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ClassWithoutGenerics.java
@@ -1,0 +1,12 @@
+package io.smallrye.graphql.schema.test_generics;
+
+public class ClassWithoutGenerics {
+
+    public String getName() {
+        return null;
+    }
+
+    public int getAge() {
+        return 42;
+    }
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ControllerWithGenerics.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/ControllerWithGenerics.java
@@ -1,0 +1,50 @@
+package io.smallrye.graphql.schema.test_generics;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class ControllerWithGenerics {
+
+    @Query
+    public String getString() {
+        return null;
+    }
+
+    @Query
+    public ClassWithoutGenerics getClassWithoutGenerics() {
+        return null;
+    }
+
+    @Query
+    public ClassWithOneGenericsParam<String> getClassWithOneGenericsParamInControllerString() {
+        return null;
+    }
+
+    @Query
+    public ClassWithTwoGenericsParams<String, ClassWithOneGenericsParam<Integer>> getClassWithTwoGenericsParamsWithNestedOneGenericsParamInControllerString() {
+        return null;
+    }
+
+    @Query
+    public InterfaceWithOneGenericsParam<String> getInterfaceWithOneGenericsParamInControllerString() {
+        return null;
+    }
+
+    @Query
+    public InterfaceWithOneGenericsParam<Integer> getInterfaceWithOneGenericsParamInControllerInteger() {
+        return null;
+    }
+
+    @Query
+    public ClassWithOneGenericsParamToString2 getClassWithOneGenericsParamToString() {
+        return null;
+    }
+
+    @Mutation
+    public InterfaceWithOneGenericsParam<String> setClassWithOneGenericsParamInControllerString(
+            ClassWithOneGenericsParam<String> param1) {
+        return null;
+    }
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/GenericsTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/GenericsTest.java
@@ -1,0 +1,52 @@
+package io.smallrye.graphql.schema.test_generics;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.graphql.index.SchemaBuilderTest;
+import io.smallrye.graphql.schema.SchemaBuilder;
+import io.smallrye.graphql.schema.model.Schema;
+
+public class GenericsTest {
+
+    private static final Logger LOG = Logger.getLogger(GenericsTest.class.getName());
+
+    @Test
+    public void testSchemaString() throws Exception {
+
+        Indexer indexer = new Indexer();
+        SchemaBuilderTest.indexDirectory(indexer, "io/smallrye/graphql/schema/test_generics");
+        Index index = indexer.complete();
+
+        Schema schema = SchemaBuilder.build(index);
+        assertNotNull(schema);
+
+        String schemaString = SchemaBuilderTest.toString(schema);
+        LOG.info(schemaString);
+
+        assertTrue(schemaString.contains("io.smallrye.graphql.schema.test_generics.InterfaceWithOneGenericsParam"));
+        assertTrue(schemaString.contains("InterfaceWithOneGenericsParam_Int"));
+        assertTrue(schemaString.contains("InterfaceWithOneGenericsParam_String"));
+
+        assertTrue(schemaString.contains("io.smallrye.graphql.schema.test_generics.ClassWithoutGenerics"));
+        assertTrue(schemaString.contains("ClassWithoutGenerics"));
+
+        assertTrue(schemaString.contains("io.smallrye.graphql.schema.test_generics.ClassWithOneGenericsParamToString2"));
+        assertTrue(schemaString.contains("ClassWithOneGenericsParamToString2_String"));
+
+        assertTrue(schemaString.contains("io.smallrye.graphql.schema.test_generics.ClassWithOneGenericsParam"));
+        assertTrue(schemaString.contains("ClassWithOneGenericsParam_String"));
+        assertTrue(schemaString.contains("ClassWithOneGenericsParam_Int"));
+        assertTrue(schemaString.contains("ClassWithOneGenericsParam_StringInput"));
+
+        assertTrue(schemaString.contains("io.smallrye.graphql.schema.test_generics.ClassWithTwoGenericsParams"));
+        assertTrue(schemaString.contains("ClassWithTwoGenericsParams_String_ClassWithOneGenericsParam_Integer"));
+
+    }
+
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/InterfaceWithOneGenericsParam.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/InterfaceWithOneGenericsParam.java
@@ -1,0 +1,9 @@
+package io.smallrye.graphql.schema.test_generics;
+
+public interface InterfaceWithOneGenericsParam<T> {
+
+    T getInstance();
+
+    String getName();
+
+}

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Reference.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Reference.java
@@ -1,11 +1,11 @@
 package io.smallrye.graphql.schema.model;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /**
- * Represents a reference to some other type (type/input/enum/interface)
- * This so that, as we are scanning, we can refer to a type that might not exist yet
- * All types extends this.
+ * Represents a reference to some other type (type/input/enum/interface) This so that, as we are scanning, we can refer
+ * to a type that might not exist yet All types extends this.
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
@@ -16,28 +16,37 @@ public class Reference implements Serializable {
     private ReferenceType type;
     private String graphQlClassName;
     private MappingInfo mappingInfo = null; // If the type is mapped to another type
+    private Map<String, Reference> parametrizedTypeArguments;
 
     public Reference() {
     }
 
-    public Reference(String className, String name, ReferenceType type, String graphQlClassName) {
-        this(className, name, type, graphQlClassName, null);
+    public Reference(String className, String name, ReferenceType type, String graphQlClassName,
+            Map<String, Reference> parametrizedTypeArguments) {
+        this(className, name, type, graphQlClassName, parametrizedTypeArguments, null);
     }
 
-    public Reference(String className, String name, ReferenceType type, String graphQlClassName, MappingInfo mappingInfo) {
+    public Reference(String className, String name, ReferenceType type, String graphQlClassName,
+            Map<String, Reference> parametrizedTypeArguments, MappingInfo mappingInfo) {
         this.className = className;
         this.name = name;
         this.type = type;
         this.graphQlClassName = graphQlClassName;
+        this.parametrizedTypeArguments = parametrizedTypeArguments;
         this.mappingInfo = mappingInfo;
     }
 
     public Reference(String className, String name, ReferenceType type) {
-        this(className, name, type, className, null);
+        this(className, name, type, className, null, null);
+    }
+
+    public Reference(String className, String name, ReferenceType type, Map<String, Reference> parametrizedTypeArguments) {
+        this(className, name, type, className, parametrizedTypeArguments, null);
     }
 
     public Reference(final Reference reference) {
-        this(reference.className, reference.name, reference.type, reference.graphQlClassName, reference.mappingInfo);
+        this(reference.className, reference.name, reference.type, reference.graphQlClassName,
+                reference.parametrizedTypeArguments, reference.mappingInfo);
     }
 
     /**
@@ -106,5 +115,9 @@ public class Reference implements Serializable {
 
     public boolean hasMappingInfo() {
         return this.mappingInfo != null;
+    }
+
+    public Map<String, Reference> getParametrizedTypeArguments() {
+        return parametrizedTypeArguments;
     }
 }

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
@@ -61,7 +61,7 @@ public class Scalars {
     }
 
     public static Reference getIDScalar(String className) {
-        return new Reference(className, ID, ReferenceType.SCALAR);
+        return new Reference(className, ID, ReferenceType.SCALAR, null);
     }
 
     static {
@@ -128,14 +128,14 @@ public class Scalars {
     }
 
     private static void populateScalar(String className, String scalarName, String externalClassName) {
-        Reference reference = new Reference(className, scalarName, ReferenceType.SCALAR, externalClassName);
+        Reference reference = new Reference(className, scalarName, ReferenceType.SCALAR, externalClassName, null);
         scalarMap.put(className, reference);
 
         // looking up by name
         scalarNameMap.putIfAbsent(scalarName, reference);
 
         //Currently, each scalar is formatted as String
-        formattedScalarMap.put(className, new Reference(className, STRING, ReferenceType.SCALAR, String.class.getName()));
+        formattedScalarMap.put(className, new Reference(className, STRING, ReferenceType.SCALAR, String.class.getName(), null));
     }
 
 }


### PR DESCRIPTION
Support for generics as proposed in issue #281. 
Added mainly to schema generation process. Unit tests for schema generation added also.

Runtime tested using example application as I do not see any automated tests for this. 
Everything looks OK, I only see this log message when generics is used as input parameter in mutation `WARNING [org.eclipse.yasson.internal.ReflectionUtils] (default task-1) Generic bound not found for type T declared in class com.github.phillipkruger.user.graphql.ClassWithOneGenericsParam.`, but it looks to work well.