### PR TITLE
Prevent NPE in SmallRyeContext.DocumentSupplier when queryCache not set

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContext.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContext.java
@@ -346,12 +346,17 @@ public class SmallRyeContext implements Context {
 
         @Override
         public Document get() {
-            PreparsedDocumentEntry documentEntry = queryCache.getDocument(executionInput, ei -> {
-                ParseAndValidateResult parse = ParseAndValidate.parse(ei);
-                return parse.isFailure() ? new PreparsedDocumentEntry(parse.getErrors())
-                        : new PreparsedDocumentEntry(parse.getDocument());
-            });
-            return documentEntry.hasErrors() ? null : documentEntry.getDocument();
+            if (queryCache == null) {
+                ParseAndValidateResult parse = ParseAndValidate.parse(executionInput);
+                return parse.isFailure() ? null : parse.getDocument();
+            } else {
+                PreparsedDocumentEntry documentEntry = queryCache.getDocument(executionInput, ei -> {
+                    ParseAndValidateResult parse = ParseAndValidate.parse(ei);
+                    return parse.isFailure() ? new PreparsedDocumentEntry(parse.getErrors())
+                            : new PreparsedDocumentEntry(parse.getDocument());
+                });
+                return documentEntry.hasErrors() ? null : documentEntry.getDocument();
+            }
         }
     }
 }


### PR DESCRIPTION
#818 added `SmallRyeContext.withDataFromExecution(ExecutionInput, QueryCache)`, leaving the old method `withDataFromExecution(ExecutionInput)`. 
As `SmallRyeContext.unwrap(Document.class)` is right now it requires queryCache being set. 
This PR falls back to parsing the query if queryCache is not set.