### PR TITLE
Allow running with Micrometer metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <version.yasson>1.0.8</version.yasson>
         <version.jakarta-validation>2.0.2</version.jakarta-validation>
         <version.graphql-java>16.2</version.graphql-java>
+        <verison.io.micrometer>1.6.4</verison.io.micrometer>
 
         <!-- Test -->
         <version.arquillian.jetty>1.0.0.CR3</version.arquillian.jetty>
@@ -110,6 +111,11 @@
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-metrics</artifactId>
                 <version>${version.smallrye.metrics}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>${verison.io.micrometer}</version>
             </dependency>
 
             <dependency>

--- a/server/implementation-cdi/pom.xml
+++ b/server/implementation-cdi/pom.xml
@@ -29,6 +29,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
             <scope>provided</scope>

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/metrics/MPMetricsService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/metrics/MPMetricsService.java
@@ -20,12 +20,12 @@ import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.spi.EventingService;
 
 /**
- * Listening for event and create metrics from it
+ * Listening for event and create metrics from it. Uses MP Metrics 3.x API.
  * 
  * @author Jan Martiska (jmartisk@redhat.com)
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
-public class MetricsService implements EventingService {
+public class MPMetricsService implements EventingService {
 
     private MetricRegistry metricRegistry;
     private final Map<Context, Long> startTimes = Collections.synchronizedMap(new IdentityHashMap<>());

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/metrics/MicrometerMetricsService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/metrics/MicrometerMetricsService.java
@@ -1,0 +1,66 @@
+package io.smallrye.graphql.cdi.metrics;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.smallrye.graphql.api.Context;
+import io.smallrye.graphql.cdi.config.ConfigKey;
+import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.spi.EventingService;
+
+public class MicrometerMetricsService implements EventingService {
+
+    private final MeterRegistry meterRegistry = Metrics.globalRegistry;
+    private final Map<Context, Long> startTimes = Collections.synchronizedMap(new IdentityHashMap<>());
+    private static final String METRIC_NAME = "mp_graphql";
+    private final String DESCRIPTION = "Call statistics for the operation denoted by the 'name' tag";
+
+    @Override
+    public Operation createOperation(Operation operation) {
+        final Tags tags = getTags(operation);
+        Timer.builder(METRIC_NAME)
+                .tags(tags)
+                .description(DESCRIPTION)
+                .register(meterRegistry);
+        return operation;
+    }
+
+    @Override
+    public void beforeDataFetch(Context context) {
+        startTimes.put(context, System.nanoTime());
+    }
+
+    @Override
+    public void afterDataFetch(Context context) {
+        Long startTime = startTimes.remove(context);
+        if (startTime != null) {
+            long duration = System.nanoTime() - startTime;
+            meterRegistry.timer(METRIC_NAME, getTags(context))
+                    .record(Duration.ofNanos(duration));
+        }
+    }
+
+    @Override
+    public String getConfigKey() {
+        return ConfigKey.ENABLE_METRICS;
+    }
+
+    private Tags getTags(Context context) {
+        return Tags.of("name", context.getFieldName())
+                .and("type", context.getOperationType())
+                .and("source", String.valueOf(context.getSource() != null));
+    }
+
+    private Tags getTags(Operation operation) {
+        return Tags.of("name", operation.getName())
+                .and("type", operation.getOperationType().toString())
+                .and("source", String.valueOf(operation.isSourceField()));
+    }
+
+}

--- a/server/implementation-cdi/src/main/resources/META-INF/services/io.smallrye.graphql.spi.EventingService
+++ b/server/implementation-cdi/src/main/resources/META-INF/services/io.smallrye.graphql.spi.EventingService
@@ -1,4 +1,3 @@
 io.smallrye.graphql.cdi.event.EventsService
 io.smallrye.graphql.cdi.validation.ValidationService
-io.smallrye.graphql.cdi.metrics.MetricsService
 io.smallrye.graphql.cdi.tracing.TracingService

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/MetricTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/metrics/MetricTest.java
@@ -62,6 +62,8 @@ public class MetricTest {
                 // END OF TEMPORARY HACK
                 .addAsResource(new StringAsset("smallrye.graphql.metrics.enabled=true"),
                         "META-INF/microprofile-config.properties")
+                .addAsResource(new StringAsset("io.smallrye.graphql.cdi.metrics.MPMetricsService"),
+                        "META-INF/services/io.smallrye.graphql.spi.EventingService")
                 .addClasses(DummyGraphQLApi.class, Foo.class);
     }
 


### PR DESCRIPTION
Not quite ready yet, needs more testing on WildFly and Quarkus side because runtimes will be broken by this

This adds a new implementation of MetricsService and because we don't know which one will be used, it moves the responsibility of adding the correct `META-INF/services/io.smallrye.graphql.spi.EventingService` entry from SmallRye to the runtime.

Fixes #384 