### PR TITLE
Dynamic client documentation

### DIFF
--- a/client/README-dynamic-client.adoc
+++ b/client/README-dynamic-client.adoc
@@ -1,0 +1,89 @@
+= SmallRye GraphQL Dynamic Client
+:toc2:
+
+A Java GraphQL client. The main difference from the typesafe client is that while the typesafe client
+behaves like a typesafe proxy very similar to the MicroProfile REST Client, the dynamic client
+is more like the JAX-RS client from the `javax.ws.rs.client` package. Instead of working with model
+classes directly, the dynamic client focuses on programmatically working with GraphQL documents
+representing GraphQL requests and responses. It still offers the option to convert between documents
+and model classes when necessary.
+
+In the current implementation, Vert.x HTTP client is used for handling the underlying traffic.
+
+== Basic Usage
+
+Given the following GraphQL service on the server side:
+
+[source,java]
+----
+@GraphQLApi
+class SuperHeroesApi {
+    @Query
+    List<SuperHero> allHeroesIn(String location) {
+        // ....
+    }
+}
+
+class SuperHero {
+    private String name;
+    private List<String> superPowers;
+}
+----
+
+Such service can be queried this way:
+[source]
+----
+Document document = document(      // <1>
+    operation(field("allHeroesIn",
+        args(arg("location", Outer Space")),
+        field("name"),
+        field("superPowers"))));
+Response response = client.executeSync(document);  // <2>
+
+JsonArray heroesArray = response.getData().getJsonArray("allHeroesIn");  // <3>
+List<SuperHero> heroes = response.getList(SuperHero.class, "allHeroesIn"); // <4>
+----
+
+<1> Creating the document representing the request. We used static imports to make the code easy to read,
+they all come from the classes in the `io.smallrye.graphql.client.core` package.
+
+<2> Executing the request. You can either do that in a blocking way, or request a `Uni` if you
+prefer the reactive style.
+
+<3> Obtaining the resulting list of heroes as a `JsonArray`.
+
+<4> Obtaining the resulting list of heroes as instances of the model class.
+
+== Initializing the client instance
+
+There are two ways to obtain a client instance.
+
+Using CDI injection where the configuration values are defined in system properties:
+
+[source]
+----
+@Inject
+@NamedClient("superheroes")
+DynamicGraphQLClient client;
+
+// assuming that this system property exists:
+// superheroes/mp-graphql/url=https://superheroes.org/graphql
+----
+
+Programmatically using a builder:
+
+[source]
+----
+DynamicGraphQLClient client = DynamicGraphQLClientBuilder.newBuilder()
+    .url("https://superheroes.org/graphql")
+    .build()
+----
+
+== Configuration properties
+
+These properties apply when you're using CDI to inject named client instances (the first example
+in the previous section).
+
+- `CLIENT_NAME/mp-graphql/url` - defines the URL where the client should donnect
+- `CLIENT_NAME/mp-graphql/header/KEY` - this property declares that the client will add a HTTP header
+named `KEY` to all requests (with a value being the value of this property)

--- a/client/README-typesafe-client.adoc
+++ b/client/README-typesafe-client.adoc
@@ -1,4 +1,4 @@
-= SmallRye GraphQL Client
+= SmallRye GraphQL Typesafe Client
 :toc2:
 
 A Java code-first type-safe GraphQL Client API suggestion for https://github.com/eclipse/microprofile-graphql/issues/185[Microprofile GraphQL Issue #185].


### PR DESCRIPTION
Initial docs for the dynamic client. Planning to add more text later.

This also moves the typesafe client docs from `client/api` to `client`, I'd say it's better (especially given how many submodules the `client` directory has now)