### PR TITLE
Added Uni

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Classes.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Classes.java
@@ -134,7 +134,7 @@ public class Classes {
 
     @Deprecated
     private static boolean isAsyncType(Type type) {
-        return type.name().equals(COMPLETABLE_FUTURE) || type.name().equals(COMPLETION_STAGE);
+        return type.name().equals(COMPLETABLE_FUTURE) || type.name().equals(COMPLETION_STAGE) || type.name().equals(UNI);
     }
 
     /**
@@ -206,10 +206,13 @@ public class Classes {
         ;
     }
 
+    // TODO: This needs to be remove once Generics handling has moved to runtime.
     @Deprecated
     public static final DotName COMPLETABLE_FUTURE = DotName.createSimple(CompletableFuture.class.getName());
     @Deprecated
     public static final DotName COMPLETION_STAGE = DotName.createSimple(CompletionStage.class.getName());
+    @Deprecated
+    public static final DotName UNI = DotName.createSimple("io.smallrye.mutiny.Uni");
 
     public static final DotName COLLECTION = DotName.createSimple(Collection.class.getName());
     public static final DotName LIST = DotName.createSimple(List.class.getName());


### PR DESCRIPTION
Until all generics logic has moved to runtime, we need to 'hardcode' async providers
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>