### PR TITLE
Upgrade to MP GraphQL 1.0.4-RC1, removed the override for default values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <version.eclipse.microprofile.config>1.4</version.eclipse.microprofile.config>
-        <version.eclipse.microprofile.graphql>1.0.3</version.eclipse.microprofile.graphql>
+        <version.eclipse.microprofile.graphql>1.0.4-RC1</version.eclipse.microprofile.graphql>
         <version.eclipse.microprofile.metrics>2.3.2</version.eclipse.microprofile.metrics>
         <version.eclipse.microprofile.context-propagation>1.1</version.eclipse.microprofile.context-propagation>
         <version.smallrye-config>1.10.0</version.smallrye-config>

--- a/server/tck/src/test/resources/overrides/schemaTests.csv
+++ b/server/tck/src/test/resources/overrides/schemaTests.csv
@@ -1,2 +1,0 @@
-# testJsonDefault
-59|type Mutation       |   provisionHero(hero: String, item: ItemInput = {dateCreated : "19 February 1900 at 12:00 in Africa/Johannesburg", dateLastUsed : "29 Jan 2020 at 09:45 in zone +0200", height : 1.2, id : 1000, name : "Cape", powerLevel : 3, supernatural : false, weight : 0.3}): SuperHero | Expecting a default value for item for provisionHero


### PR DESCRIPTION
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>