### PR TITLE
Rework the client configuration

### DIFF
--- a/client/implementation-jaxrs/src/main/java/io/smallrye/graphql/client/typesafe/jaxrs/HeaderBuilder.java
+++ b/client/implementation-jaxrs/src/main/java/io/smallrye/graphql/client/typesafe/jaxrs/HeaderBuilder.java
@@ -5,6 +5,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Base64;
+import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -22,10 +23,12 @@ import io.smallrye.graphql.client.typesafe.impl.reflection.TypeInfo;
 public class HeaderBuilder {
     private final Class<?> api;
     private final MethodInvocation method;
+    private final Map<String, String> additionalHeaders;
 
-    public HeaderBuilder(Class<?> api, MethodInvocation method) {
+    public HeaderBuilder(Class<?> api, MethodInvocation method, Map<String, String> additionalHeaders) {
         this.api = api;
         this.method = method;
+        this.additionalHeaders = additionalHeaders;
     }
 
     public MultivaluedMap<String, Object> build() {
@@ -40,6 +43,9 @@ public class HeaderBuilder {
                 .findFirst()
                 .map(header -> resolveAuthHeader(method.getDeclaringType(), header))
                 .ifPresent(auth -> headers.add("Authorization", auth));
+        if (additionalHeaders != null) {
+            additionalHeaders.forEach(headers::putSingle);
+        }
         return headers;
     }
 

--- a/client/implementation-jaxrs/src/main/java/io/smallrye/graphql/client/typesafe/jaxrs/JaxRsTypesafeGraphQLClientProxy.java
+++ b/client/implementation-jaxrs/src/main/java/io/smallrye/graphql/client/typesafe/jaxrs/JaxRsTypesafeGraphQLClientProxy.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +29,7 @@ import javax.ws.rs.core.Response.StatusType;
 
 import org.jboss.logging.Logger;
 
+import io.smallrye.graphql.client.GraphQLClientConfiguration;
 import io.smallrye.graphql.client.typesafe.api.GraphQLClientException;
 import io.smallrye.graphql.client.typesafe.impl.QueryBuilder;
 import io.smallrye.graphql.client.typesafe.impl.ResultBuilder;
@@ -44,16 +46,27 @@ class JaxRsTypesafeGraphQLClientProxy {
 
     private final Map<String, String> queryCache = new HashMap<>();
     private final WebTarget target;
+    private final GraphQLClientConfiguration configuration;
 
     JaxRsTypesafeGraphQLClientProxy(WebTarget target) {
         this.target = target;
+        this.configuration = null;
+    }
+
+    JaxRsTypesafeGraphQLClientProxy(WebTarget target,
+            GraphQLClientConfiguration configuration) {
+        this.target = target;
+        this.configuration = configuration;
     }
 
     Object invoke(Class<?> api, MethodInvocation method) {
         if (method.isDeclaredInObject())
             return method.invoke(this);
 
-        MultivaluedMap<String, Object> headers = new HeaderBuilder(api, method).build();
+        MultivaluedMap<String, Object> headers = new HeaderBuilder(api,
+                method,
+                configuration != null ? configuration.getHeaders() : Collections.emptyMap())
+                        .build();
         String request = request(method);
 
         String response = post(request, headers);

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/GraphQLClientConfiguration.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/GraphQLClientConfiguration.java
@@ -1,0 +1,35 @@
+package io.smallrye.graphql.client;
+
+import java.util.Map;
+
+/**
+ * The configuration of a single GraphQL client.
+ */
+public class GraphQLClientConfiguration {
+
+    /**
+     * The URL that the client connects to.
+     */
+    private String url;
+
+    /**
+     * HTTP headers to be appended to each HTTP request.
+     */
+    private Map<String, String> headers;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+}

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/GraphQLClientsConfiguration.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/GraphQLClientsConfiguration.java
@@ -1,0 +1,96 @@
+package io.smallrye.graphql.client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * The wrapper that stores configuration of all GraphQL clients.
+ */
+@ApplicationScoped
+public class GraphQLClientsConfiguration {
+
+    /**
+     * The map storing the configs of each individual client.
+     * <p>
+     * The key in this map is:
+     * For typesafe clients, the client's `configKey` or, if the `configKey` is not defined, the fully qualified class name
+     * For dynamic clients, always the client's `configKey`.
+     */
+    private Map<String, GraphQLClientConfiguration> clients;
+
+    /**
+     * This bean needs to know the list of known @GraphQLClientApi classes.
+     * This needs to be set before this bean is instantiated.
+     * The CDI extension takes care of setting this, but because it can't access the instance
+     * of this bean (it does not exist yet), this needs to be a static field.
+     * Therefore, to allow multiple applications within one VM without clashing, this static field is a map,
+     * where the key is the context class loader of an application.
+     */
+    private static Map<ClassLoader, List<Class<?>>> apis = new WeakHashMap<>();
+
+    /**
+     * Initializes this configuration bean with config from system properties and annotations.
+     */
+    @PostConstruct
+    void initialize() {
+        clients = new HashMap<>();
+
+        // store configurations for detected typesafe clients (interfaces with @GraphQLClientApi)
+        List<Class<?>> classes = apis.get(Thread.currentThread().getContextClassLoader());
+        for (Class<?> api : classes) {
+            TypesafeClientConfigurationReader configReader = new TypesafeClientConfigurationReader(api);
+            clients.put(configReader.getConfigKey(), configReader.getClientConfiguration());
+        }
+
+        // store configured dynamic clients
+        // FIXME: move this logic to a class similar to TypesafeClientConfigurationReader?
+        List<String> detectedClientNames = new ArrayList<>();
+        Config mpConfig = ConfigProvider.getConfig();
+        for (String propertyName : mpConfig.getPropertyNames()) {
+            if (propertyName.matches("[a-z]+/mp-graphql/.+")) {
+                String key = propertyName.substring(0, propertyName.indexOf("/mp-graphql"));
+                if (!clients.containsKey(key)) {
+                    detectedClientNames.add(key);
+                }
+            }
+        }
+        for (String clientName : detectedClientNames) {
+            GraphQLClientConfiguration configuration = new GraphQLClientConfiguration();
+            configuration.setUrl(mpConfig.getValue(clientName + "/mp-graphql/url", String.class));
+            configuration.setHeaders(getConfigurationValueMap(clientName, "header", mpConfig));
+            clients.put(clientName, configuration);
+        }
+    }
+
+    public Map<String, GraphQLClientConfiguration> getClients() {
+        return clients;
+    }
+
+    // FIXME: find a better way to let this bean know what api classes are known
+    public static void apiClasses(List<Class<?>> apiList) {
+        apis.put(Thread.currentThread().getContextClassLoader(), apiList);
+    }
+
+    private Map<String, String> getConfigurationValueMap(String clientName, String configKey, Config config) {
+        Map<String, String> map = new HashMap<>();
+        for (String propertyName : config.getPropertyNames()) {
+            String prefix = clientName + "/mp-graphql/" + configKey + "/";
+            if (!propertyName.startsWith(prefix)) {
+                continue;
+            }
+            String name = propertyName.substring(prefix.length());
+            String value = config.getValue(propertyName, String.class);
+            map.put(name, value);
+        }
+        return map;
+    }
+}

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/TypesafeClientConfigurationReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/TypesafeClientConfigurationReader.java
@@ -1,0 +1,69 @@
+package io.smallrye.graphql.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+
+/**
+ * Parses a typesafe client's configuration object from available config properties and annotations.
+ */
+class TypesafeClientConfigurationReader {
+
+    private final String configKey;
+    private final GraphQLClientConfiguration clientConfiguration;
+
+    TypesafeClientConfigurationReader(Class<?> apiClass) {
+        GraphQLClientApi annotation = apiClass.getAnnotation(GraphQLClientApi.class);
+        if (annotation == null) {
+            throw new RuntimeException("Could not find a GraphQLClientApi annotation on " + apiClass);
+        }
+        configKey = !annotation.configKey().isEmpty() ? annotation.configKey() : apiClass.getName();
+        clientConfiguration = new GraphQLClientConfiguration();
+
+        // Now, read configuration from config properties.
+        // These take precedence over values in the GraphQLClientApi annotation
+        Config mpConfig = ConfigProvider.getConfig();
+
+        // URL
+        Optional<String> configuredUrl = mpConfig.getOptionalValue(configKey + "/mp-graphql/url", String.class);
+        if (configuredUrl.isPresent()) {
+            clientConfiguration.setUrl(configuredUrl.get());
+        } else {
+            String endpointFromAnnotation = annotation.endpoint();
+            if (!endpointFromAnnotation.isEmpty()) {
+                clientConfiguration.setUrl(endpointFromAnnotation);
+            }
+        }
+
+        // Headers
+        clientConfiguration.setHeaders(getConfigurationValueMap(configKey, "header", mpConfig));
+    }
+
+    GraphQLClientConfiguration getClientConfiguration() {
+        return clientConfiguration;
+    }
+
+    String getConfigKey() {
+        return configKey;
+    }
+
+    private Map<String, String> getConfigurationValueMap(String clientName, String configKey, Config config) {
+        Map<String, String> map = new HashMap<>();
+        for (String propertyName : config.getPropertyNames()) {
+            String prefix = clientName + "/mp-graphql/" + configKey + "/";
+            if (!propertyName.startsWith(prefix)) {
+                continue;
+            }
+            String name = propertyName.substring(prefix.length());
+            String value = config.getValue(propertyName, String.class);
+            map.put(name, value);
+        }
+        return map;
+    }
+
+}

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/cdi/NamedDynamicClients.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/cdi/NamedDynamicClients.java
@@ -2,7 +2,6 @@ package io.smallrye.graphql.client.dynamic.cdi;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -11,11 +10,11 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
-
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
+import javax.inject.Inject;
 
 import io.smallrye.graphql.client.GraphQLClient;
+import io.smallrye.graphql.client.GraphQLClientConfiguration;
+import io.smallrye.graphql.client.GraphQLClientsConfiguration;
 import io.smallrye.graphql.client.SmallRyeGraphQLClientMessages;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClientBuilder;
@@ -23,16 +22,14 @@ import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClientBuilder;
 @ApplicationScoped
 public class NamedDynamicClients {
 
-    private static final String CONFIG_KEY_URL = "url";
-    private static final String CONFIG_KEY_HEADER = "header";
-    private Config config;
-
     private final String DEFAULT_CLIENT_NAME = "default";
+
+    @Inject
+    GraphQLClientsConfiguration globalConfig;
 
     @PostConstruct
     void initialize() {
         createdClients = new HashMap<>();
-        config = ConfigProvider.getConfig();
     }
 
     private Map<String, DynamicGraphQLClient> createdClients;
@@ -44,15 +41,15 @@ public class NamedDynamicClients {
         GraphQLClient annotation = ip.getAnnotated().getAnnotation(GraphQLClient.class);
         String clientName = annotation != null ? annotation.value() : DEFAULT_CLIENT_NAME;
         return createdClients.computeIfAbsent(clientName, name -> {
-            DynamicGraphQLClientBuilder builder = DynamicGraphQLClientBuilder.newBuilder();
-            try {
-                builder = builder.url(getConfigurationValue(clientName, CONFIG_KEY_URL));
-            } catch (NoSuchElementException e) {
+            GraphQLClientConfiguration config = globalConfig.getClients().get(name);
+            if (config == null || config.getUrl() == null) {
                 throw SmallRyeGraphQLClientMessages.msg.urlNotConfiguredForNamedClient(clientName);
             }
-            // determine the HTTP headers
-            for (Map.Entry<String, String> header : getConfigurationValueMap(clientName, CONFIG_KEY_HEADER).entrySet()) {
-                builder = builder.header(header.getKey(), header.getValue());
+
+            DynamicGraphQLClientBuilder builder = DynamicGraphQLClientBuilder.newBuilder();
+            builder = builder.url(config.getUrl());
+            for (Map.Entry<String, String> headers : config.getHeaders().entrySet()) {
+                builder = builder.header(headers.getKey(), headers.getValue());
             }
             return builder.build();
         });
@@ -67,31 +64,6 @@ public class NamedDynamicClients {
                 e.printStackTrace();
             }
         });
-    }
-
-    private String getConfigurationValue(String clientName, String configKey) {
-        return config.getValue(clientName + "/mp-graphql/" + configKey, String.class);
-    }
-
-    /**
-     * For example, if there's a named client 'client1' with this:
-     * client1/mp-graphql/header/Foo=Bar
-     * client1/mp-graphql/header/A=B
-     *
-     * then getConfigurationValueMap(client1, header) will return a map containing Foo=Bar and A=B
-     */
-    private Map<String, String> getConfigurationValueMap(String clientName, String configKey) {
-        Map<String, String> map = new HashMap<>();
-        for (String propertyName : config.getPropertyNames()) {
-            String prefix = clientName + "/mp-graphql/" + configKey + "/";
-            if (!propertyName.startsWith(prefix)) {
-                continue;
-            }
-            String name = propertyName.substring(prefix.length());
-            String value = config.getValue(propertyName, String.class);
-            map.put(name, value);
-        }
-        return map;
     }
 
 }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/cdi/TypesafeGraphQLClientExtension.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/cdi/TypesafeGraphQLClientExtension.java
@@ -12,6 +12,7 @@ import javax.enterprise.inject.spi.WithAnnotations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.smallrye.graphql.client.GraphQLClientsConfiguration;
 import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
 
 public class TypesafeGraphQLClientExtension implements Extension {
@@ -34,5 +35,6 @@ public class TypesafeGraphQLClientExtension implements Extension {
         for (Class<?> api : apis) {
             afterBeanDiscovery.addBean(new TypesafeGraphQLClientBean<>(api));
         }
+        GraphQLClientsConfiguration.apiClasses(apis);
     }
 }

--- a/client/tck/src/main/java/tck/graphql/typesafe/ConfigBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/ConfigBehavior.java
@@ -6,10 +6,14 @@ import static org.assertj.core.api.BDDAssertions.then;
 import java.net.URI;
 import java.util.NoSuchElementException;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
 
+// FIXME: doesn't work without a CDI container now because the configuration is stored in a CDI bean
+// Do we move this into an integration test module?
+@Disabled
 class ConfigBehavior {
     private final TypesafeGraphQLClientFixture fixture = TypesafeGraphQLClientFixture.load();
 


### PR DESCRIPTION
This unifies all client-related configuration into a single CDI bean that is initialized during startup and all clients will look into that bean instead of reading the config values directly. The bean recognizes the `*/mp-graphql/*` properties, so the plan is that Quarkus will "enhance" the configuration with what it recognizes beyond that (`quarkus.*` properties).

This also allows to define HTTP headers for the typesafe client using configuration `clientname/mp-graphql/header/headerKey=headerValue`, in Quarkus this will also work with `quarkus.smallrye-graphql-client.clientname.header.headerKey=headerValue`

One more plan for the future is to include information derived from annotations into this new configuration bean. Right now, the typesafe client reads annotations at runtime for each invocation, which is very slow. But to be able to scan the annotations just once during boot, we will need to include Jandex dependency in the client module. This will probably be done as part of https://github.com/smallrye/smallrye-graphql/issues/873

After releasing with this PR, the Quarkus upgrade will need to include this: https://github.com/jmartisk/quarkus/commits/graphql-client-config 