### PR TITLE
Ignore non type parameters of specialized implementation of generic type

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
@@ -196,12 +196,14 @@ public class ReferenceCreator {
                         }
                     }
                     parametrizedTypeArgumentsReferencesImpl = new HashMap<>();
-
                     int i = 0;
                     for (TypeVariable tp : classInfo.typeParameters()) {
-                        parametrizedTypeArgumentsReferencesImpl.put(
-                                interfaceType.arguments().get(i++).asTypeVariable().identifier(),
-                                parametrizedTypeArgumentsReferences.get(tp.identifier()));
+                        Type type = interfaceType.arguments().get(i++);
+                        if (type.kind() == Type.Kind.TYPE_VARIABLE) {
+                            parametrizedTypeArgumentsReferencesImpl.put(
+                                    type.asTypeVariable().identifier(),
+                                    parametrizedTypeArgumentsReferences.get(tp.identifier()));
+                        }
                     }
 
                 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/IndexCreator.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/IndexCreator.java
@@ -7,11 +7,13 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 
 public class IndexCreator {
-    public static Index index(Class<?> clazz) throws IOException {
+    public static Index index(Class<?>... clazzes) throws IOException {
         final Indexer indexer = new Indexer();
-        InputStream stream = IndexCreator.class.getClassLoader()
-                .getResourceAsStream(clazz.getName().replace('.', '/') + ".class");
-        indexer.index(stream);
+        for (Class<?> clazz : clazzes) {
+            InputStream stream = IndexCreator.class.getClassLoader()
+                    .getResourceAsStream(clazz.getName().replace('.', '/') + ".class");
+            indexer.index(stream);
+        }
         return indexer.complete();
     }
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/ReferenceCreatorTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/ReferenceCreatorTest.java
@@ -1,0 +1,57 @@
+package io.smallrye.graphql.schema.creator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.smallrye.graphql.schema.Annotations;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.graphql.schema.IndexCreator;
+import io.smallrye.graphql.schema.ScanningContext;
+import io.smallrye.graphql.schema.helper.TypeAutoNameStrategy;
+import io.smallrye.graphql.schema.model.Reference;
+import io.smallrye.graphql.schema.model.ReferenceType;
+
+public class ReferenceCreatorTest {
+
+    interface GenericInterface<T> {}
+
+    public static class TestOps {
+        public GenericInterface<String> getGenericInterface() {
+            return null;
+        }
+    }
+
+    public static class SpecializedImplementorOfGenericInterface implements GenericInterface<String> {
+    }
+
+    @Test
+    public void shouldCreateReferenceDespiteSpecializedImplementationOfInterface() throws Exception {
+        try {
+            ReferenceCreator referenceCreator = new ReferenceCreator(TypeAutoNameStrategy.Full);
+
+            Index index = IndexCreator.index(TestOps.class, GenericInterface.class, SpecializedImplementorOfGenericInterface.class);
+            ScanningContext.register(index);
+
+            ClassInfo testOps = index.getClassByName(DotName.createSimple(TestOps.class.getName()));
+            MethodInfo method = testOps.method("getGenericInterface");
+            Reference reference = referenceCreator.createReferenceForOperationField(method.returnType(), Annotations.getAnnotationsForMethod(method));
+
+            assertEquals("io_smallrye_graphql_schema_creator_ReferenceCreatorTestGenericInterface_String", reference.getName());
+            assertEquals("io.smallrye.graphql.schema.creator.ReferenceCreatorTest$GenericInterface",
+                    reference.getClassName());
+            assertEquals("io.smallrye.graphql.schema.creator.ReferenceCreatorTest$GenericInterface",
+                    reference.getGraphQlClassName());
+            assertEquals(ReferenceType.INTERFACE, reference.getType());
+            assertNull(reference.getMappingInfo());
+            assertFalse(reference.getParametrizedTypeArguments().isEmpty());
+            assertTrue(reference.isAddParametrizedTypeNameExtension());
+        } finally {
+            ScanningContext.remove();
+        }
+    }
+
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/ReferenceCreatorTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/ReferenceCreatorTest.java
@@ -2,13 +2,13 @@ package io.smallrye.graphql.schema.creator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.smallrye.graphql.schema.Annotations;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.MethodInfo;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.IndexCreator;
 import io.smallrye.graphql.schema.ScanningContext;
 import io.smallrye.graphql.schema.helper.TypeAutoNameStrategy;
@@ -17,7 +17,8 @@ import io.smallrye.graphql.schema.model.ReferenceType;
 
 public class ReferenceCreatorTest {
 
-    interface GenericInterface<T> {}
+    interface GenericInterface<T> {
+    }
 
     public static class TestOps {
         public GenericInterface<String> getGenericInterface() {
@@ -33,16 +34,17 @@ public class ReferenceCreatorTest {
         try {
             ReferenceCreator referenceCreator = new ReferenceCreator(TypeAutoNameStrategy.Full);
 
-            Index index = IndexCreator.index(TestOps.class, GenericInterface.class, SpecializedImplementorOfGenericInterface.class);
+            Index index = IndexCreator.index(TestOps.class, GenericInterface.class,
+                    SpecializedImplementorOfGenericInterface.class);
             ScanningContext.register(index);
 
             ClassInfo testOps = index.getClassByName(DotName.createSimple(TestOps.class.getName()));
             MethodInfo method = testOps.method("getGenericInterface");
-            Reference reference = referenceCreator.createReferenceForOperationField(method.returnType(), Annotations.getAnnotationsForMethod(method));
+            Reference reference = referenceCreator.createReferenceForOperationField(method.returnType(),
+                    Annotations.getAnnotationsForMethod(method));
 
             assertEquals("io_smallrye_graphql_schema_creator_ReferenceCreatorTestGenericInterface_String", reference.getName());
-            assertEquals("io.smallrye.graphql.schema.creator.ReferenceCreatorTest$GenericInterface",
-                    reference.getClassName());
+            assertEquals("io.smallrye.graphql.schema.creator.ReferenceCreatorTest$GenericInterface", reference.getClassName());
             assertEquals("io.smallrye.graphql.schema.creator.ReferenceCreatorTest$GenericInterface",
                     reference.getGraphQlClassName());
             assertEquals(ReferenceType.INTERFACE, reference.getType());
@@ -53,5 +55,4 @@ public class ReferenceCreatorTest {
             ScanningContext.remove();
         }
     }
-
 }


### PR DESCRIPTION
Proposed fix for https://github.com/smallrye/smallrye-graphql/issues/493

This issue is not specific to Map, but to all generic interface types that have specialized implementation.