### PR TITLE
Fix/Refactor CollectionCreator

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -753,7 +753,7 @@ public class Bootstrap {
             if (wrapper != null && wrapper.isCollectionOrArray()) {
                 type = classloadingService.loadClass(field.getWrapper().getWrapperClassName());
                 if (Collection.class.isAssignableFrom(type)) {
-                    type = CollectionCreator.newCollection(field.getWrapper().getWrapperClassName()).getClass();
+                    type = CollectionCreator.newCollection(field.getWrapper().getWrapperClassName(), 0).getClass();
                 }
             } else {
                 type = classloadingService.loadClass(field.getReference().getClassName());

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/CollectionCreator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/CollectionCreator.java
@@ -2,11 +2,7 @@ package io.smallrye.graphql.execution.datafetcher;
 
 import static io.smallrye.graphql.SmallRyeGraphQLServerLogging.log;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import io.smallrye.graphql.spi.ClassloadingService;
 
@@ -41,9 +37,20 @@ public class CollectionCreator {
         } catch (Exception ex) {
             log.noArgConstructorMissing(type == null ? "null" : type.getName());
         }
-        if (Set.class.isAssignableFrom(type)) {
+
+        if (type.isAssignableFrom(HashSet.class)) {
             return new HashSet<>();
         }
-        return new ArrayList<>();
+        if (type.isAssignableFrom(ArrayList.class)) {
+            return new ArrayList<>();
+        }
+        if (type.isAssignableFrom(TreeSet.class)) {
+            return new TreeSet<>();
+        }
+        if (type.isAssignableFrom(ArrayDeque.class)) {
+            return new ArrayDeque<>();
+        }
+
+        throw new IllegalArgumentException("Could not create collection if type " + type.getName());
     }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/CollectionCreator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/CollectionCreator.java
@@ -32,23 +32,23 @@ public class CollectionCreator {
      * @return the collection
      */
     private static Collection<?> newCollection(Class<?> type) {
-        try {
-            return (Collection<?>) type.getDeclaredConstructor().newInstance();
-        } catch (Exception ex) {
-            log.noArgConstructorMissing(type == null ? "null" : type.getName());
+        if (type.isAssignableFrom(ArrayList.class)) {
+            return new ArrayList<>();
         }
-
         if (type.isAssignableFrom(HashSet.class)) {
             return new HashSet<>();
         }
-        if (type.isAssignableFrom(ArrayList.class)) {
-            return new ArrayList<>();
+        if (type.isAssignableFrom(ArrayDeque.class)) {
+            return new ArrayDeque<>();
         }
         if (type.isAssignableFrom(TreeSet.class)) {
             return new TreeSet<>();
         }
-        if (type.isAssignableFrom(ArrayDeque.class)) {
-            return new ArrayDeque<>();
+
+        try {
+            return (Collection<?>) type.getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            log.noArgConstructorMissing(type.getName());
         }
 
         throw new IllegalArgumentException("Could not create collection if type " + type.getName());

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/CollectionCreator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/CollectionCreator.java
@@ -19,27 +19,27 @@ public class CollectionCreator {
 
     private static final ClassloadingService classloadingService = ClassloadingService.get();
 
-    public static Collection<?> newCollection(String className) {
+    public static Collection<?> newCollection(String className, int initialSize) {
         Class<?> type = classloadingService.loadClass(className);
-        return newCollection(type);
+        return newCollection(type, initialSize);
     }
 
     /**
      * Creates an empty instance of a non-interface type of collection, or a suitable subclass of
      * the interfaces {@link List}, {@link Collection}, or {@link Set}.
-     * 
+     *
      * @param type the collection class
      * @return the collection
      */
-    private static Collection<?> newCollection(Class<?> type) {
+    private static Collection<?> newCollection(Class<?> type, int initialSize) {
         if (type.isAssignableFrom(ArrayList.class)) {
-            return new ArrayList<>();
+            return new ArrayList<>(initialSize);
         }
         if (type.isAssignableFrom(HashSet.class)) {
-            return new HashSet<>();
+            return new HashSet<>((int) (initialSize / 0.75 + 1));
         }
         if (type.isAssignableFrom(ArrayDeque.class)) {
-            return new ArrayDeque<>();
+            return new ArrayDeque<>(initialSize);
         }
         if (type.isAssignableFrom(TreeSet.class)) {
             return new TreeSet<>();

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/AbstractHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/AbstractHelper.java
@@ -226,7 +226,7 @@ public abstract class AbstractHelper {
 
         String collectionClassName = field.getWrapper().getWrapperClassName();
 
-        Collection convertedCollection = CollectionCreator.newCollection(collectionClassName);
+        Collection convertedCollection = CollectionCreator.newCollection(collectionClassName, givenCollection.size());
 
         for (Object objectInGivenCollection : givenCollection) {
             Field fieldInCollection = getFieldInField(field);
@@ -249,7 +249,7 @@ public abstract class AbstractHelper {
     private Object recursiveMappingCollection(Object argumentValue, Field field) throws AbstractDataFetcherException {
         Collection givenCollection = getGivenCollection(argumentValue);
         String collectionClassName = field.getWrapper().getWrapperClassName();
-        Collection convertedCollection = CollectionCreator.newCollection(collectionClassName);
+        Collection convertedCollection = CollectionCreator.newCollection(collectionClassName, givenCollection.size());
 
         for (Object objectInGivenCollection : givenCollection) {
             Field fieldInCollection = getFieldInField(field);

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/datafetcher/CollectionHelperTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/datafetcher/CollectionHelperTest.java
@@ -3,18 +3,7 @@ package io.smallrye.graphql.execution.datafetcher;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Set;
-import java.util.Stack;
-import java.util.TreeSet;
-import java.util.Vector;
+import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -40,6 +29,8 @@ public class CollectionHelperTest {
             TreeSet.class,
             ConcurrentSkipListSet.class,
             CustomSet.class,
+            NavigableSet.class,
+            SortedSet.class,
 
             List.class,
             ArrayList.class,
@@ -48,6 +39,8 @@ public class CollectionHelperTest {
             Vector.class,
             CopyOnWriteArrayList.class,
             CustomList.class,
+            Queue.class,
+            Deque.class,
     })
 
     public void newCollection(Class<? extends Collection<?>> clazz) {

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/datafetcher/CollectionHelperTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/datafetcher/CollectionHelperTest.java
@@ -44,7 +44,7 @@ public class CollectionHelperTest {
     })
 
     public void newCollection(Class<? extends Collection<?>> clazz) {
-        test(CollectionCreator.newCollection(clazz.getName()), clazz);
+        test(CollectionCreator.newCollection(clazz.getName(), 0), clazz);
     }
 
     static class CustomSet implements Set<Object> {

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/datafetcher/CollectionHelperTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/datafetcher/CollectionHelperTest.java
@@ -1,12 +1,10 @@
 package io.smallrye.graphql.execution.datafetcher;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -20,119 +18,45 @@ import java.util.Vector;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class CollectionHelperTest {
 
     private void test(Collection<?> c, Class<?> expected) {
         assertNotNull(c, "Return value is null");
-        assertEquals(expected, c.getClass(), "Unexpected type returned, expected " + expected + ", found: " + c.getClass());
+        assertTrue(expected.isAssignableFrom(c.getClass()),
+                "Unexpected type returned, expected subtype of " + expected + ", found: " + c.getClass());
         assertTrue(c.isEmpty(), "Unexpected non-empty collection returned: " + c);
     }
 
-    @Test
-    public void newCollection_Set() {
-        test(CollectionCreator.newCollection(Set.class.getName()), HashSet.class);
-    }
+    @ParameterizedTest
+    @ValueSource(classes = {
+            Collection.class,
 
-    @Test
-    public void newCollection_HashSet() {
-        test(CollectionCreator.newCollection(HashSet.class.getName()), HashSet.class);
-    }
+            Set.class,
+            HashSet.class,
+            LinkedHashSet.class,
+            TreeSet.class,
+            ConcurrentSkipListSet.class,
+            CustomSet.class,
 
-    @Test
-    public void newCollection_LinkedHashSet() {
-        test(CollectionCreator.newCollection(LinkedHashSet.class.getName()), LinkedHashSet.class);
-    }
+            List.class,
+            ArrayList.class,
+            LinkedList.class,
+            Stack.class,
+            Vector.class,
+            CopyOnWriteArrayList.class,
+            CustomList.class,
+    })
 
-    @Test
-    public void newCollection_TreeSet() {
-        test(CollectionCreator.newCollection(TreeSet.class.getName()), TreeSet.class);
-    }
-
-    @Test
-    public void newCollection_ConcurrentSkipListSet() {
-        test(CollectionCreator.newCollection(ConcurrentSkipListSet.class.getName()), ConcurrentSkipListSet.class);
-    }
-
-    @Test
-    public void newCollection_CustomSet() {
-        test(CollectionCreator.newCollection(CustomSet.class.getName()), HashSet.class);
-    }
-
-    @Test
-    public void newCollection_EmptySet() {
-        test(CollectionCreator.newCollection(Collections.EMPTY_SET.getClass().getName()), HashSet.class);
-    }
-
-    @Test
-    public void newCollection_EmptySetMethod() {
-        test(CollectionCreator.newCollection(Collections.emptySet().getClass().getName()), HashSet.class);
-    }
-
-    @Test
-    public void newCollection_CollectionsSingleton() {
-        test(CollectionCreator.newCollection(Collections.singleton("foo").getClass().getName()), HashSet.class);
-    }
-
-    @Test
-    public void newCollection_Collection() {
-        test(CollectionCreator.newCollection(Collection.class.getName()), ArrayList.class);
-    }
-
-    @Test
-    public void newCollection_List() {
-        test(CollectionCreator.newCollection(List.class.getName()), ArrayList.class);
-    }
-
-    @Test
-    public void newCollection_ArrayList() {
-        test(CollectionCreator.newCollection(ArrayList.class.getName()), ArrayList.class);
-    }
-
-    @Test
-    public void newCollection_LinkedList() {
-        test(CollectionCreator.newCollection(LinkedList.class.getName()), LinkedList.class);
-    }
-
-    @Test
-    public void newCollection_Stack() {
-        test(CollectionCreator.newCollection(Stack.class.getName()), Stack.class);
-    }
-
-    @Test
-    public void newCollection_Vector() {
-        test(CollectionCreator.newCollection(Vector.class.getName()), Vector.class);
-    }
-
-    @Test
-    public void newCollection_CopyOnWriteArrayList() {
-        test(CollectionCreator.newCollection(CopyOnWriteArrayList.class.getName()), CopyOnWriteArrayList.class);
-    }
-
-    @Test
-    public void newCollection_CustomList() {
-        test(CollectionCreator.newCollection(CustomList.class.getName()), CustomList.class);
-    }
-
-    @Test
-    public void newCollection_EmptyList() {
-        test(CollectionCreator.newCollection(Collections.EMPTY_LIST.getClass().getName()), ArrayList.class);
-    }
-
-    @Test
-    public void newCollection_EmptyListMethod() {
-        test(CollectionCreator.newCollection(Collections.emptyList().getClass().getName()), ArrayList.class);
-    }
-
-    @Test
-    public void newCollection_CollectionsSingletonList() {
-        test(CollectionCreator.newCollection(Collections.singletonList("foo").getClass().getName()), ArrayList.class);
+    public void newCollection(Class<? extends Collection<?>> clazz) {
+        test(CollectionCreator.newCollection(clazz.getName()), clazz);
     }
 
     static class CustomSet implements Set<Object> {
 
-        private CustomSet(String someString) {
+        public CustomSet() {
         }
 
         @Override


### PR DESCRIPTION
CollectionCreator contained a few bugs (wrong collection was created in some cases) and had bad performance in some cases (e.g. when `List` was used in an input type, the reflective call failed, which is quite slow).

This PR should fix both.