### PR TITLE
#429 - patched Bootstrap.generateGraphQLSchema when generic type with

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -237,7 +237,7 @@ public class Bootstrap {
         GraphQLInterfaceType graphQLInterfaceType = interfaceTypeBuilder.build();
         // To resolve the concrete class
         this.codeRegistryBuilder.typeResolver(graphQLInterfaceType, new InterfaceResolver(interfaceType));
-        this.interfaceMap.put(interfaceType.getClassName(), graphQLInterfaceType);
+        this.interfaceMap.put(interfaceType.getName(), graphQLInterfaceType);
     }
 
     private void createGraphQLInputObjectTypes() {
@@ -262,7 +262,7 @@ public class Bootstrap {
         }
 
         GraphQLInputObjectType graphQLInputObjectType = inputObjectTypeBuilder.build();
-        inputMap.put(inputType.getClassName(), graphQLInputObjectType);
+        inputMap.put(inputType.getName(), graphQLInputObjectType);
     }
 
     private void createGraphQLObjectTypes() {
@@ -315,15 +315,15 @@ public class Bootstrap {
         if (type.hasInterfaces()) {
             Set<Reference> interfaces = type.getInterfaces();
             for (Reference i : interfaces) {
-                if (interfaceMap.containsKey(i.getClassName())) {
-                    GraphQLInterfaceType graphQLInterfaceType = interfaceMap.get(i.getClassName());
+                if (interfaceMap.containsKey(i.getName())) {
+                    GraphQLInterfaceType graphQLInterfaceType = interfaceMap.get(i.getName());
                     objectTypeBuilder = objectTypeBuilder.withInterface(graphQLInterfaceType);
                 }
             }
         }
 
         GraphQLObjectType graphQLObjectType = objectTypeBuilder.build();
-        typeMap.put(type.getClassName(), graphQLObjectType);
+        typeMap.put(type.getName(), graphQLObjectType);
 
         // Register this output for interface type resolving
         InterfaceOutputRegistry.register(type, graphQLObjectType);

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/ClassWithOneGenericsParam.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/ClassWithOneGenericsParam.java
@@ -1,0 +1,12 @@
+package io.smallrye.graphql.test;
+
+public class ClassWithOneGenericsParam<T> {
+
+    public T getParam1() {
+        return null;
+    }
+
+    public String getName() {
+        return null;
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/TestEndpoint.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/TestEndpoint.java
@@ -45,6 +45,18 @@ public class TestEndpoint {
         return values;
     }
 
+    // issue #429 reproducer part 1
+    @Query
+    public ClassWithOneGenericsParam<String> getGeneric1() {
+        return null;
+    }
+
+    // issue #429 reproducer part 2
+    @Query
+    public ClassWithOneGenericsParam<Integer> getGeneric2() {
+        return null;
+    }
+
     // This method will be ignored, with a WARN in the log, due to below duplicate
     @Name("timestamp")
     public TestSource getTestSource(@Source TestObject testObject, String indicator) {


### PR DESCRIPTION
two distinct resolutions exists in the schema. Test added to cover this problem.