### PR TITLE
Subscription support for the dynamic client

### DIFF
--- a/client/api/src/main/java/io/smallrye/graphql/client/core/OperationType.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/core/OperationType.java
@@ -2,5 +2,6 @@ package io.smallrye.graphql.client.core;
 
 public enum OperationType {
     QUERY,
-    MUTATION
+    MUTATION,
+    SUBSCRIPTION
 }

--- a/client/api/src/main/java/io/smallrye/graphql/client/dynamic/api/DynamicGraphQLClient.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/dynamic/api/DynamicGraphQLClient.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ExecutionException;
 import io.smallrye.graphql.client.Request;
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.core.Document;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 public interface DynamicGraphQLClient extends AutoCloseable {
@@ -16,5 +17,9 @@ public interface DynamicGraphQLClient extends AutoCloseable {
     Uni<Response> executeAsync(Document document);
 
     Uni<Response> executeAsync(Request request);
+
+    Multi<Response> subscription(Document document);
+
+    Multi<Response> subscription(Request request);
 
 }

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/dynamic/vertx/VertxDynamicGraphQLClientBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/dynamic/vertx/VertxDynamicGraphQLClientBuilder.java
@@ -5,7 +5,6 @@ import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClientBuilder;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
-import io.vertx.ext.web.client.WebClientOptions;
 
 /**
  * Implementation of dynamic client builder that creates GraphQL clients using Vert.x under the hood.
@@ -39,12 +38,11 @@ public class VertxDynamicGraphQLClientBuilder implements DynamicGraphQLClientBui
 
     @Override
     public DynamicGraphQLClient build() {
-        WebClientOptions options = new WebClientOptions();
         if (url == null) {
             throw new IllegalArgumentException("URL is required");
         }
         Vertx toUseVertx = vertx != null ? vertx : Vertx.vertx();
-        return new VertxDynamicGraphQLClient(options, toUseVertx, url, headersMap);
+        return new VertxDynamicGraphQLClient(toUseVertx, url, headersMap);
     }
 
 }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/core/OperationImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/core/OperationImpl.java
@@ -15,6 +15,9 @@ public class OperationImpl extends AbstractOperation {
             case MUTATION:
                 builder.append("mutation");
                 break;
+            case SUBSCRIPTION:
+                builder.append("subscription");
+                break;
             default:
                 throw new BuildException("Operation type must be one of QUERY, MUTATION or SUBSCRIPTION");
         }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/subscription/DynamicClientSubscriptionApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/subscription/DynamicClientSubscriptionApi.java
@@ -1,0 +1,28 @@
+package io.smallrye.graphql.tests.client.dynamic.subscription;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+import io.smallrye.graphql.api.Subscription;
+import io.smallrye.mutiny.Multi;
+
+@GraphQLApi
+public class DynamicClientSubscriptionApi {
+
+    // this needs to be here because a GraphQLApi with only subscriptions does not work
+    @Query
+    public String nothing() {
+        return null;
+    }
+
+    @Subscription
+    public Multi<Integer> countToFive() {
+        return Multi.createFrom().range(0, 5);
+    }
+
+    @Subscription
+    public Multi<Integer> failingImmediately() {
+        return Multi.createFrom().failure(new RuntimeException("blabla"));
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/subscription/DynamicClientSubscriptionTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/subscription/DynamicClientSubscriptionTest.java
@@ -1,0 +1,111 @@
+package io.smallrye.graphql.tests.client.dynamic.subscription;
+
+import static io.smallrye.graphql.client.core.Document.document;
+import static io.smallrye.graphql.client.core.Field.field;
+import static io.smallrye.graphql.client.core.Operation.operation;
+import static org.junit.Assert.*;
+
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import javax.json.JsonValue;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.smallrye.graphql.client.Error;
+import io.smallrye.graphql.client.Response;
+import io.smallrye.graphql.client.core.Document;
+import io.smallrye.graphql.client.core.OperationType;
+import io.smallrye.graphql.client.dynamic.vertx.VertxDynamicGraphQLClient;
+import io.smallrye.graphql.client.dynamic.vertx.VertxDynamicGraphQLClientBuilder;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DynamicClientSubscriptionTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "dynamic-client-subscription-test.war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(DynamicClientSubscriptionApi.class);
+    }
+
+    @ArquillianResource
+    URL testingURL;
+
+    private static VertxDynamicGraphQLClient client;
+
+    @Before
+    public void prepare() {
+        client = (VertxDynamicGraphQLClient) new VertxDynamicGraphQLClientBuilder()
+                .url(testingURL.toString() + "graphql")
+                .build();
+    }
+
+    @After
+    public void cleanup() {
+        client.close();
+    }
+
+    @Test
+    public void testCounting() {
+        Document document = document(
+                operation(OperationType.SUBSCRIPTION,
+                        field("countToFive")));
+        List<Response> responses = client.subscription(document)
+                .subscribe()
+                .asStream()
+                .collect(Collectors.toList());
+        for (int i = 0; i < 5; i++) {
+            Response response = responses.get(i);
+            assertEquals(i, response.getData().getInt("countToFive"));
+            assertNoErrors(response.getErrors());
+        }
+    }
+
+    @Test
+    public void testFailingImmediately() throws InterruptedException {
+        Document document = document(
+                operation(OperationType.SUBSCRIPTION,
+                        field("failingImmediately")));
+        AtomicReference<Response> response = new AtomicReference<>();
+        CountDownLatch finished = new CountDownLatch(1);
+        client.subscription(document)
+                .subscribe()
+                .with(item -> {
+                    response.set(item);
+                }, throwable -> {
+                    // nothing
+                }, () -> {
+                    finished.countDown();
+                });
+        finished.await(10, TimeUnit.SECONDS);
+        Response actualResponse = response.get();
+        assertNotNull("One response was expected to arrive", actualResponse);
+        Assert.assertEquals(JsonValue.NULL, actualResponse.getData().get("failingImmediately"));
+        // FIXME: add an assertion about the contained error message
+        // right now, there is no error message present, which is a bug
+    }
+
+    private void assertNoErrors(List<Error> errors) {
+        if (errors != null && !errors.isEmpty()) {
+            fail("No error expected, but there was: " + errors);
+        }
+    }
+
+}


### PR DESCRIPTION
I also tried to perform an equivalent of the changes from https://github.com/quarkusio/quarkus/pull/17423 to `SubscriptionWebSocket`. That class is currently only used in testing (WildFly feature pack has its own, slightly modified copy of it; and Quarkus uses `SmallRyeGraphQLSubscriptionHandler`)