### PR TITLE
fix #444: send charset with Accept and Content-Type

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/GraphQlClientProxy.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/GraphQlClientProxy.java
@@ -2,6 +2,7 @@ package io.smallrye.graphql.client.typesafe.impl;
 
 import static java.util.stream.Collectors.joining;
 import static javax.json.JsonValue.ValueType.ARRAY;
+import static javax.ws.rs.client.Entity.entity;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 
@@ -14,8 +15,8 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonReaderFactory;
 import javax.json.JsonValue;
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.StatusType;
@@ -31,6 +32,7 @@ import io.smallrye.graphql.client.typesafe.impl.reflection.TypeInfo;
 
 class GraphQlClientProxy {
     private static final Logger log = LoggerFactory.getLogger(GraphQlClientProxy.class);
+    private static final MediaType APPLICATION_JSON_UTF8 = APPLICATION_JSON_TYPE.withCharset("utf-8");
 
     private static final JsonBuilderFactory jsonObjectFactory = Json.createBuilderFactory(null);
     private static final JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
@@ -104,9 +106,9 @@ class GraphQlClientProxy {
 
     private String post(String request, MultivaluedMap<String, Object> headers) {
         Response response = target
-                .request(APPLICATION_JSON_TYPE)
+                .request(APPLICATION_JSON_UTF8)
                 .headers(headers)
-                .post(Entity.json(request));
+                .post(entity(request, APPLICATION_JSON_UTF8));
         StatusType status = response.getStatusInfo();
         if (status.getFamily() != SUCCESSFUL)
             throw new GraphQlClientException("expected successful status code but got " +

--- a/client/implementation/src/test/java/test/unit/HeaderBehavior.java
+++ b/client/implementation/src/test/java/test/unit/HeaderBehavior.java
@@ -561,4 +561,21 @@ public class HeaderBehavior {
         then(fixture.sentHeader("H5")).isEqualTo("V5");
         then(fixture.sentHeader("overwrite")).isEqualTo("sub");
     }
+
+    @GraphQlClientApi
+    interface SimpleApi {
+        String greeting(String target);
+    }
+
+    @Test
+    public void shouldAddCharsetRequestAndResponseHeaders() {
+        fixture.returnsData("'greeting':'dummy-greeting'");
+        SimpleApi api = fixture.builder().build(SimpleApi.class);
+
+        api.greeting("foo");
+
+        then(fixture.query()).isEqualTo("greeting(target: 'foo')");
+        then(fixture.sentHeader("Content-Type")).hasToString("application/json;charset=utf-8");
+        then(fixture.sentHeader("Accept")).hasToString("application/json;charset=utf-8");
+    }
 }


### PR DESCRIPTION
The client sends the `charset=utf-8` with both the `Accept` as well as the `Content-Type` headers to fix encoding problems.