### PR TITLE
Added ability to control the naming strategy when creating Types.

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
@@ -26,6 +26,7 @@ import io.smallrye.graphql.schema.model.MappingInfo;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Scalars;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * Here we create references to things that might not yet exist.
@@ -47,6 +48,12 @@ public class ReferenceCreator {
     private final Map<String, Reference> typeReferenceMap = new HashMap<>();
     private final Map<String, Reference> enumReferenceMap = new HashMap<>();
     private final Map<String, Reference> interfaceReferenceMap = new HashMap<>();
+
+    private final TypeAutoNameStrategy autoNameStrategy;
+
+    public ReferenceCreator(TypeAutoNameStrategy autoNameStrategy) {
+        this.autoNameStrategy = autoNameStrategy;
+    }
 
     /**
      * Clear the scanned references. This is done when we created all references and do not need to remember what to
@@ -185,8 +192,8 @@ public class ReferenceCreator {
         // Now we should have the correct reference type.
         String className = classInfo.name().toString();
         Annotations annotationsForClass = Annotations.getAnnotationsForClass(classInfo);
-        String name = TypeNameHelper.getAnyTypeName(referenceType, classInfo, annotationsForClass,
-                TypeNameHelper.createParametrizedTypeNameExtension(parametrizedTypeArguments));
+        String name = TypeNameHelper.getAnyTypeName(parametrizedTypeArguments, referenceType, classInfo, annotationsForClass,
+                this.autoNameStrategy);
 
         Map<String, Reference> parametrizedTypeArgumentsReferences = null;
         if (parametrizedTypeArguments != null && referenceType != ReferenceType.ENUM) {

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
@@ -16,6 +16,7 @@ import io.smallrye.graphql.schema.helper.TypeNameHelper;
 import io.smallrye.graphql.schema.model.EnumType;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * This create an Enum Type.
@@ -25,6 +26,12 @@ import io.smallrye.graphql.schema.model.ReferenceType;
 public class EnumCreator implements Creator<EnumType> {
     private static final Logger LOG = Logger.getLogger(EnumCreator.class.getName());
 
+    private final TypeAutoNameStrategy autoNameStrategy;
+
+    public EnumCreator(TypeAutoNameStrategy autoNameStrategy) {
+        this.autoNameStrategy = autoNameStrategy;
+    }
+
     @Override
     public EnumType create(ClassInfo classInfo, Reference reference) {
         LOG.debug("Creating enum from " + classInfo.name().toString());
@@ -32,7 +39,7 @@ public class EnumCreator implements Creator<EnumType> {
         Annotations annotations = Annotations.getAnnotationsForClass(classInfo);
 
         // Name
-        String name = TypeNameHelper.getAnyTypeName(ReferenceType.ENUM, classInfo, annotations);
+        String name = TypeNameHelper.getAnyTypeName(reference, ReferenceType.ENUM, classInfo, annotations, autoNameStrategy);
 
         // Description
         Optional<String> maybeDescription = DescriptionHelper.getDescriptionForType(annotations);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
@@ -21,6 +21,7 @@ import io.smallrye.graphql.schema.helper.TypeNameHelper;
 import io.smallrye.graphql.schema.model.InputType;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * This creates an input type object.
@@ -34,9 +35,11 @@ public class InputTypeCreator implements Creator<InputType> {
     private static final Logger LOG = Logger.getLogger(InputTypeCreator.class.getName());
 
     private final FieldCreator fieldCreator;
+    private final TypeAutoNameStrategy autoNameStrategy;
 
-    public InputTypeCreator(FieldCreator fieldCreator) {
+    public InputTypeCreator(FieldCreator fieldCreator, TypeAutoNameStrategy autoNameStrategy) {
         this.fieldCreator = fieldCreator;
+        this.autoNameStrategy = autoNameStrategy;
     }
 
     @Override
@@ -53,8 +56,7 @@ public class InputTypeCreator implements Creator<InputType> {
         Annotations annotations = Annotations.getAnnotationsForClass(classInfo);
 
         // Name
-        String name = TypeNameHelper.getAnyTypeName(ReferenceType.INPUT, classInfo, annotations,
-                TypeNameHelper.createParametrizedTypeNameExtension(reference));
+        String name = TypeNameHelper.getAnyTypeName(reference, ReferenceType.INPUT, classInfo, annotations, autoNameStrategy);
 
         // Description
         String description = DescriptionHelper.getDescriptionForType(annotations).orElse(null);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InterfaceCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InterfaceCreator.java
@@ -19,6 +19,7 @@ import io.smallrye.graphql.schema.helper.TypeNameHelper;
 import io.smallrye.graphql.schema.model.InterfaceType;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * This creates an interface object.
@@ -33,10 +34,13 @@ public class InterfaceCreator implements Creator<InterfaceType> {
 
     private final ReferenceCreator referenceCreator;
     private final FieldCreator fieldCreator;
+    private final TypeAutoNameStrategy autoNameStrategy;
 
-    public InterfaceCreator(ReferenceCreator referenceCreator, FieldCreator fieldCreator) {
+    public InterfaceCreator(ReferenceCreator referenceCreator, FieldCreator fieldCreator,
+            TypeAutoNameStrategy autoNameStrategy) {
         this.referenceCreator = referenceCreator;
         this.fieldCreator = fieldCreator;
+        this.autoNameStrategy = autoNameStrategy;
     }
 
     @Override
@@ -46,8 +50,8 @@ public class InterfaceCreator implements Creator<InterfaceType> {
         Annotations annotations = Annotations.getAnnotationsForClass(classInfo);
 
         // Name
-        String name = TypeNameHelper.getAnyTypeName(ReferenceType.INTERFACE, classInfo, annotations,
-                TypeNameHelper.createParametrizedTypeNameExtension(reference));
+        String name = TypeNameHelper.getAnyTypeName(reference, ReferenceType.INTERFACE, classInfo, annotations,
+                autoNameStrategy);
 
         // Description
         String description = DescriptionHelper.getDescriptionForType(annotations).orElse(null);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/TypeCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/TypeCreator.java
@@ -27,6 +27,7 @@ import io.smallrye.graphql.schema.model.OperationType;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Type;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * This creates a type object.
@@ -43,11 +44,14 @@ public class TypeCreator implements Creator<Type> {
     private final ReferenceCreator referenceCreator;
     private final FieldCreator fieldCreator;
     private final OperationCreator operationCreator;
+    private final TypeAutoNameStrategy autoNameStrategy;
 
-    public TypeCreator(ReferenceCreator referenceCreator, FieldCreator fieldCreator, OperationCreator operationCreator) {
+    public TypeCreator(ReferenceCreator referenceCreator, FieldCreator fieldCreator, OperationCreator operationCreator,
+            TypeAutoNameStrategy autoNameStrategy) {
         this.referenceCreator = referenceCreator;
         this.fieldCreator = fieldCreator;
         this.operationCreator = operationCreator;
+        this.autoNameStrategy = autoNameStrategy;
     }
 
     @Override
@@ -57,8 +61,7 @@ public class TypeCreator implements Creator<Type> {
         Annotations annotations = Annotations.getAnnotationsForClass(classInfo);
 
         // Name
-        String name = TypeNameHelper.getAnyTypeName(ReferenceType.TYPE, classInfo, annotations,
-                TypeNameHelper.createParametrizedTypeNameExtension(reference));
+        String name = TypeNameHelper.getAnyTypeName(reference, ReferenceType.TYPE, classInfo, annotations, autoNameStrategy);
 
         // Description
         String description = DescriptionHelper.getDescriptionForType(annotations).orElse(null);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/TypeNameHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/TypeNameHelper.java
@@ -13,6 +13,7 @@ import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.Classes;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * Helping with Name of types in the schema
@@ -35,22 +36,34 @@ public class TypeNameHelper {
      * @param annotationsForThisClass annotations on this class
      * @return name of this type
      */
-    public static String getAnyTypeName(ReferenceType referenceType, ClassInfo classInfo, Annotations annotationsForThisClass) {
-        return getAnyTypeName(referenceType, classInfo, annotationsForThisClass, null);
+    public static String getAnyTypeName(List<Type> parametrizedTypeArguments, ReferenceType referenceType, ClassInfo classInfo,
+            Annotations annotationsForThisClass, TypeAutoNameStrategy autoNameStrategy) {
+        String parametrizedTypeNameExtension = createParametrizedTypeNameExtension(parametrizedTypeArguments);
+        return getAnyTypeName(parametrizedTypeNameExtension, referenceType, classInfo, annotationsForThisClass,
+                autoNameStrategy);
     }
 
-    public static String getAnyTypeName(ReferenceType referenceType, ClassInfo classInfo, Annotations annotationsForThisClass,
-            String parametrizedTypeNameExtension) {
+    public static String getAnyTypeName(Reference reference, ReferenceType referenceType, ClassInfo classInfo,
+            Annotations annotationsForThisClass, TypeAutoNameStrategy autoNameStrategy) {
+        String parametrizedTypeNameExtension = createParametrizedTypeNameExtension(reference);
+        return getAnyTypeName(parametrizedTypeNameExtension, referenceType, classInfo, annotationsForThisClass,
+                autoNameStrategy);
+    }
+
+    private static String getAnyTypeName(String parametrizedTypeNameExtension, ReferenceType referenceType, ClassInfo classInfo,
+            Annotations annotationsForThisClass, TypeAutoNameStrategy autoNameStrategy) {
         if (Classes.isEnum(classInfo)) {
-            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.ENUM, parametrizedTypeNameExtension);
+            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.ENUM, parametrizedTypeNameExtension,
+                    autoNameStrategy);
         } else if (Classes.isInterface(classInfo)) {
             return getNameForClassType(classInfo, annotationsForThisClass, Annotations.INTERFACE,
-                    parametrizedTypeNameExtension);
+                    parametrizedTypeNameExtension, autoNameStrategy);
         } else if (referenceType.equals(ReferenceType.TYPE)) {
-            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.TYPE, parametrizedTypeNameExtension);
+            return getNameForClassType(classInfo, annotationsForThisClass, Annotations.TYPE, parametrizedTypeNameExtension,
+                    autoNameStrategy);
         } else if (referenceType.equals(ReferenceType.INPUT)) {
             return getNameForClassType(classInfo, annotationsForThisClass, Annotations.INPUT, parametrizedTypeNameExtension,
-                    INPUT);
+                    INPUT, autoNameStrategy);
         } else if (referenceType.equals(ReferenceType.SCALAR)) {
             return classInfo.name().withoutPackagePrefix();
         } else {
@@ -60,12 +73,12 @@ public class TypeNameHelper {
     }
 
     private static String getNameForClassType(ClassInfo classInfo, Annotations annotations, DotName typeName,
-            String parametrizedTypeNameExtension) {
-        return getNameForClassType(classInfo, annotations, typeName, parametrizedTypeNameExtension, null);
+            String parametrizedTypeNameExtension, TypeAutoNameStrategy autoNameStrategy) {
+        return getNameForClassType(classInfo, annotations, typeName, parametrizedTypeNameExtension, null, autoNameStrategy);
     }
 
     private static String getNameForClassType(ClassInfo classInfo, Annotations annotations, DotName typeName,
-            String parametrizedTypeNameExtension, String postFix) {
+            String parametrizedTypeNameExtension, String postFix, TypeAutoNameStrategy autoNameStrategy) {
 
         StringBuilder sb = new StringBuilder();
 
@@ -75,7 +88,7 @@ public class TypeNameHelper {
         } else if (annotations.containsKeyAndValidValue(Annotations.NAME)) {
             sb.append(annotations.getAnnotationValue(Annotations.NAME).asString().trim());
         } else {
-            sb.append(classInfo.name().local());
+            sb.append(applyNamingStrategy(classInfo, autoNameStrategy));
         }
 
         if (parametrizedTypeNameExtension != null)
@@ -85,7 +98,7 @@ public class TypeNameHelper {
         return sb.toString();
     }
 
-    public static String createParametrizedTypeNameExtension(List<Type> parametrizedTypeArguments) {
+    private static String createParametrizedTypeNameExtension(List<Type> parametrizedTypeArguments) {
         if (parametrizedTypeArguments == null || parametrizedTypeArguments.isEmpty())
             return null;
         StringBuilder sb = new StringBuilder();
@@ -95,14 +108,14 @@ public class TypeNameHelper {
         return sb.toString();
     }
 
-    public static String createParametrizedTypeNameExtension(Reference reference) {
+    private static String createParametrizedTypeNameExtension(Reference reference) {
         if (reference.getParametrizedTypeArguments() == null || reference.getParametrizedTypeArguments().isEmpty())
             return null;
         StringBuilder sb = new StringBuilder();
         for (Reference gp : reference.getParametrizedTypeArguments().values()) {
             sb.append("_");
 
-            // next code must match with #appendParametrizedArgumet() to create same named types! See bug #418.
+            // next code must match with #appendParametrizedArgument() to create same named types! See bug #418.
             // If parametrized type is generic we have to use it's graphQL name which contains necessary extensions
             // already. For rest we always use names derived from the java class name to match with
             // #appendParametrizedArgumet()
@@ -115,8 +128,20 @@ public class TypeNameHelper {
         return sb.toString();
     }
 
+    private static String applyNamingStrategy(ClassInfo classInfo, TypeAutoNameStrategy autoNameStrategy) {
+        if (autoNameStrategy.equals(TypeAutoNameStrategy.Full)) {
+            return classInfo.name().toString().replaceAll("\\.", UNDERSCORE).replaceAll("\\$", "");
+        } else if (autoNameStrategy.equals(TypeAutoNameStrategy.MergeInnerClass)) {
+            DotName enclosingClass = classInfo.enclosingClass();
+            if (enclosingClass != null) {
+                return enclosingClass.local() + classInfo.name().local();
+            }
+        }
+        return classInfo.name().local(); // Default
+    }
+
     private static final void appendParametrizedArgumet(StringBuilder sb, Type gp) {
-        sb.append("_");
+        sb.append(UNDERSCORE);
         sb.append(gp.name().local());
         if (gp.kind().equals(Kind.PARAMETERIZED_TYPE)) {
             for (Type t : gp.asParameterizedType().arguments()) {
@@ -126,4 +151,5 @@ public class TypeNameHelper {
     }
 
     private static final String INPUT = "Input";
+    private static final String UNDERSCORE = "_";
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * Test the model creation
@@ -37,7 +38,7 @@ public class SchemaBuilderTest {
     public void testSchemaModelCreation() {
 
         IndexView index = getTCKIndex();
-        Schema schema = SchemaBuilder.build(index);
+        Schema schema = SchemaBuilder.build(index, TypeAutoNameStrategy.Default);
         LOG.info(toString(schema));
         assertNotNull(schema);
     }
@@ -59,9 +60,9 @@ public class SchemaBuilderTest {
         IndexView movieIndex = indexer.complete();
 
         ExecutorService executor = Executors.newFixedThreadPool(4);
-        Future<Schema> basicSchemaFuture = executor.submit(() -> SchemaBuilder.build(basicIndex));
-        Future<Schema> heroSchemaFuture = executor.submit(() -> SchemaBuilder.build(heroIndex));
-        Future<Schema> movieSchemaFuture = executor.submit(() -> SchemaBuilder.build(movieIndex));
+        Future<Schema> basicSchemaFuture = executor.submit(() -> SchemaBuilder.build(basicIndex, TypeAutoNameStrategy.Default));
+        Future<Schema> heroSchemaFuture = executor.submit(() -> SchemaBuilder.build(heroIndex, TypeAutoNameStrategy.Default));
+        Future<Schema> movieSchemaFuture = executor.submit(() -> SchemaBuilder.build(movieIndex, TypeAutoNameStrategy.Default));
 
         Schema basicSchema = basicSchemaFuture.get();
         Schema heroSchema = heroSchemaFuture.get();

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/OperationCreatorTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/OperationCreatorTest.java
@@ -12,11 +12,12 @@ import org.junit.jupiter.api.Test;
 import io.smallrye.graphql.schema.IndexCreator;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.OperationType;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 public class OperationCreatorTest {
 
     private OperationCreator operationCreator() {
-        ReferenceCreator referenceCreator = new ReferenceCreator();
+        ReferenceCreator referenceCreator = new ReferenceCreator(TypeAutoNameStrategy.Default);
         ArgumentCreator argumentCreator = new ArgumentCreator(referenceCreator);
         return new OperationCreator(referenceCreator, argumentCreator);
     }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/GenericsTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/test_generics/GenericsTest.java
@@ -21,6 +21,7 @@ import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 public class GenericsTest {
 
@@ -33,7 +34,7 @@ public class GenericsTest {
         SchemaBuilderTest.indexDirectory(indexer, "io/smallrye/graphql/schema/test_generics");
         Index index = indexer.complete();
 
-        Schema schema = SchemaBuilder.build(index);
+        Schema schema = SchemaBuilder.build(index, TypeAutoNameStrategy.Default);
         assertNotNull(schema);
 
         String schemaString = SchemaBuilderTest.toString(schema);

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/TypeAutoNameStrategy.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/TypeAutoNameStrategy.java
@@ -1,0 +1,12 @@
+package io.smallrye.graphql.schema.model;
+
+/**
+ * Naming strategy for type
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public enum TypeAutoNameStrategy {
+    Default, // Spec compliant
+    MergeInnerClass, // Inner class prefix parent name
+    Full // Use fully qualified name
+}

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/ConfigKey.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/ConfigKey.java
@@ -19,4 +19,5 @@ public interface ConfigKey extends org.eclipse.microprofile.graphql.ConfigKey {
     public static final String SCHEMA_INCLUDE_INTROSPECTION_TYPES = "smallrye.graphql.schema.includeIntrospectionTypes";
     public static final String LOG_PAYLOAD = "smallrye.graphql.logPayload";
     public static final String FIELD_VISIBILITY = "smallrye.graphql.fieldVisibility";
+    public static final String TYPE_AUTO_NAME_STRATEGY = "smallrye.graphql.typeAutoNameStrategy";
 }

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/GraphQLConfig.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/GraphQLConfig.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.smallrye.graphql.bootstrap.Config;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * Configuration for GraphQL
@@ -93,6 +94,10 @@ public class GraphQLConfig implements Config {
     @Inject
     @ConfigProperty(name = ConfigKey.FIELD_VISIBILITY, defaultValue = Config.FIELD_VISIBILITY_DEFAULT)
     private String fieldVisibility;
+
+    @Inject
+    @ConfigProperty(name = ConfigKey.TYPE_AUTO_NAME_STRATEGY, defaultValue = "Default")
+    private TypeAutoNameStrategy autoNameStrategy;
 
     public void init(@Observes @Initialized(ApplicationScoped.class) Object init) {
         hideList = mergeList(hideList, blackList);
@@ -229,6 +234,14 @@ public class GraphQLConfig implements Config {
 
     public void setFieldVisibility(String fieldVisibility) {
         this.fieldVisibility = fieldVisibility;
+    }
+
+    public TypeAutoNameStrategy getTypeAutoNameStrategy() {
+        return autoNameStrategy;
+    }
+
+    public void setTypeAutoNameStrategy(TypeAutoNameStrategy autoNameStrategy) {
+        this.autoNameStrategy = autoNameStrategy;
     }
 
     private Optional<List<String>> mergeList(Optional<List<String>> currentList, Optional<List<String>> deprecatedList) {

--- a/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/CdiExecutionTest.java
+++ b/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/CdiExecutionTest.java
@@ -36,6 +36,7 @@ import io.smallrye.graphql.bootstrap.Config;
 import io.smallrye.graphql.cdi.event.EventsService;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * Test a basic query
@@ -55,7 +56,7 @@ public class CdiExecutionTest {
     @BeforeEach
     public void init() {
         IndexView index = Indexer.getTCKIndex();
-        Schema schema = SchemaBuilder.build(index);
+        Schema schema = SchemaBuilder.build(index, TypeAutoNameStrategy.Default);
         BootstrapedResult bootstraped = Bootstrap.bootstrap(schema);
         GraphQLSchema graphQLSchema = bootstraped.getGraphQLSchema();
         DataLoaderRegistry dataLoaderRegistry = bootstraped.getDataLoaderRegistry();

--- a/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/SchemaTest.java
+++ b/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/SchemaTest.java
@@ -17,6 +17,7 @@ import io.smallrye.graphql.bootstrap.Bootstrap;
 import io.smallrye.graphql.bootstrap.Config;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * Test the graphql-java Schema creation from the schema model
@@ -31,7 +32,7 @@ public class SchemaTest {
     @BeforeEach
     public void init() {
         IndexView index = Indexer.getTCKIndex();
-        this.schema = SchemaBuilder.build(index);
+        this.schema = SchemaBuilder.build(index, TypeAutoNameStrategy.Default);
         assertNotNull(schema);
     }
 

--- a/server/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/StartupListener.java
+++ b/server/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/StartupListener.java
@@ -21,6 +21,7 @@ import javax.servlet.annotation.WebListener;
 import org.jboss.jandex.IndexView;
 
 import graphql.schema.GraphQLSchema;
+import io.smallrye.graphql.cdi.config.GraphQLConfig;
 import io.smallrye.graphql.cdi.producer.GraphQLProducer;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Schema;
@@ -35,6 +36,9 @@ public class StartupListener implements ServletContextListener {
 
     @Inject
     private GraphQLProducer graphQLProducer;
+
+    @Inject
+    GraphQLConfig config;
 
     private final IndexInitializer indexInitializer = new IndexInitializer();
 
@@ -54,7 +58,7 @@ public class StartupListener implements ServletContextListener {
 
             IndexView index = indexInitializer.createIndex(warURLs);
 
-            Schema schema = SchemaBuilder.build(index); // Get the smallrye schema
+            Schema schema = SchemaBuilder.build(index, config.getTypeAutoNameStrategy()); // Get the smallrye schema
             GraphQLSchema graphQLSchema = graphQLProducer.initialize(schema);
 
             sce.getServletContext().setAttribute(SchemaServlet.SCHEMA_PROP, graphQLSchema);

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionTestBase.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionTestBase.java
@@ -23,6 +23,7 @@ import io.smallrye.graphql.bootstrap.BootstrapedResult;
 import io.smallrye.graphql.bootstrap.Config;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * Base class for execution tests
@@ -37,7 +38,7 @@ public class ExecutionTestBase {
     @BeforeEach
     public void init() {
         IndexView index = Indexer.getTCKIndex();
-        Schema schema = SchemaBuilder.build(index);
+        Schema schema = SchemaBuilder.build(index, TypeAutoNameStrategy.Default);
         BootstrapedResult bootstraped = Bootstrap.bootstrap(schema);
         GraphQLSchema graphQLSchema = bootstraped.getGraphQLSchema();
         DataLoaderRegistry dataLoaderRegistry = bootstraped.getDataLoaderRegistry();

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/SchemaGenerationTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/SchemaGenerationTest.java
@@ -1,0 +1,50 @@
+package io.smallrye.graphql.execution;
+
+import org.jboss.jandex.IndexView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import graphql.schema.GraphQLSchema;
+import io.smallrye.graphql.bootstrap.Bootstrap;
+import io.smallrye.graphql.bootstrap.BootstrapedResult;
+import io.smallrye.graphql.bootstrap.Config;
+import io.smallrye.graphql.schema.SchemaBuilder;
+import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
+
+/**
+ * Test the schema generation
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class SchemaGenerationTest {
+
+    @Test
+    public void testDefaultSchema() {
+        String schemaString = getSchemaString(TypeAutoNameStrategy.Default);
+        Assertions.assertTrue(schemaString.contains("enum Number"));
+    }
+
+    @Test
+    public void testMergeInnerSchema() {
+        String schemaString = getSchemaString(TypeAutoNameStrategy.MergeInnerClass);
+        Assertions.assertTrue(schemaString.contains("enum TestObjectNumber"));
+    }
+
+    @Test
+    public void testFullNameSchema() {
+        String schemaString = getSchemaString(TypeAutoNameStrategy.Full);
+        Assertions.assertTrue(schemaString.contains("enum io_smallrye_graphql_test_TestObjectNumber"));
+    }
+
+    private String getSchemaString(TypeAutoNameStrategy autoNameStrategy) {
+        IndexView index = Indexer.getTCKIndex();
+        Schema schema = SchemaBuilder.build(index, autoNameStrategy);
+        BootstrapedResult bootstraped = Bootstrap.bootstrap(schema);
+        GraphQLSchema graphQLSchema = bootstraped.getGraphQLSchema();
+        SchemaPrinter schemaPrinter = new SchemaPrinter(new Config() {
+        });
+        return schemaPrinter.print(graphQLSchema);
+    }
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/TestObject.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/TestObject.java
@@ -17,6 +17,8 @@ public class TestObject {
     @Name("amounts")
     private List<TestListObject> testListObjects = new ArrayList<>();
 
+    private Number number;
+
     public String getId() {
         return id;
     }
@@ -43,5 +45,19 @@ public class TestObject {
 
     public void addTestListObject(TestListObject testListObject) {
         testListObjects.add(testListObject);
+    }
+
+    public Number getNumber() {
+        return number;
+    }
+
+    public void setNumber(Number number) {
+        this.number = number;
+    }
+
+    enum Number {
+        ONE,
+        TWO,
+        THREE
     }
 }

--- a/tools/gradle-plugin/plugin/src/main/java/io/smallrye/graphql/gradle/tasks/GenerateSchemaTask.java
+++ b/tools/gradle-plugin/plugin/src/main/java/io/smallrye/graphql/gradle/tasks/GenerateSchemaTask.java
@@ -37,6 +37,7 @@ import io.smallrye.graphql.bootstrap.Config;
 import io.smallrye.graphql.execution.SchemaPrinter;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 /**
  * Generate schema task.
@@ -54,6 +55,8 @@ public class GenerateSchemaTask extends DefaultTask {
     private boolean includeDirectives = false;
     private boolean includeSchemaDefinition = false;
     private boolean includeIntrospectionTypes = false;
+    private String typeAutoNameStrategy = "Default";
+    
     private File classesDir = new File(getProject().getBuildDir(), "classes");
 
     @Optional
@@ -155,6 +158,16 @@ public class GenerateSchemaTask extends DefaultTask {
         this.includeIntrospectionTypes = includeIntrospectionTypes;
     }
 
+    @Input
+    public String getTypeAutoNameStrategy() {
+        return typeAutoNameStrategy;
+    }
+
+    @Option(option = "type-auto-name-strategy", description = "The naming strategy to follow when creating types. Default, MergeInnerClass, Full ")
+    public void setTypeAutoNameStrategy(boolean includeIntrospectionTypes) {
+        this.typeAutoNameStrategy = typeAutoNameStrategy;
+    }
+    
     @Optional
     @InputDirectory
     public File getClassesDir() {
@@ -248,7 +261,8 @@ public class GenerateSchemaTask extends DefaultTask {
                 return includeIntrospectionTypes;
             }
         };
-        Schema internalSchema = SchemaBuilder.build(index);
+        TypeAutoNameStrategy autoNameStrategy = TypeAutoNameStrategy.valueOf(typeAutoNameStrategy);
+        Schema internalSchema = SchemaBuilder.build(index, autoNameStrategy);
         BootstrapedResult bootstraped = Bootstrap.bootstrap(internalSchema);
         if(bootstraped!=null){
             GraphQLSchema graphQLSchema = bootstraped.getGraphQLSchema();

--- a/tools/maven-plugin/src/main/java/io/smallrye/graphql/mavenplugin/GenerateSchemaMojo.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/graphql/mavenplugin/GenerateSchemaMojo.java
@@ -32,6 +32,7 @@ import io.smallrye.graphql.bootstrap.Config;
 import io.smallrye.graphql.execution.SchemaPrinter;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.schema.model.TypeAutoNameStrategy;
 
 @Mojo(name = "generate-schema", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class GenerateSchemaMojo extends AbstractMojo {
@@ -77,6 +78,9 @@ public class GenerateSchemaMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "false", property = "includeIntrospectionTypes")
     private boolean includeIntrospectionTypes;
+
+    @Parameter(defaultValue = "Default", property = "typeAutoNameStrategy")
+    private String typeAutoNameStrategy;
 
     @Parameter(defaultValue = "${project}")
     private MavenProject mavenProject;
@@ -164,7 +168,9 @@ public class GenerateSchemaMojo extends AbstractMojo {
                 return includeIntrospectionTypes;
             }
         };
-        Schema internalSchema = SchemaBuilder.build(index);
+
+        TypeAutoNameStrategy autoNameStrategy = TypeAutoNameStrategy.valueOf(typeAutoNameStrategy);
+        Schema internalSchema = SchemaBuilder.build(index, autoNameStrategy);
         BootstrapedResult bootstraped = Bootstrap.bootstrap(internalSchema);
         if (bootstraped != null) {
             GraphQLSchema graphQLSchema = bootstraped.getGraphQLSchema();


### PR DESCRIPTION
Fix #437
Fix #438

New config option that control the naming strategy. Default stay as is, but you can make inner classes merge names with their parent or use full package plus class name

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>