### PR TITLE
temporarily disable wildfly feature pack tests on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
         run: mvn -B formatter:validate impsort:check javadoc:javadoc install --file pom.xml
 
   wildfly-tests:
+    if: false # TODO: re-enable after the feature pack's master upgrades to WildFly aligned with MicroProfile 4.0
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
No reason to cause panic by failing tests when it's not possible to make them work until WildFly upgrades to MP 4