### PR TITLE
Align with MicroProfile 4.0 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,12 @@
     <url>http://smallrye.io</url>
 
     <properties>
-        <version.eclipse.microprofile.config>1.4</version.eclipse.microprofile.config>
+        <version.eclipse.microprofile.config>2.0</version.eclipse.microprofile.config>
         <version.eclipse.microprofile.graphql>1.0.3</version.eclipse.microprofile.graphql>
-        <version.eclipse.microprofile.metrics>2.3.2</version.eclipse.microprofile.metrics>
+        <version.eclipse.microprofile.metrics>3.0</version.eclipse.microprofile.metrics>
         <version.eclipse.microprofile.context-propagation>1.1</version.eclipse.microprofile.context-propagation>
-        <version.smallrye-config>1.10.0</version.smallrye-config>
-        <version.smallrye.metrics>2.4.1</version.smallrye.metrics>
+        <version.smallrye-config>2.0.0-RC3</version.smallrye-config>
+        <version.smallrye.metrics>3.0.0-RC2</version.smallrye.metrics>
         <version.smallrye-common>1.5.0</version.smallrye-common>
         <version.smallrye-mutiny>0.11.0</version.smallrye-mutiny>
         <version.smallrye-context-propagation>1.0.20</version.smallrye-context-propagation>
@@ -98,6 +98,11 @@
                 <groupId>org.eclipse.microprofile.metrics</groupId>
                 <artifactId>microprofile-metrics-api</artifactId>
                 <version>${version.eclipse.microprofile.metrics}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-metrics</artifactId>
+                <version>${version.smallrye.metrics}</version>
             </dependency>
 
             <dependency>

--- a/server/integration-tests/pom.xml
+++ b/server/integration-tests/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>microprofile-metrics-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-metrics</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- Bean Validation -->
         <dependency>
             <groupId>jakarta.validation</groupId>


### PR DESCRIPTION
**IMPORTANT NOTE:**
Once this is merged and released, GraphQL will only work for runtimes that have already moved to MicroProfile 4.0.
For Quarkus in particular, the goal is to release this and send an upgrade to the `microprofile-4` branch (https://github.com/quarkusio/quarkus/tree/microprofile-4) along with other MP 4.0 related upgrades, and then it will be merged to Quarkus master.

If we want to keep supporting MP 3.0 runtimes, we will have to keep a separate branch (1.0.x), and probably bump the version to 1.1.0 before releasing this. WildFly won't support MP 4.0 until March 2021 or so, so it might be a good idea to do that IMO. 