### PR TITLE
More resilient error handling in GQL client

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/ResultBuilder.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/ResultBuilder.java
@@ -55,6 +55,8 @@ public class ResultBuilder {
     }
 
     private void readErrors() {
+        if (!response.containsKey("errors") || response.isNull("errors"))
+            return;
         JsonArray jsonErrors = response.getJsonArray("errors");
         if (jsonErrors == null)
             return;


### PR DESCRIPTION
Some GraphQL server implementations return `errors` with the value `null`, which causes a `ClassCastException` during parsing of the response. This small change makes the parsing of the `errors` more resilient.