### PR TITLE
Reuse JsonReader from the typesafe client by the dynamic client

### DIFF
--- a/client/implementation/pom.xml
+++ b/client/implementation/pom.xml
@@ -68,10 +68,6 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.json.bind</groupId>
-            <artifactId>jakarta.json.bind-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
         </dependency>

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/Dummy.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/Dummy.java
@@ -1,10 +1,15 @@
 package io.smallrye.graphql.tests.client.dynamic;
 
+import org.eclipse.microprofile.graphql.Name;
+
 public class Dummy {
 
     private String string;
 
     private Integer integer;
+
+    @Name("specialName")
+    private String renamedField;
 
     public String getString() {
         return string;
@@ -22,4 +27,11 @@ public class Dummy {
         this.integer = integer;
     }
 
+    public String getRenamedField() {
+        return renamedField;
+    }
+
+    public void setRenamedField(String renamedField) {
+        this.renamedField = renamedField;
+    }
 }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientApi.java
@@ -1,5 +1,8 @@
 package io.smallrye.graphql.tests.client.dynamic;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
@@ -31,6 +34,28 @@ public class DynamicClientApi {
         Dummy ret = new Dummy();
         ret.setInteger(number);
         return ret;
+    }
+
+    @Query
+    public Dummy withRenamedField() {
+        Dummy ret = new Dummy();
+        ret.setRenamedField("foo");
+        ret.setString("string");
+        ret.setInteger(30);
+        return ret;
+    }
+
+    @Query
+    public List<Dummy> listWithRenamedField() {
+        Dummy dummy1 = new Dummy();
+        dummy1.setRenamedField("foo");
+        Dummy dummy2 = new Dummy();
+        dummy2.setRenamedField("foo2");
+
+        ArrayList<Dummy> list = new ArrayList<>();
+        list.add(dummy1);
+        list.add(dummy2);
+        return list;
     }
 
 }


### PR DESCRIPTION
- This only addresses the usage of `@Name` for now. `@DateFormat` etc need to be added to the common code IIUC.
- This removes the JSON-B dependency from the client 
- While this makes some dynamic client bits depend on stuff from packages named `typesafe`, I'd perhaps prefer not reorganizing the packages now (like moving that stuff into something called "common"), that will be done with #725 

But most importantly:
- I find it a bit odd that the client code does not make use of the `@Name` annotation when parsing a returned object, so when client and server share the same model class, and that class contains a `@Name("b") String a`, then the client has to request `a:b` (an alias) to properly retrieve and parse the field. @t1 says it's by design, I'm not quite sure. See `DynamicClientTest#testRenamedField`. @phillip-kruger WDYT?