### PR TITLE
Added better error handling for Subscriptions (Multi and Publisher)

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -99,7 +99,8 @@ public class Bootstrap {
     private final ClassloadingService classloadingService = ClassloadingService.get();
 
     public static GraphQLSchema bootstrap(Schema schema) {
-        return bootstrap(schema, null);
+        return bootstrap(schema, new Config() {
+        });
     }
 
     public static GraphQLSchema bootstrap(Schema schema, Config config) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/CompletionStageDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/CompletionStageDataFetcher.java
@@ -47,7 +47,7 @@ public class CompletionStageDataFetcher<K, T> extends AbstractDataFetcher<K, T> 
                     eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), throwable);
                     if (throwable instanceof GraphQLException) {
                         GraphQLException graphQLException = (GraphQLException) throwable;
-                        partialResultHelper.appendPartialResult(resultBuilder, dfe, graphQLException);
+                        errorResultHelper.appendPartialResult(resultBuilder, dfe, graphQLException);
                     } else if (throwable instanceof Exception) {
                         throw SmallRyeGraphQLServerMessages.msg.dataFetcherException(operation, throwable);
                     } else if (throwable instanceof Error) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/MultiDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/MultiDataFetcher.java
@@ -2,15 +2,19 @@ package io.smallrye.graphql.execution.datafetcher;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import org.dataloader.BatchLoaderEnvironment;
+import org.eclipse.microprofile.graphql.GraphQLException;
 
 import graphql.GraphQLContext;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
 import io.smallrye.graphql.bootstrap.Config;
 import io.smallrye.graphql.execution.context.SmallRyeContext;
 import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.transformation.AbstractDataFetcherException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 
@@ -37,7 +41,39 @@ public class MultiDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
         try {
             SmallRyeContext.setContext(context);
             Multi<?> multi = reflectionHelper.invoke(transformedArguments);
-            return (O) multi;
+
+            return (O) multi
+
+                    .onItem().transform((t) -> {
+                        try {
+                            Object resultFromTransform = fieldHelper.transformResponse(t);
+                            resultBuilder.data(resultFromTransform);
+                            return (O) resultBuilder.build();
+                        } catch (AbstractDataFetcherException abstractDataFetcherException) {
+                            //Arguments or result couldn't be transformed
+                            abstractDataFetcherException.appendDataFetcherResult(resultBuilder, dfe);
+                            eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), abstractDataFetcherException);
+                            return (O) resultBuilder.build();
+                        }
+                    })
+
+                    .onFailure().recoverWithItem(new Function<Throwable, O>() {
+                        public O apply(Throwable throwable) {
+                            eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), throwable);
+                            if (throwable instanceof GraphQLException) {
+                                GraphQLException graphQLException = (GraphQLException) throwable;
+                                errorResultHelper.appendPartialResult(resultBuilder, dfe, graphQLException);
+                            } else if (throwable instanceof Exception) {
+                                DataFetcherException dataFetcherException = SmallRyeGraphQLServerMessages.msg
+                                        .dataFetcherException(operation, throwable);
+                                errorResultHelper.appendException(resultBuilder, dfe, dataFetcherException);
+                            } else if (throwable instanceof Error) {
+                                errorResultHelper.appendException(resultBuilder, dfe, throwable);
+                            }
+                            return (O) resultBuilder.build();
+                        }
+                    });
+
         } finally {
             SmallRyeContext.remove();
         }
@@ -47,10 +83,7 @@ public class MultiDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
     @SuppressWarnings("unchecked")
     protected <O> O invokeFailure(DataFetcherResult.Builder<Object> resultBuilder) {
         return (O) Multi.createFrom()
-                .item(resultBuilder::build).toUni()
-                .runSubscriptionOn(Infrastructure.getDefaultExecutor())
-                .subscribe()
-                .asCompletionStage();
+                .item(resultBuilder::build);
     }
 
     @Override

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/UniDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/UniDataFetcher.java
@@ -47,7 +47,7 @@ public class UniDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
                             eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), throwable);
                             if (throwable instanceof GraphQLException) {
                                 GraphQLException graphQLException = (GraphQLException) throwable;
-                                partialResultHelper.appendPartialResult(resultBuilder, dfe, graphQLException);
+                                errorResultHelper.appendPartialResult(resultBuilder, dfe, graphQLException);
                             } else if (throwable instanceof Exception) {
                                 emitter.fail(SmallRyeGraphQLServerMessages.msg.dataFetcherException(operation, throwable));
                                 return;


### PR DESCRIPTION
As discussed with Clement. This is also moving from Quarkus to SmallRye and once release and pulled into Quarkus, the Quarkus error handling can be removed.

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>