### PR TITLE
Remove reference to Narayana code

### DIFF
--- a/server/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/IndexInitializer.java
+++ b/server/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/IndexInitializer.java
@@ -28,8 +28,6 @@ import org.jboss.jandex.Indexer;
 
 /**
  * This creates an index from the classpath.
- * Based on similar class in LRA
- * (https://github.com/jbosstm/narayana/blob/master/rts/lra/lra-proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/ClassPathIndexer.java)
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */


### PR DESCRIPTION
Removing reference to Narayana code since it is licensed under LGPL, but SmallRye GraphQL is licensed under Apache.  In this case, the IndexInitializer just uses similar patterns to the Narayana code - so it is not using the same IP - but removing the comment should prevent confusion.