### PR TITLE
#627: change `@Multiple` target from `METHOD` to `TYPE`

### DIFF
--- a/client/api/README.adoc
+++ b/client/api/README.adoc
@@ -219,10 +219,10 @@ Say you need the result from several root queries, e.g. all `superHeroes` and al
 -----------------------------------------------------------
 @GraphQlClientApi
 interface SuperHeroesApi {
-    @Multiple
     HeroesAndVillains heroesAndVillains();
 }
 
+@Multiple
 class HeroesAndVillains {
     List<SuperHero> superHeroes;
     List<SuperVillain> superVillains;
@@ -248,6 +248,6 @@ The actual response below will be mapped to an instance of the `HeroesAndVillain
 }
 -----------------------------------------------------------
 
-If the nested queries require parameters, use `@<<NestedParameter>>` annotations.
+If the nested queries require parameters, use `@<<NestedParameter>>` annotations to put them on the field (remember: GraphQL fields can have parameters).
 
 If you need the same request several times (e.g. with different query parameters), use `@Name` annotations, so the actual field names are used as <<Name Mapping / Aliases,alias>>.

--- a/client/api/src/main/java/io/smallrye/graphql/client/typesafe/api/Multiple.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/typesafe/api/Multiple.java
@@ -1,6 +1,6 @@
 package io.smallrye.graphql.client.typesafe.api;
 
-import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
@@ -16,10 +16,10 @@ import java.lang.annotation.Target;
  * <pre>
  * &#64;GraphQlClientApi
  * interface FooAndBarApi {
- *     &#64;Multiple
  *     FooAndBar fooAndBar(&#64;NestedParameter("bar") String id);
  * }
  *
+ * &#64;Multiple
  * static class FooAndBar {
  *     Foo foo;
  *     Bar bar;
@@ -40,6 +40,6 @@ import java.lang.annotation.Target;
  * </pre>
  */
 @Retention(RUNTIME)
-@Target(METHOD)
+@Target(TYPE)
 public @interface Multiple {
 }

--- a/client/implementation-jaxrs/src/main/java/io/smallrye/graphql/client/typesafe/jaxrs/JaxRsTypesafeGraphQLClientProxy.java
+++ b/client/implementation-jaxrs/src/main/java/io/smallrye/graphql/client/typesafe/jaxrs/JaxRsTypesafeGraphQLClientProxy.java
@@ -76,7 +76,7 @@ class JaxRsTypesafeGraphQLClientProxy {
 
     private JsonObjectBuilder variables(MethodInvocation method) {
         JsonObjectBuilder builder = Json.createObjectBuilder();
-        method.valueParameters().forEach(parameter -> builder.add(parameter.getName(), value(parameter.getValue())));
+        method.valueParameters().forEach(parameter -> builder.add(parameter.getRawName(), value(parameter.getValue())));
         return builder;
     }
 

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/QueryBuilder.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/QueryBuilder.java
@@ -44,11 +44,11 @@ public class QueryBuilder {
     }
 
     private String declare(ParameterInfo parameter) {
-        return "$" + parameter.getName() + ": " + parameter.graphQlInputTypeName();
+        return "$" + parameter.getRawName() + ": " + parameter.graphQlInputTypeName();
     }
 
     private String bind(ParameterInfo parameter) {
-        return parameter.getName() + ": $" + parameter.getName();
+        return parameter.getName() + ": $" + parameter.getRawName();
     }
 
     private String fields(TypeInfo type) {
@@ -82,7 +82,7 @@ public class QueryBuilder {
         field.getAlias().ifPresent(alias -> expression.append(alias).append(":"));
         expression.append(field.getName());
         if (!type.isScalar() && (!type.isCollection() || !type.getItemType().isScalar())) {
-            String path = nestedExpressionPrefix() + field.getName();
+            String path = nestedExpressionPrefix() + field.getRawName();
             if (method.hasNestedParameters(path))
                 expression.append(method.nestedParameters(path)
                         .map(this::bind)

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/FieldInfo.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/FieldInfo.java
@@ -19,7 +19,7 @@ public class FieldInfo {
 
     @Override
     public String toString() {
-        return "field '" + field.getName() + "' in " + container;
+        return "field '" + getRawName() + "' in " + container;
     }
 
     public TypeInfo getType() {
@@ -29,13 +29,17 @@ public class FieldInfo {
     public String getName() {
         if (field.isAnnotationPresent(Name.class))
             return field.getAnnotation(Name.class).value();
+        return getRawName();
+    }
+
+    public String getRawName() {
         return field.getName();
     }
 
     /** If the field is renamed with a {@link Name} annotation, the real field name is used as an alias. */
     public Optional<String> getAlias() {
         if (field.isAnnotationPresent(Name.class))
-            return Optional.of(field.getName());
+            return Optional.of(getRawName());
         return Optional.empty();
     }
 

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/ParameterInfo.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/ParameterInfo.java
@@ -109,6 +109,10 @@ public class ParameterInfo {
                     "You can either annotate all parameters with @Name, " +
                     "or compile your source code with the -parameters options, " +
                     "so the parameter names are compiled into the class file and available at runtime.");
+        return getRawName();
+    }
+
+    public String getRawName() {
         return parameter.getName();
     }
 
@@ -117,7 +121,7 @@ public class ParameterInfo {
     }
 
     public boolean isHeaderParameter() {
-        return parameter.getAnnotationsByType(Header.class).length > 0;
+        return parameter.isAnnotationPresent(Header.class);
     }
 
     public boolean isValueParameter() {
@@ -129,7 +133,7 @@ public class ParameterInfo {
     }
 
     public boolean isNestedParameter() {
-        return parameter.getAnnotationsByType(NestedParameter.class).length > 0;
+        return parameter.isAnnotationPresent(NestedParameter.class);
     }
 
     public String getNestedParameterName() {

--- a/client/tck/src/test/java/test/unit/ErrorBehavior.java
+++ b/client/tck/src/test/java/test/unit/ErrorBehavior.java
@@ -419,7 +419,7 @@ class ErrorBehavior {
     @Test
     void shouldFetchFullWrapper() {
         fixture.returns("{\"data\":{\"find\":{" +
-                "\"superHeroes\":[{\"name\":\"Spider Man\",\"location\":\"New York\"}]," +
+                "\"superHeroes\":[{\"name\":\"Spider-Man\",\"location\":\"New York\"}]," +
                 "\"teams\":[{\"name\":\"Avengers\"}]" +
                 "}}}");
         SuperHeroWrappedApi api = fixture.build(SuperHeroWrappedApi.class);
@@ -432,7 +432,7 @@ class ErrorBehavior {
             ErrorOr<SuperHero> superHero = response.superHeroes.get(0);
             then(superHero.isPresent()).isTrue();
             then(superHero.isError()).isFalse();
-            then(superHero.get().name).isEqualTo("Spider Man");
+            then(superHero.get().name).isEqualTo("Spider-Man");
             then(superHero.get().location.isPresent()).isTrue();
             then(superHero.get().location.isError()).isFalse();
             then(superHero.get().location.get()).isEqualTo("New York");

--- a/client/tck/src/test/java/test/unit/ParametersBehavior.java
+++ b/client/tck/src/test/java/test/unit/ParametersBehavior.java
@@ -17,8 +17,6 @@ import org.eclipse.microprofile.graphql.Type;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.client.typesafe.api.GraphQlClientApi;
-import io.smallrye.graphql.client.typesafe.api.Multiple;
-import io.smallrye.graphql.client.typesafe.api.NestedParameter;
 
 class ParametersBehavior {
     private final GraphQlClientFixture fixture = new GraphQlClientFixture();
@@ -609,36 +607,5 @@ class ParametersBehavior {
         then(fixture.variables()).isEqualTo("{'who':123}");
         then(fixture.operationName()).isEqualTo("greeting");
         then(greeting).isEqualTo("hi, foo");
-    }
-
-    @GraphQlClientApi
-    interface FooAndBarApi {
-        @Multiple
-        FooAndBar fooAndBar(@NestedParameter("bar") @NonNull @Name("id") String barId);
-    }
-
-    static class FooAndBar {
-        Foo foo;
-        Bar bar;
-    }
-
-    static class Foo {
-        String name;
-    }
-
-    static class Bar {
-        String name;
-    }
-
-    @Test
-    void shouldQueryWithMultiple() {
-        fixture.returnsData("'foo': {'name': 'foo'}, 'bar': {'name': 'bar'}");
-        FooAndBarApi stuff = fixture.build(FooAndBarApi.class);
-
-        FooAndBar fooAndBar = stuff.fooAndBar("bar-id");
-
-        then(fixture.query()).isEqualTo("query fooAndBar($id: String!) {foo {name} bar(id: $id) {name}}");
-        then(fooAndBar.foo.name).isEqualTo("foo");
-        then(fooAndBar.bar.name).isEqualTo("bar");
     }
 }

--- a/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/CdiExecutionTest.java
+++ b/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/CdiExecutionTest.java
@@ -296,7 +296,7 @@ public class CdiExecutionTest {
         JsonArray errors = executeAndGetError(MUTATION_INVALID_NUMBER_SCALAR);
 
         assertEquals(1, errors.size(),
-                "Wrong size for errors while updateItemPowerLevel with wrong numner");
+                "Wrong size for errors while updateItemPowerLevel with wrong number");
 
         JsonObject error = errors.getJsonObject(0);
 
@@ -382,7 +382,7 @@ public class CdiExecutionTest {
     private static final String DATA = "data";
     private static final String ERRORS = "errors";
 
-    // This test a cenario where the inputfield and typefield is named different
+    // This test a scenario where the inputfield and typefield is named different
     private static final String MUTATION_NAME_DIFF_ON_INPUT_AND_TYPE = "mutation inputFieldWithAnotherName {\n" +
             "   createNewHero (hero: {\n" +
             "    realName: \"Steven Rogers\"\n" +
@@ -604,11 +604,11 @@ public class CdiExecutionTest {
             "}";
 
     // Create the CDI Beans in the TCK Tests app
-    private static final Class heroFinder;
-    private static final Class heroDatabase;
-    private static final Class sidekickDatabase;
-    private static final Class heroLocator;
-    private static final Class scalarTestApi;
+    private static final Class<?> heroFinder;
+    private static final Class<?> heroDatabase;
+    private static final Class<?> sidekickDatabase;
+    private static final Class<?> heroLocator;
+    private static final Class<?> scalarTestApi;
 
     private static final Map<String, Object> JSON_PROPERTIES = new HashMap<>(1);
 


### PR DESCRIPTION
As discussed in the last meeting. This is actually a breaking change, but IIRC it hasn't been released yet.

And more sensible test, which discovered a bug: we need to use raw field names for variable names (important for multiple parameters/fields mapped to the same name)

And some typos