### PR TITLE
Very hacky fix for quarkus issue 18194 - using typesafe client with `…

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/MethodInvocation.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/MethodInvocation.java
@@ -123,7 +123,8 @@ public class MethodInvocation {
             this.parameters = IntStream.range(0, method.getParameterCount())
                     .mapToObj(i -> new ParameterInfo(this,
                             method.getParameters()[i],
-                            parameterValues[i]))
+                            parameterValues[i],
+                            method.getGenericParameterTypes()[i]))
                     .collect(toList());
         return parameters.stream();
     }


### PR DESCRIPTION
…@NonNull` types

I'm utterly disgusted by this, but this is the best solution I can come up with for now.
This fixes native mode usage of queries containing `@NonNull` types. Unfortunately, for now, only on top level of arguments.
So `@NonNull List<String>` will work but `@NonNull List<@NonNull String>` will not.
Tests will be on the Quarkus side only, because this is native mode specific.