### PR TITLE
Enable usage of `@JsonbCreator`

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
@@ -102,6 +102,16 @@ public class Annotations {
         }
     }
 
+    public static Annotations getAnnotationsForInputCreator(MethodInfo method, short position, FieldInfo fieldInfo) {
+        Map<DotName, AnnotationInstance> annotationsForField = getAnnotationsForField(fieldInfo, null);
+
+        if (fieldInfo != null) {
+            annotationsForField.putAll(getTypeUseAnnotations(fieldInfo.type()));
+        }
+        annotationsForField.putAll(getAnnotationsForArgument(method, position).annotationsMap);
+        return new Annotations(annotationsForField);
+    }
+
     /**
      * Get used when we create types and references to them
      * <p>
@@ -478,6 +488,7 @@ public class Annotations {
     public static final DotName JSONB_NUMBER_FORMAT = DotName.createSimple("javax.json.bind.annotation.JsonbNumberFormat");
     public static final DotName JSONB_PROPERTY = DotName.createSimple("javax.json.bind.annotation.JsonbProperty");
     public static final DotName JSONB_TRANSIENT = DotName.createSimple("javax.json.bind.annotation.JsonbTransient");
+    public static final DotName JSONB_CREATOR = DotName.createSimple("javax.json.bind.annotation.JsonbCreator");
 
     // Bean Validation Annotations (SmallRye extra, not part of the spec)
     public static final DotName BEAN_VALIDATION_NOT_NULL = DotName.createSimple("javax.validation.constraints.NotNull");

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
@@ -129,6 +129,31 @@ public class FieldCreator {
         return Optional.empty();
     }
 
+    public Optional<Field> createFieldForParameter(MethodInfo method, short position, FieldInfo fieldInfo,
+            Reference parentObjectReference) {
+        Annotations annotationsForPojo = Annotations.getAnnotationsForInputCreator(method, position, fieldInfo);
+
+        // Name
+        String name = getFieldName(Direction.IN, annotationsForPojo, method.parameterName(position));
+
+        // Field Type
+        Type fieldType = getFieldType(fieldInfo, method.parameters().get(position));
+
+        Reference reference = referenceCreator.createReferenceForPojoField(Direction.IN, fieldType,
+                method.parameters().get(position), annotationsForPojo, parentObjectReference);
+
+        String fieldName = fieldInfo != null ? fieldInfo.name() : null;
+        Field field = new Field(null, fieldName, name, reference);
+
+        // Wrapper
+        field.setWrapper(WrapperCreator.createWrapper(fieldType, method.parameters().get(position)).orElse(null));
+
+        configure2(field, method.parameters().get(position), annotationsForPojo);
+
+        return Optional.of(field);
+
+    }
+
     /**
      * Creates a field from a public field.
      * Used by Type and Input

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/IndexCreator.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/IndexCreator.java
@@ -1,18 +1,21 @@
 package io.smallrye.graphql.schema;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 
 public class IndexCreator {
-    public static Index index(Class<?>... clazzes) throws IOException {
+    public static Index index(Class<?>... clazzes) {
         final Indexer indexer = new Indexer();
         for (Class<?> clazz : clazzes) {
             InputStream stream = IndexCreator.class.getClassLoader()
                     .getResourceAsStream(clazz.getName().replace('.', '/') + ".class");
-            indexer.index(stream);
+            try {
+                indexer.index(stream);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
         return indexer.complete();
     }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/PojoWithConstructor.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/PojoWithConstructor.java
@@ -1,0 +1,13 @@
+package io.smallrye.graphql.schema.creator;
+
+import org.eclipse.microprofile.graphql.Name;
+
+public class PojoWithConstructor {
+
+    String field;
+
+    public PojoWithConstructor(
+            @Name("Foo") final String field) {
+        this.field = field;
+    }
+}

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/InputType.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/InputType.java
@@ -1,7 +1,6 @@
 package io.smallrye.graphql.schema.model;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Represent a GraphQL Input Type.
@@ -20,6 +19,11 @@ public final class InputType extends Reference {
     private String description;
 
     private Map<String, Field> fields = new LinkedHashMap<>();
+
+    /**
+     * All fields which are required by the creator method (e.g. {@code @JsonbCreator}).
+     */
+    private List<Field> creatorParameters = new ArrayList<>();
 
     public InputType() {
     }
@@ -55,5 +59,17 @@ public final class InputType extends Reference {
 
     public boolean hasField(String fieldName) {
         return this.fields.containsKey(fieldName);
+    }
+
+    public List<Field> getCreatorParameters() {
+        return creatorParameters;
+    }
+
+    public void setCreatorParameters(List<Field> creatorParameters) {
+        this.creatorParameters = creatorParameters;
+    }
+
+    public void addCreatorParameter(Field creatorParameter) {
+        this.creatorParameters.add(creatorParameter);
     }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
@@ -289,7 +289,13 @@ public class ArgumentHelper extends AbstractHelper {
             }
         }
 
-        // Create a valid jsonString from a map    
+        // make sure, all fields required by creator-method are set
+        for (final String s : InputFieldsInfo.getCreatorParameters(className)) {
+            // null should be safe, since primitive fields are already set (since marked as non null)
+            m.putIfAbsent(s, null);
+        }
+
+        // Create a valid jsonString from a map
         String jsonString = JsonBCreator.getJsonB().toJson(m);
         return correctComplexObjectFromJsonString(jsonString, field);
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/json/InputFieldsInfo.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/json/InputFieldsInfo.java
@@ -1,7 +1,10 @@
 package io.smallrye.graphql.json;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import io.smallrye.graphql.schema.model.Field;
@@ -16,12 +19,19 @@ public class InputFieldsInfo {
 
     private static final Map<String, Map<String, Field>> inputFieldTransformationMap = new HashMap<>();
     private static final Map<String, Map<String, Field>> inputFieldMappingMap = new HashMap<>();
+    private static final Map<String, List<String>> creatorParameters = new HashMap<>();
 
     private InputFieldsInfo() {
     }
 
     protected static void register(InputType inputType) {
         if (inputType.hasFields()) {
+            final ArrayList<String> creatorParameters = new ArrayList<>();
+            for (final Field creatorParameter : inputType.getCreatorParameters()) {
+                creatorParameters.add(creatorParameter.getName());
+            }
+            InputFieldsInfo.creatorParameters.put(inputType.getClassName(), creatorParameters);
+
             Map<String, Field> fieldsThatNeedsTransformation = new HashMap<>();
             Map<String, Field> fieldsThatNeedsMapping = new HashMap<>();
 
@@ -70,4 +80,12 @@ public class InputFieldsInfo {
         }
         return null;
     }
+
+    public static List<String> getCreatorParameters(String className) {
+        if (creatorParameters.containsKey(className)) {
+            return creatorParameters.get(className);
+        }
+        return Collections.emptyList();
+    }
+
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/json/JsonBCreator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/json/JsonBCreator.java
@@ -19,7 +19,9 @@ import io.smallrye.graphql.schema.model.InputType;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class JsonBCreator {
-    private static final Jsonb JSONB = JsonbBuilder.create(new JsonbConfig().withFormatting(true)); //default
+    private static final Jsonb JSONB = JsonbBuilder.create(new JsonbConfig()
+            .withFormatting(true)
+            .withNullValues(true)); //null values are required by @JsonbCreator
 
     private static final Map<String, Jsonb> jsonMap = new HashMap<>();
 

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/Indexer.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/Indexer.java
@@ -25,6 +25,10 @@ public class Indexer {
         return indexer.complete();
     }
 
+    public static IndexView getTestIndex(Class<?> clazz) {
+        return getTestIndex(clazz.getPackage().getName().replace('.', '/'));
+    }
+
     private static void indexDirectory(org.jboss.jandex.Indexer indexer, String baseDir) {
         InputStream directoryStream = getResourceAsStream(baseDir);
         BufferedReader reader = new BufferedReader(new InputStreamReader(directoryStream));

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/JsonbCreatorTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/JsonbCreatorTest.java
@@ -1,0 +1,131 @@
+package io.smallrye.graphql.execution;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+
+import org.jboss.jandex.IndexView;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.graphql.test.jsonbCreator.CreatorApi;
+
+public class JsonbCreatorTest extends ExecutionTestBase {
+
+    protected IndexView getIndex() {
+        return Indexer.getTestIndex(CreatorApi.class);
+    }
+
+    @Test
+    public void testWithValue() {
+        JsonObject data = executeAndGetData("{\n"
+                + "  withJsonbCreator(input: {field: \"A\"}) {\n"
+                + "    field\n"
+                + "  }\n"
+                + "}");
+
+        JsonObject testObject = data.getJsonObject("withJsonbCreator");
+        assertNotNull(testObject);
+
+        String field = testObject.getJsonString("field").getString();
+        assertEquals("A", field);
+    }
+
+    @Test
+    public void testWithStaticFactory() {
+        JsonObject data = executeAndGetData("{\n"
+                + "  withStaticFactory(input: {field: \"A\"}) {\n"
+                + "    field\n"
+                + "  }\n"
+                + "}");
+
+        JsonObject testObject = data.getJsonObject("withStaticFactory");
+        assertNotNull(testObject);
+
+        String field = testObject.getJsonString("field").getString();
+        assertEquals("A", field);
+    }
+
+    @Test
+    public void testWithMissingValue() {
+        JsonObject data = executeAndGetData("{\n"
+                + "  withJsonbCreator(input: {}) {\n"
+                + "    field\n"
+                + "  }\n"
+                + "}");
+
+        JsonObject testObject = data.getJsonObject("withJsonbCreator");
+
+        assertNotNull(testObject);
+        assertEquals(JsonValue.ValueType.NULL, testObject.get("field").getValueType());
+    }
+
+    @Test
+    public void testWithTransformation() {
+        JsonObject data = executeAndGetData("{\n"
+                + "  creatorWithTransformation(input: {field: \"1\"}) {\n"
+                + "    field\n"
+                + "  }\n"
+                + "}");
+
+        JsonObject testObject = data.getJsonObject("creatorWithTransformation");
+        assertNotNull(testObject);
+
+        String field = testObject.getJsonString("field").getString();
+        assertEquals("1", field);
+    }
+
+    @Test
+    public void testWithDefault() {
+        JsonObject data = executeAndGetData("{\n"
+                + "  creatorWithFieldDefault(input: {}) {\n"
+                + "    field\n"
+                + "  }\n"
+                + "}");
+
+        JsonObject testObject = data.getJsonObject("creatorWithFieldDefault");
+
+        assertNotNull(testObject);
+
+        String field = testObject.getJsonString("field").getString();
+        assertEquals("Some value", field);
+    }
+
+    @Test
+    public void testWithParameterDefault() {
+        JsonObject data = executeAndGetData("{\n"
+                + "  creatorWithParameterDefault(input: {}) {\n"
+                + "    field\n"
+                + "  }\n"
+                + "}");
+
+        JsonObject testObject = data.getJsonObject("creatorWithParameterDefault");
+        assertNotNull(testObject);
+
+        String field = testObject.getJsonString("field").getString();
+        assertEquals("Some value", field);
+    }
+
+    @Test
+    public void testWithMultipleParameters() {
+        JsonObject data = executeAndGetData("{\n"
+                + "  creatorWithMultipleParameters(input: {string: \"Foobar\", localDate:\"2021-01-01\"}) {\n"
+                + "    string\n"
+                + "    integer\n"
+                + "    localDate\n"
+                + "  }\n"
+                + "}");
+
+        JsonObject testObject = data.getJsonObject("creatorWithMultipleParameters");
+        assertNotNull(testObject);
+
+        String string = testObject.getJsonString("string").getString();
+        assertEquals("Foobar", string);
+
+        JsonValue integer = testObject.get("integer");
+        assertEquals(JsonValue.ValueType.NULL, integer.getValueType());
+
+        String localDate = testObject.getJsonString("localDate").getString();
+        assertEquals("2021-01-01", localDate);
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/CreatorApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/CreatorApi.java
@@ -1,0 +1,38 @@
+package io.smallrye.graphql.test.jsonbCreator;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class CreatorApi {
+    @Query
+    public WithJsonbCreator withJsonbCreator(WithJsonbCreator input) {
+        return input;
+    }
+
+    @Query
+    public CreatorWithTransformation creatorWithTransformation(CreatorWithTransformation input) {
+        return input;
+    }
+
+    @Query
+    public CreatorWithFieldDefault creatorWithFieldDefault(CreatorWithFieldDefault input) {
+        return input;
+    }
+
+    @Query
+    public CreatorWithParameterDefault creatorWithParameterDefault(CreatorWithParameterDefault input) {
+        return input;
+    }
+
+    @Query
+    public CreatorWithMultipleParameters creatorWithMultipleParameters(CreatorWithMultipleParameters input) {
+        return input;
+    }
+
+    @Query
+    public WithStaticFactory withStaticFactory(WithStaticFactory input) {
+        return input;
+    }
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/CreatorWithFieldDefault.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/CreatorWithFieldDefault.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.test.jsonbCreator;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+import org.eclipse.microprofile.graphql.DefaultValue;
+
+public class CreatorWithFieldDefault {
+
+    @DefaultValue("Some value")
+    private final String field;
+
+    @JsonbCreator
+    public CreatorWithFieldDefault(@JsonbProperty("field") final String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/CreatorWithMultipleParameters.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/CreatorWithMultipleParameters.java
@@ -1,0 +1,34 @@
+package io.smallrye.graphql.test.jsonbCreator;
+
+import java.time.LocalDate;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+public class CreatorWithMultipleParameters {
+
+    private final String string;
+    private final Integer integer;
+    private final LocalDate localDate;
+
+    @JsonbCreator
+    public CreatorWithMultipleParameters(@JsonbProperty("string") final String string,
+            @JsonbProperty("integer") final Integer integer,
+            @JsonbProperty("localDate") final LocalDate localDate) {
+        this.string = string;
+        this.integer = integer;
+        this.localDate = localDate;
+    }
+
+    public String getString() {
+        return string;
+    }
+
+    public Integer getInteger() {
+        return integer;
+    }
+
+    public LocalDate getLocalDate() {
+        return localDate;
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/CreatorWithParameterDefault.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/CreatorWithParameterDefault.java
@@ -1,0 +1,21 @@
+package io.smallrye.graphql.test.jsonbCreator;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+import org.eclipse.microprofile.graphql.DefaultValue;
+
+public class CreatorWithParameterDefault {
+
+    private final String field;
+
+    @JsonbCreator
+    public CreatorWithParameterDefault(@JsonbProperty("field") @DefaultValue("Some value") final String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/CreatorWithTransformation.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/CreatorWithTransformation.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.test.jsonbCreator;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+import org.eclipse.microprofile.graphql.NumberFormat;
+
+public class CreatorWithTransformation {
+
+    @NumberFormat
+    private final Integer field;
+
+    @JsonbCreator
+    public CreatorWithTransformation(@JsonbProperty("field") final Integer field) {
+        this.field = field;
+    }
+
+    public Integer getField() {
+        return field;
+    }
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/WithJsonbCreator.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/WithJsonbCreator.java
@@ -1,0 +1,18 @@
+package io.smallrye.graphql.test.jsonbCreator;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+public class WithJsonbCreator {
+
+    private final String field;
+
+    @JsonbCreator
+    public WithJsonbCreator(@JsonbProperty("field") final String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/WithStaticFactory.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/jsonbCreator/WithStaticFactory.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.test.jsonbCreator;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+public class WithStaticFactory {
+
+    private final String field;
+
+    private WithStaticFactory(final String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    @JsonbCreator
+    public static WithStaticFactory create(@JsonbProperty("field") String field) {
+        return new WithStaticFactory(field);
+    }
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/SmallRyeGraphQLArchiveProcessor.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/SmallRyeGraphQLArchiveProcessor.java
@@ -14,6 +14,7 @@ import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import io.smallrye.graphql.test.apps.async.api.AsyncApi;
 import io.smallrye.graphql.test.apps.batch.api.BatchApi;
 import io.smallrye.graphql.test.apps.context.api.ContextApi;
+import io.smallrye.graphql.test.apps.creators.api.CreatorApi;
 import io.smallrye.graphql.test.apps.defaultvalue.api.DefaultValueParrotAPI;
 import io.smallrye.graphql.test.apps.error.api.ErrorApi;
 import io.smallrye.graphql.test.apps.fieldexistence.api.FieldExistenceApi;
@@ -92,6 +93,7 @@ public class SmallRyeGraphQLArchiveProcessor implements ApplicationArchiveProces
             war.addPackage(BatchApi.class.getPackage());
             war.addPackage(MappingResource.class.getPackage());
             war.addPackage(FieldExistenceApi.class.getPackage());
+            war.addPackage(CreatorApi.class.getPackage());
 
         }
     }

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/CreatorApi.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/CreatorApi.java
@@ -1,0 +1,39 @@
+package io.smallrye.graphql.test.apps.creators.api;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class CreatorApi {
+
+    @Query
+    public WithJsonbCreator withJsonbCreator(WithJsonbCreator input) {
+        return input;
+    }
+
+    @Query
+    public CreatorWithTransformation creatorWithTransformation(CreatorWithTransformation input) {
+        return input;
+    }
+
+    @Query
+    public CreatorWithFieldDefault creatorWithFieldDefault(CreatorWithFieldDefault input) {
+        return input;
+    }
+
+    @Query
+    public CreatorWithParameterDefault creatorWithParameterDefault(CreatorWithParameterDefault input) {
+        return input;
+    }
+
+    @Query
+    public CreatorWithMultipleParameters creatorWithMultipleParameters(CreatorWithMultipleParameters input) {
+        return input;
+    }
+
+    @Query
+    public WithStaticFactory withStaticFactory(WithStaticFactory input) {
+        return input;
+    }
+
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/CreatorWithFieldDefault.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/CreatorWithFieldDefault.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.test.apps.creators.api;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+import org.eclipse.microprofile.graphql.DefaultValue;
+
+public class CreatorWithFieldDefault {
+
+    @DefaultValue("Some value")
+    private final String field;
+
+    @JsonbCreator
+    public CreatorWithFieldDefault(@JsonbProperty("field") final String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/CreatorWithMultipleParameters.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/CreatorWithMultipleParameters.java
@@ -1,0 +1,34 @@
+package io.smallrye.graphql.test.apps.creators.api;
+
+import java.time.LocalDate;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+public class CreatorWithMultipleParameters {
+
+    private final String string;
+    private final Integer integer;
+    private final LocalDate localDate;
+
+    @JsonbCreator
+    public CreatorWithMultipleParameters(@JsonbProperty("string") final String string,
+            @JsonbProperty("integer") final Integer integer,
+            @JsonbProperty("localDate") final LocalDate localDate) {
+        this.string = string;
+        this.integer = integer;
+        this.localDate = localDate;
+    }
+
+    public String getString() {
+        return string;
+    }
+
+    public Integer getInteger() {
+        return integer;
+    }
+
+    public LocalDate getLocalDate() {
+        return localDate;
+    }
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/CreatorWithParameterDefault.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/CreatorWithParameterDefault.java
@@ -1,0 +1,21 @@
+package io.smallrye.graphql.test.apps.creators.api;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+import org.eclipse.microprofile.graphql.DefaultValue;
+
+public class CreatorWithParameterDefault {
+
+    private final String field;
+
+    @JsonbCreator
+    public CreatorWithParameterDefault(@JsonbProperty("field") @DefaultValue("Some value") final String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/CreatorWithTransformation.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/CreatorWithTransformation.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.test.apps.creators.api;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+import org.eclipse.microprofile.graphql.NumberFormat;
+
+public class CreatorWithTransformation {
+
+    @NumberFormat
+    private final Integer field;
+
+    @JsonbCreator
+    public CreatorWithTransformation(@JsonbProperty("field") final Integer field) {
+        this.field = field;
+    }
+
+    public Integer getField() {
+        return field;
+    }
+
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/WithJsonbCreator.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/WithJsonbCreator.java
@@ -1,0 +1,18 @@
+package io.smallrye.graphql.test.apps.creators.api;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+public class WithJsonbCreator {
+
+    private final String field;
+
+    @JsonbCreator
+    public WithJsonbCreator(@JsonbProperty("field") final String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/WithStaticFactory.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/creators/api/WithStaticFactory.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.test.apps.creators.api;
+
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+
+public class WithStaticFactory {
+
+    private final String field;
+
+    private WithStaticFactory(final String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    @JsonbCreator
+    public static WithStaticFactory create(@JsonbProperty("field") String field) {
+        return new WithStaticFactory(field);
+    }
+}

--- a/server/tck/src/test/resources/tests/creator/input.graphql
+++ b/server/tck/src/test/resources/tests/creator/input.graphql
@@ -1,0 +1,22 @@
+{
+    withJsonbCreator(input: {field: "ABC"}) {
+        field
+    }
+    creatorWithTransformation(input: {field: "123 "}) {
+        field
+    }
+    creatorWithFieldDefault(input: {}) {
+        field
+    }
+    creatorWithParameterDefault(input: {}) {
+        field
+    }
+    creatorWithMultipleParameters(input: {string: "ABC", integer: 123, localDate:"2021-01-01"}) {
+        string
+        integer
+        localDate
+    }
+    withStaticFactory(input: {field: "ABC"}) {
+        field
+    }
+}

--- a/server/tck/src/test/resources/tests/creator/output.json
+++ b/server/tck/src/test/resources/tests/creator/output.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "withJsonbCreator": {
+      "field": "ABC"
+    },
+    "creatorWithTransformation": {
+      "field": "123"
+    },
+    "creatorWithFieldDefault": {
+      "field": "Some value"
+    },
+    "creatorWithParameterDefault": {
+      "field": "Some value"
+    },
+    "creatorWithMultipleParameters": {
+      "string": "ABC",
+      "integer": 123,
+      "localDate": "2021-01-01"
+    },
+    "withStaticFactory": {
+      "field": "ABC"
+    }
+  }
+}

--- a/server/tck/src/test/resources/tests/creator/test.properties
+++ b/server/tck/src/test/resources/tests/creator/test.properties
@@ -1,0 +1,2 @@
+ignore=false
+priority=100


### PR DESCRIPTION
Allows to use constructor or factory methods instead of just setters or public fields for input types.

Can backport this to 1.0.x, but would wait for a backport of #628 if any is planned?

----
Closes #705.