### PR TITLE
Add support for records as graphql types

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Classes.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Classes.java
@@ -251,6 +251,8 @@ public class Classes {
 
     public static final DotName ENUM = DotName.createSimple(Enum.class.getName());
 
+    public static final DotName RECORD = DotName.createSimple("java.lang.Record");
+
     public static final DotName LOCALDATE = DotName.createSimple(LocalDate.class.getName());
     public static final DotName LOCALDATETIME = DotName.createSimple(LocalDateTime.class.getName());
     public static final DotName LOCALTIME = DotName.createSimple(LocalTime.class.getName());


### PR DESCRIPTION
Allows to use records as GraphQL-Types without further annotations:

```java
public record SomeType(String someField){}
```

would be mapped to
```graphql
type SomeType {
  someField: String
}
```

Tests are currently not included, as these would have to be built and run with Java 16.

----

If getters are present, they are preferred over record component accessors for backwards compatibility:

```java
public record SomeType(String someField){
  @Description("Description...")
  public String getSomeField() {
    return someField;
  }
}
```

would be mapped to
```graphql
type SomeType {
  "Description..."
  someField: String
}
```

.----

See also #704