### PR TITLE
Add support for java.time.Instant (1.0.x)

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Classes.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Classes.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -116,7 +117,7 @@ public class Classes {
      */
     public static boolean isDateLikeTypeOrContainedIn(Type type) {
         return isTypeOrContainedIn(type, LOCALDATE, LOCALTIME, LOCALDATETIME, ZONEDDATETIME, OFFSETDATETIME, OFFSETTIME,
-                UTIL_DATE, SQL_DATE, SQL_TIMESTAMP, SQL_TIME);
+                UTIL_DATE, SQL_DATE, SQL_TIMESTAMP, SQL_TIME, INSTANT);
     }
 
     private static boolean isTypeOrContainedIn(Type type, DotName... valid) {
@@ -246,6 +247,7 @@ public class Classes {
     public static final DotName ZONEDDATETIME = DotName.createSimple(ZonedDateTime.class.getName());
     public static final DotName OFFSETDATETIME = DotName.createSimple(OffsetDateTime.class.getName());
     public static final DotName OFFSETTIME = DotName.createSimple(OffsetTime.class.getName());
+    public static final DotName INSTANT = DotName.createSimple(Instant.class.getName());
 
     public static final DotName PERIOD = DotName.createSimple(Period.class.getName());
     public static final DotName DURATION = DotName.createSimple(Duration.class.getName());

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
@@ -8,6 +8,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -130,10 +131,11 @@ public class Scalars {
         populateScalar(Timestamp.class.getName(), DATETIME, String.class.getName());
         populateScalar(ZonedDateTime.class.getName(), DATETIME, String.class.getName());
         populateScalar(OffsetDateTime.class.getName(), DATETIME, String.class.getName());
+        populateScalar(Instant.class.getName(), DATETIME, String.class.getName());
 
         // Duration
         populateScalar(Duration.class.getName(), DURATION, String.class.getName());
-        // Duration
+        // Period
         populateScalar(Period.class.getName(), PERIOD, String.class.getName());
     }
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/Classes.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/Classes.java
@@ -5,6 +5,7 @@ import static io.smallrye.graphql.SmallRyeGraphQLServerMessages.msg;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -94,6 +95,7 @@ public class Classes {
     public static final String ZONEDDATETIME = ZonedDateTime.class.getName();
     public static final String OFFSETDATETIME = OffsetDateTime.class.getName();
     public static final String OFFSETTIME = OffsetTime.class.getName();
+    public static final String INSTANT = Instant.class.getName();
 
     public static final String UTIL_DATE = Date.class.getName();
     public static final String SQL_DATE = java.sql.Date.class.getName();
@@ -166,6 +168,7 @@ public class Classes {
         DATES.add(LOCALDATE);
         DATES.add(LOCALTIME);
         DATES.add(LOCALDATETIME);
+        DATES.add(INSTANT);
         DATES.add(ZONEDDATETIME);
         DATES.add(OFFSETDATETIME);
         DATES.add(OFFSETTIME);

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/time/DateTimeScalar.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/time/DateTimeScalar.java
@@ -1,6 +1,7 @@
 package io.smallrye.graphql.scalar.time;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
@@ -15,7 +16,7 @@ public class DateTimeScalar extends AbstractDateScalar {
 
     public DateTimeScalar() {
         super("DateTime", LocalDateTime.class, Date.class, Timestamp.class, ZonedDateTime.class,
-                OffsetDateTime.class);
+                OffsetDateTime.class, Instant.class);
     }
 
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/transformation/DateTransformer.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/transformation/DateTransformer.java
@@ -9,7 +9,6 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
@@ -100,7 +99,7 @@ public class DateTransformer implements Transformer<Temporal, String> {
         defaultFormatter.put(OffsetDateTime.class.getName(), DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         defaultFormatter.put(ZonedDateTime.class.getName(), DateTimeFormatter.ISO_ZONED_DATE_TIME);
         defaultFormatter.put(Instant.class.getName(),
-                DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC)));
+                DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.systemDefault()));
         return defaultFormatter;
     }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/transformation/DateTransformer.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/transformation/DateTransformer.java
@@ -2,11 +2,14 @@ package io.smallrye.graphql.transformation;
 
 import static io.smallrye.graphql.SmallRyeGraphQLServerMessages.msg;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
@@ -67,6 +70,7 @@ public class DateTransformer implements Transformer<Temporal, String> {
         defaultFormatter.put(OffsetTime.class.getName(), OffsetTime::from);
         defaultFormatter.put(OffsetDateTime.class.getName(), OffsetDateTime::from);
         defaultFormatter.put(ZonedDateTime.class.getName(), ZonedDateTime::from);
+        defaultFormatter.put(Instant.class.getName(), Instant::from);
 
         return defaultFormatter;
     }
@@ -95,7 +99,8 @@ public class DateTransformer implements Transformer<Temporal, String> {
         defaultFormatter.put(OffsetTime.class.getName(), DateTimeFormatter.ISO_OFFSET_TIME);
         defaultFormatter.put(OffsetDateTime.class.getName(), DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         defaultFormatter.put(ZonedDateTime.class.getName(), DateTimeFormatter.ISO_ZONED_DATE_TIME);
-
+        defaultFormatter.put(Instant.class.getName(),
+                DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC)));
         return defaultFormatter;
     }
 }

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/scalars/api/AdditionalDateScalars.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/scalars/api/AdditionalDateScalars.java
@@ -2,6 +2,7 @@ package io.smallrye.graphql.test.apps.scalars.api;
 
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
@@ -12,9 +13,11 @@ public class AdditionalDateScalars {
     private final java.sql.Date sqlDate;
     private final Timestamp sqlTimestamp;
     private final Time sqlTime;
+    private final Instant now;
 
     public AdditionalDateScalars() {
-        this.date = Date.from(LocalDateTime.parse("2006-01-02T15:04:05.876").atZone(ZoneId.systemDefault()).toInstant());
+        this.now = LocalDateTime.parse("2006-01-02T15:04:05.876").atZone(ZoneId.of("Africa/Johannesburg")).toInstant();
+        this.date = Date.from(now);
         this.sqlDate = new java.sql.Date(date.getTime());
         this.sqlTimestamp = new Timestamp(date.getTime());
         this.sqlTime = new Time(date.getTime());
@@ -35,4 +38,9 @@ public class AdditionalDateScalars {
     public Time getSqlTime() {
         return sqlTime;
     }
+
+    public Instant getInstant() {
+        return now;
+    }
+
 }

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/scalars/api/AdditionalDateScalars.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/scalars/api/AdditionalDateScalars.java
@@ -16,7 +16,7 @@ public class AdditionalDateScalars {
     private final Instant now;
 
     public AdditionalDateScalars() {
-        this.now = LocalDateTime.parse("2006-01-02T15:04:05.876").atZone(ZoneId.of("Africa/Johannesburg")).toInstant();
+        this.now = LocalDateTime.parse("2006-01-02T15:04:05.876").atZone(ZoneId.systemDefault()).toInstant();
         this.date = Date.from(now);
         this.sqlDate = new java.sql.Date(date.getTime());
         this.sqlTimestamp = new Timestamp(date.getTime());

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/scalars/api/AdditionalDateScalarsApi.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/scalars/api/AdditionalDateScalarsApi.java
@@ -13,6 +13,10 @@ public class AdditionalDateScalarsApi {
         return new AdditionalDateScalars();
     }
 
+    public java.time.Instant instantInput(@Source AdditionalDateScalars additionalDateScalars, java.time.Instant instant) {
+        return instant;
+    }
+
     public java.util.Date dateInput(@Source AdditionalDateScalars additionalDateScalars, java.util.Date date) {
         return date;
     }
@@ -28,6 +32,11 @@ public class AdditionalDateScalarsApi {
 
     public java.sql.Time sqlTimeInput(@Source AdditionalDateScalars additionalDateScalars, java.sql.Time time) {
         return time;
+    }
+
+    public java.time.Instant instantDefault(@Source AdditionalDateScalars additionalDateScalars,
+            @DefaultValue("2006-01-02T15:04:05.876") java.time.Instant instant) {
+        return instant;
     }
 
     public java.util.Date dateDefault(@Source AdditionalDateScalars additionalDateScalars,

--- a/server/tck/src/test/resources/tests/scalars/date/input.graphql
+++ b/server/tck/src/test/resources/tests/scalars/date/input.graphql
@@ -15,5 +15,9 @@
     sqlTimestamp
     sqlTimestampInput(timestamp: "2006-01-02T15:04:05.876")
     sqlTimestampDefault
+
+    instant
+    instantInput(instant:"2006-01-02T15:04:05.876")
+    instantDefault
   }
 }

--- a/server/tck/src/test/resources/tests/scalars/date/output.json
+++ b/server/tck/src/test/resources/tests/scalars/date/output.json
@@ -15,7 +15,11 @@
 
       "sqlTimestamp": "2006-01-02T15:04:05.876",
       "sqlTimestampInput": "2006-01-02T15:04:05.876",
-      "sqlTimestampDefault": "2006-01-02T15:04:05.876"
+      "sqlTimestampDefault": "2006-01-02T15:04:05.876",
+            
+      "instant": "2006-01-02T13:04:05.876",
+      "instantInput": "2006-01-02T15:04:05.876",
+      "instantDefault": "2006-01-02T15:04:05.876"
     }
   }
 }

--- a/server/tck/src/test/resources/tests/scalars/date/output.json
+++ b/server/tck/src/test/resources/tests/scalars/date/output.json
@@ -17,7 +17,7 @@
       "sqlTimestampInput": "2006-01-02T15:04:05.876",
       "sqlTimestampDefault": "2006-01-02T15:04:05.876",
             
-      "instant": "2006-01-02T13:04:05.876",
+      "instant": "2006-01-02T15:04:05.876",
       "instantInput": "2006-01-02T15:04:05.876",
       "instantDefault": "2006-01-02T15:04:05.876"
     }

--- a/ui/graphiql/src/main/webapp/style.css
+++ b/ui/graphiql/src/main/webapp/style.css
@@ -13,3 +13,6 @@ body {
 .graphiql-container .execute-button{
     box-shadow:unset;
 }
+.history-contents>li:hover{
+    background-color: #00aada !important;
+}


### PR DESCRIPTION
This PR adds support for `java.time.Instant` as a DateTime type.

Fix #666

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>