### PR TITLE
Invoke eventEmitter.fireOnDataFetchError for all exceptions in AbstractDataFetcher

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
@@ -62,8 +62,7 @@ public abstract class AbstractDataFetcher<K, T> implements DataFetcher<T>, Batch
         } catch (GraphQLException graphQLException) {
             errorResultHelper.appendPartialResult(resultBuilder, dfe, graphQLException);
             eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), graphQLException);
-        } catch (SecurityException | IllegalAccessException | IllegalArgumentException ex) {
-            //m.invoke failed
+        } catch (Throwable ex) {
             eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), ex);
             throw ex;
         } finally {
@@ -76,7 +75,7 @@ public abstract class AbstractDataFetcher<K, T> implements DataFetcher<T>, Batch
     protected SmallRyeContext getSmallRyeContext(final DataFetchingEnvironment dfe) {
         // update the context
         GraphQLContext graphQLContext = dfe.getContext();
-        SmallRyeContext context = ((SmallRyeContext) graphQLContext.get("context"));
+        SmallRyeContext context = graphQLContext.get("context");
         if (context != null) {
             context = context.withDataFromFetcher(dfe, operation);
             graphQLContext.put("context", context);

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
@@ -20,7 +20,7 @@ import io.smallrye.graphql.transformation.AbstractDataFetcherException;
 
 /**
  * The abstract data fetcher
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  * @param <K>
  * @param <T>
@@ -71,19 +71,6 @@ public abstract class AbstractDataFetcher<K, T> implements DataFetcher<T>, Batch
         }
 
         return invokeFailure(resultBuilder);
-    }
-
-    protected DataFetcherResult.Builder<Object> getDataFetcherResultBuilder(final DataFetchingEnvironment dfe) {
-        // update the context
-        GraphQLContext graphQLContext = dfe.getContext();
-        SmallRyeContext context = ((SmallRyeContext) graphQLContext.get("context"));
-        if (context != null) {
-            context = context.withDataFromFetcher(dfe, operation);
-            graphQLContext.put("context", context);
-        }
-
-        eventEmitter.fireBeforeDataFetch(context);
-        return DataFetcherResult.newResult().localContext(graphQLContext);
     }
 
     protected SmallRyeContext getSmallRyeContext(final DataFetchingEnvironment dfe) {


### PR DESCRIPTION
All classes extending `AbstractDataFetcher` call `eventEmitter.fireOnDataFetchError` for all exceptions, but the default in `AbstractDataFetcher` only calls `eventEmitter.fireOnDataFetchError` for certain exceptions. 