### PR TITLE
Hide our error extensions fields by default

### DIFF
--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/ConfigKey.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/ConfigKey.java
@@ -18,6 +18,7 @@ public interface ConfigKey extends org.eclipse.microprofile.graphql.ConfigKey {
     public static final String SCHEMA_INCLUDE_DIRECTIVES = "smallrye.graphql.schema.includeDirectives";
     public static final String SCHEMA_INCLUDE_INTROSPECTION_TYPES = "smallrye.graphql.schema.includeIntrospectionTypes";
     public static final String LOG_PAYLOAD = "smallrye.graphql.logPayload";
+    public static final String ERROR_EXTENSION_FIELDS = "smallrye.graphql.errorExtensionFields";
     public static final String FIELD_VISIBILITY = "smallrye.graphql.fieldVisibility";
     public static final String UNWRAP_EXCEPTIONS = "smallrye.graphql.unwrapExceptions";
 }

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/GraphQLConfig.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/GraphQLConfig.java
@@ -98,6 +98,10 @@ public class GraphQLConfig implements Config {
     @ConfigProperty(name = ConfigKey.UNWRAP_EXCEPTIONS, defaultValue = "")
     private Optional<List<String>> unwrapExceptions;
 
+    @Inject
+    @ConfigProperty(name = ConfigKey.ERROR_EXTENSION_FIELDS, defaultValue = "")
+    private Optional<List<String>> errorExtensionFields;
+
     public void init(@Observes @Initialized(ApplicationScoped.class) Object init) {
         hideList = mergeList(hideList, blackList);
         showList = mergeList(showList, whiteList);
@@ -188,6 +192,11 @@ public class GraphQLConfig implements Config {
         return unwrapExceptions;
     }
 
+    @Override
+    public Optional<List<String>> getErrorExtensionFields() {
+        return errorExtensionFields;
+    }
+
     public void setHideErrorMessageList(Optional<List<String>> hideList) {
         this.hideList = hideList;
     }
@@ -242,6 +251,10 @@ public class GraphQLConfig implements Config {
 
     public void setUnwrapExceptions(Optional<List<String>> unwrapExceptions) {
         this.unwrapExceptions = unwrapExceptions;
+    }
+
+    public void setErrorExtensionFields(Optional<List<String>> errorExtensionFields) {
+        this.errorExtensionFields = errorExtensionFields;
     }
 
     private Optional<List<String>> mergeList(Optional<List<String>> currentList, Optional<List<String>> deprecatedList) {

--- a/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/CdiExecutionTest.java
+++ b/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/CdiExecutionTest.java
@@ -9,7 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -362,6 +364,11 @@ public class CdiExecutionTest {
             @Override
             public boolean isPrintDataFetcherException() {
                 return true;
+            }
+
+            @Override
+            public Optional<List<String>> getErrorExtensionFields() {
+                return Optional.of(Config.ERROR_EXTENSION_ALL_KNOWN);
             }
         };
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Config.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Config.java
@@ -1,5 +1,6 @@
 package io.smallrye.graphql.bootstrap;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -78,10 +79,29 @@ public interface Config {
         return FIELD_VISIBILITY_DEFAULT;
     }
 
+    default Optional<List<String>> getErrorExtensionFields() {
+        return Optional.empty();
+    }
+
     default <T> T getConfigValue(String key, Class<T> type, T defaultValue) {
         return defaultValue;
     }
 
     public static final String FIELD_VISIBILITY_DEFAULT = "default";
     public static final String FIELD_VISIBILITY_NO_INTROSPECTION = "no-introspection";
+
+    public static final String ERROR_EXTENSION_EXCEPTION = "exception";
+    public static final String ERROR_EXTENSION_CLASSIFICATION = "classification";
+    public static final String ERROR_EXTENSION_CODE = "code";
+    public static final String ERROR_EXTENSION_DESCRIPTION = "description";
+    public static final String ERROR_EXTENSION_VALIDATION_ERROR_TYPE = "validationErrorType";
+    public static final String ERROR_EXTENSION_QUERY_PATH = "queryPath";
+
+    public static final List<String> ERROR_EXTENSION_ALL_KNOWN = Arrays.asList(
+            ERROR_EXTENSION_EXCEPTION,
+            ERROR_EXTENSION_CLASSIFICATION,
+            ERROR_EXTENSION_CODE,
+            ERROR_EXTENSION_DESCRIPTION,
+            ERROR_EXTENSION_VALIDATION_ERROR_TYPE,
+            ERROR_EXTENSION_QUERY_PATH);
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponse.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponse.java
@@ -13,6 +13,7 @@ import javax.json.spi.JsonProvider;
 
 import graphql.ExecutionResult;
 import graphql.GraphQLError;
+import io.smallrye.graphql.bootstrap.Config;
 import io.smallrye.graphql.execution.error.ExecutionErrorsService;
 
 /**
@@ -29,12 +30,14 @@ public class ExecutionResponse {
             .withNullValues(Boolean.TRUE)
             .withFormatting(Boolean.TRUE));
 
-    private final ExecutionErrorsService errorsService = new ExecutionErrorsService();
+    private final Config config;
+    private final ExecutionResult executionResult;
+    private final ExecutionErrorsService errorsService;
 
-    private ExecutionResult executionResult;
-
-    public ExecutionResponse(ExecutionResult executionResult) {
+    public ExecutionResponse(ExecutionResult executionResult, Config config) {
+        this.config = config;
         this.executionResult = executionResult;
+        this.errorsService = new ExecutionErrorsService(config);
     }
 
     public ExecutionResult getExecutionResult() {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -115,7 +115,7 @@ public class ExecutionService {
                 // Notify after
                 eventEmitter.fireAfterExecute(context);
 
-                ExecutionResponse executionResponse = new ExecutionResponse(executionResult);
+                ExecutionResponse executionResponse = new ExecutionResponse(executionResult, config);
                 if (config.logPayload()) {
                     log.payloadOut(executionResponse.toString());
                 }

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionTestBase.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionTestBase.java
@@ -3,7 +3,9 @@ package io.smallrye.graphql.execution;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -95,6 +97,11 @@ public abstract class ExecutionTestBase {
             @Override
             public boolean isPrintDataFetcherException() {
                 return true;
+            }
+
+            @Override
+            public Optional<List<String>> getErrorExtensionFields() {
+                return Optional.of(Config.ERROR_EXTENSION_ALL_KNOWN);
             }
         };
         return config;

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/error/ExecutionErrorsServiceTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/error/ExecutionErrorsServiceTest.java
@@ -4,7 +4,9 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
@@ -18,6 +20,7 @@ import graphql.execution.ResultPath;
 import graphql.language.SourceLocation;
 import graphql.validation.ValidationError;
 import graphql.validation.ValidationErrorType;
+import io.smallrye.graphql.bootstrap.Config;
 
 /**
  * Test for {@link ExecutionErrorsService}
@@ -26,7 +29,7 @@ import graphql.validation.ValidationErrorType;
  */
 class ExecutionErrorsServiceTest {
 
-    private final ExecutionErrorsService executionErrorsService = new ExecutionErrorsService();
+    private final ExecutionErrorsService executionErrorsService = new ExecutionErrorsService(getGraphQLConfig());
 
     @Test
     void testToJsonErrors_WhenExceptionWhileDataFetchingErrorCaught_ShouldReturnJsonBodyWithCustomExtensions() {
@@ -93,5 +96,19 @@ class ExecutionErrorsServiceTest {
         SourceLocation location = new SourceLocation(12, 34);
         GraphQLError graphQLError = new GraphQLExceptionWhileDataFetching(path, exception, location);
         return executionErrorsService.toJsonErrors(singletonList(graphQLError));
+    }
+
+    private Config getGraphQLConfig() {
+        return new Config() {
+            @Override
+            public boolean isPrintDataFetcherException() {
+                return true;
+            }
+
+            @Override
+            public Optional<List<String>> getErrorExtensionFields() {
+                return Optional.of(Config.ERROR_EXTENSION_ALL_KNOWN);
+            }
+        };
     }
 }

--- a/server/tck/src/test/resources/META-INF/microprofile-config.properties
+++ b/server/tck/src/test/resources/META-INF/microprofile-config.properties
@@ -3,3 +3,4 @@ smallrye.graphql.tracing.enabled=true
 smallrye.graphql.allowGet=true
 smallrye.graphql.logPayload=true
 mp.graphql.showErrorMessage=java.security.AccessControlException
+smallrye.graphql.errorExtensionFields=exception,classification,code,description,validationErrorType,queryPath


### PR DESCRIPTION
with an option to show certain fields

You can add  `smallrye.graphql.errorExtensionFields=exception,classification,code,description,validationErrorType,queryPath` to add the known extensions back.

Note, this is only for the extension keys we write. We still need a PR to allow switching of others coming from graphql-java.

Fix #772

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>