### PR TITLE
Use QueryCache when supplying Document from Context

### DIFF
--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/producer/SmallRyeContextAccessorProxy.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/producer/SmallRyeContextAccessorProxy.java
@@ -10,6 +10,7 @@ import javax.json.JsonObject;
 
 import graphql.ExecutionInput;
 import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.execution.QueryCache;
 import io.smallrye.graphql.execution.context.SmallRyeContext;
 import io.smallrye.graphql.schema.model.Field;
 
@@ -33,6 +34,11 @@ public class SmallRyeContextAccessorProxy extends SmallRyeContext {
     @Override
     public SmallRyeContext withDataFromExecution(ExecutionInput executionInput) {
         return SmallRyeContext.getContext().withDataFromExecution(executionInput);
+    }
+
+    @Override
+    public SmallRyeContext withDataFromExecution(ExecutionInput executionInput, QueryCache queryCache) {
+        return SmallRyeContext.getContext().withDataFromExecution(executionInput, queryCache);
     }
 
     @Override


### PR DESCRIPTION
#790 added support for getting the parsed query document with `context.unwrap(Document.class)`.
The current and previous version of `SmallRyeContext` reparse the query when using Document. 
This PR attempts to use the QueryCache such that a given query is parsed only once.