### PR TITLE
typesafe client: `@OutputOnly`

### DIFF
--- a/client/api/src/main/java/io/smallrye/graphql/client/typesafe/api/OutputOnly.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/typesafe/api/OutputOnly.java
@@ -1,0 +1,14 @@
+package io.smallrye.graphql.client.typesafe.api;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+/**
+ * Allow this field only when the containing class is used as a <code>Type</code>s, but not
+ * when used as an <code>Input</code>. This happens when the GraphQL service has resolver
+ * methods (see the <code>@Source</code> annotation).
+ */
+@Retention(RUNTIME)
+public @interface OutputOnly {
+}

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/QueryBuilder.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/QueryBuilder.java
@@ -62,11 +62,12 @@ class QueryBuilder {
         if (type.isCollection())
             return fields(type.getItemType());
         return type.fields()
-                .map(this::field)
+                .filter(FieldInfo::isOutput)
+                .map(this::fieldName)
                 .collect(joining(" ", " {", "}"));
     }
 
-    private String field(FieldInfo field) {
+    private String fieldName(FieldInfo field) {
         TypeInfo type = field.getType();
         if (type.isScalar() || type.isCollection() && type.getItemType().isScalar()) {
             return field.getName();

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/ResultBuilder.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/ResultBuilder.java
@@ -30,13 +30,11 @@ import io.smallrye.graphql.client.typesafe.impl.reflection.MethodInvocation;
 
 public class ResultBuilder {
     private final MethodInvocation method;
-    private final Map<String, String> queryCache;
     private final JsonObject response;
     private JsonObject data;
 
-    public ResultBuilder(MethodInvocation method, Map<String, String> queryCache, String responseString) {
+    public ResultBuilder(MethodInvocation method, String responseString) {
         this.method = method;
-        this.queryCache = queryCache;
         this.response = Json.createReader(new StringReader(responseString)).readObject();
     }
 
@@ -141,5 +139,6 @@ public class ResultBuilder {
         return (jsonArray == null) ? null : jsonArray.stream().map(JsonUtils::toValue).collect(Collectors.toList());
     }
 
-    private static final JsonPatch ERROR_MARK = Json.createPatchBuilder().add("/__typename", ErrorOr.class.getSimpleName()).build();
+    private static final JsonPatch ERROR_MARK = Json.createPatchBuilder().add("/__typename", ErrorOr.class.getSimpleName())
+            .build();
 }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/FieldInfo.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/FieldInfo.java
@@ -2,10 +2,12 @@ package io.smallrye.graphql.client.typesafe.impl.reflection;
 
 import java.lang.reflect.Field;
 
+import org.eclipse.microprofile.graphql.Ignore;
 import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.NonNull;
 
 import io.smallrye.graphql.client.typesafe.api.GraphQlClientException;
+import io.smallrye.graphql.client.typesafe.api.OutputOnly;
 
 public class FieldInfo {
     private final TypeInfo container;
@@ -52,5 +54,13 @@ public class FieldInfo {
 
     public boolean isNonNull() {
         return field.isAnnotationPresent(NonNull.class) || getType().isPrimitive();
+    }
+
+    public boolean isInput() {
+        return !field.isAnnotationPresent(OutputOnly.class) && !field.isAnnotationPresent(Ignore.class);
+    }
+
+    public boolean isOutput() {
+        return !field.isAnnotationPresent(Ignore.class);
     }
 }


### PR DESCRIPTION
fixes #522 and a minor bug when an error has a path to a nested field but the container value is null