### PR TITLE
Avoid initializing multiple EventEmitter instances

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -111,7 +111,7 @@ public class Bootstrap {
     private Bootstrap(Schema schema, Config config) {
         this.schema = schema;
         this.config = config;
-        this.eventEmitter = new EventEmitter(config);
+        this.eventEmitter = EventEmitter.getInstance(config);
         SmallRyeContext.setSchema(schema);
     }
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -72,7 +72,7 @@ public class ExecutionService {
         this.config = config;
         this.graphQLSchema = graphQLSchema;
         this.dataLoaderRegistry = dataLoaderRegistry;
-        this.eventEmitter = new EventEmitter(config);
+        this.eventEmitter = EventEmitter.getInstance(config);
         // use schema's hash as prefix to differentiate between multiple apps
         this.executionIdPrefix = Integer.toString(Objects.hashCode(graphQLSchema));
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/batchloader/SourceBatchLoader.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/batchloader/SourceBatchLoader.java
@@ -30,7 +30,7 @@ public class SourceBatchLoader implements BatchLoaderWithContext<Object, Object>
     private final boolean async;
 
     public SourceBatchLoader(Operation operation, Config config) {
-        EventEmitter eventEmitter = new EventEmitter(config);
+        EventEmitter eventEmitter = EventEmitter.getInstance(config);
         this.reflectionHelper = new ReflectionHelper(operation, eventEmitter);
         async = operation.isAsync();
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/BatchDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/BatchDataFetcher.java
@@ -25,7 +25,7 @@ public class BatchDataFetcher<T> implements DataFetcher<T> {
 
     public BatchDataFetcher(Operation operation, Config config) {
         this.operation = operation;
-        this.eventEmitter = new EventEmitter(config);
+        this.eventEmitter = EventEmitter.getInstance(config);
         this.argumentHelper = new ArgumentHelper(operation.getArguments());
         this.batchLoaderName = SourceBatchLoaderHelper.getName(operation);
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/ReflectionDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/ReflectionDataFetcher.java
@@ -54,7 +54,7 @@ public class ReflectionDataFetcher<T> implements DataFetcher<T> {
      */
     public ReflectionDataFetcher(Operation operation, Config config) {
         this.operation = operation;
-        this.eventEmitter = new EventEmitter(config);
+        this.eventEmitter = EventEmitter.getInstance(config);
         this.fieldHelper = new FieldHelper(operation);
         this.reflectionHelper = new ReflectionHelper(operation, eventEmitter);
         this.argumentHelper = new ArgumentHelper(operation.getArguments());

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
@@ -1,9 +1,13 @@
 package io.smallrye.graphql.execution.event;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
+
+import org.jboss.logging.Logger;
 
 import graphql.schema.GraphQLSchema;
 import io.smallrye.graphql.api.Context;
@@ -19,15 +23,21 @@ import io.smallrye.graphql.spi.EventingService;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class EventEmitter {
-
-    private final ServiceLoader<EventingService> eventingServices = ServiceLoader.load(EventingService.class);
+    private static final Logger LOG = Logger.getLogger(EventEmitter.class);
+    private static final Map<Config, EventEmitter> INSTANCES = new IdentityHashMap<>();
     private final List<EventingService> enabledServices = new ArrayList<>();
 
-    public EventEmitter(Config config) {
+    public static EventEmitter getInstance(Config config) {
+        return INSTANCES.computeIfAbsent(config, k -> new EventEmitter(config));
+    }
+
+    private EventEmitter(Config config) {
+        ServiceLoader<EventingService> eventingServices = ServiceLoader.load(EventingService.class);
         Iterator<EventingService> it = eventingServices.iterator();
         while (it.hasNext()) {
+            EventingService eventingService = null;
             try {
-                EventingService eventingService = it.next();
+                eventingService = it.next();
                 String configKey = eventingService.getConfigKey();
                 boolean enabled = config.getConfigValue(configKey, boolean.class, false);
                 if (enabled) {
@@ -35,6 +45,9 @@ public class EventEmitter {
                 }
             } catch (Throwable t) {
                 // Ignore that service...
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Failed to register eventing service, " + eventingService, t);
+                }
             }
         }
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
@@ -46,7 +46,7 @@ public class EventEmitter {
             } catch (Throwable t) {
                 // Ignore that service...
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Failed to register eventing service, " + eventingService, t);
+                    LOG.warn("Failed to register eventing service, " + eventingService, t);
                 }
             }
         }


### PR DESCRIPTION
While debugging an issue with Metrics and Open Liberty, I noticed that the EventEmitter class is initialized four times using the same Config object.  Each time it does that it uses the ServiceLoader to find classes and attempt to register them.  This can get expensive, and we really only need one instance of the EventEmitter class.  This change makes one per Config (assuming that there could be some case where there will be multiple Configs - each with different class loaders allowing a different set of EmitterServices).