### PR TITLE
Fix tracing somewhat

### DIFF
--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/tracing/TracingService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/tracing/TracingService.java
@@ -18,6 +18,7 @@ import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNamedType;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLType;
+import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.smallrye.graphql.api.Context;
@@ -27,19 +28,31 @@ import io.smallrye.graphql.spi.EventingService;
 /**
  * Listening for event and create traces from it
  *
+ * FIXME: currently, this places the work of all fetchers inside an operation (execution)
+ * under the same parent, which is the execution itself. It would be cool
+ * to define some reasonable hierarchy between fetchers, so
+ * for example, when evaluating a source method requires evaluating another source method,
+ * the second one would be a child of the first one.
+ *
  * @author Jan Martiska (jmartisk@redhat.com)
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class TracingService implements EventingService {
 
     private final String SPAN_CLASS = "io.opentracing.Span";
+    private final String SCOPE_CLASS = "io.opentracing.Scope";
+
+    // key = execution ID
+    // value = the root span of this execution
     private final Map<String, Span> spans = Collections.synchronizedMap(new IdentityHashMap<>());
+    private final Map<String, Scope> scopes = Collections.synchronizedMap(new IdentityHashMap<>());
 
     private Tracer tracer;
 
     @Override
     public void beforeExecute(Context context) {
         ExecutionInput executionInput = context.unwrap(ExecutionInput.class);
+        // FIXME: if operationName is not set in the request explicitly, this is empty
         String operationName = getOperationName(executionInput);
 
         Span span = getTracer().buildSpan(operationName)
@@ -48,39 +61,17 @@ public class TracingService implements EventingService {
                 .withTag("graphql.operationType", getOperationNameString(context.getRequestedOperationTypes()))
                 .withTag("graphql.operationName", context.getOperationName().orElse(EMPTY))
                 .start();
-        tracer.activateSpan(span);
-
-        ((GraphQLContext) executionInput.getContext()).put(SPAN_CLASS, span); // TODO: Do we need this ?
-    }
-
-    @Override
-    public void beforeDataFetch(Context context) {
-        final DataFetchingEnvironment env = context.unwrap(DataFetchingEnvironment.class);
-
-        Span parentSpan = getParentSpan(getTracer(), env);
-
-        Span span = getTracer().buildSpan(getOperationName(env))
-                .asChildOf(parentSpan)
-                .withTag("graphql.executionId", context.getExecutionId())
-                .withTag("graphql.operationType", getOperationNameString(context.getOperationType()))
-                .withTag("graphql.operationName", context.getOperationName().orElse(EMPTY))
-                .withTag("graphql.parent", context.getParentTypeName().orElse(EMPTY))
-                .withTag("graphql.field", context.getFieldName())
-                .withTag("graphql.path", context.getPath())
-                .start();
-        tracer.activateSpan(span);
-
-        GraphQLContext graphQLContext = env.getContext();
-        graphQLContext.put(SPAN_CLASS, span);
-
+        Scope scope = tracer.activateSpan(span);
         spans.put(context.getExecutionId(), span);
+        scopes.put(context.getExecutionId(), scope);
     }
 
     @Override
-    public void errorDataFetch(String executionId, Throwable t) {
-        Span span = spans.get(executionId);
+    public void afterExecute(Context context) {
+        Span span = spans.remove(context.getExecutionId());
         if (span != null) {
-            logError(span, t);
+            scopes.get(context.getExecutionId()).close();
+            span.finish();
         }
     }
 
@@ -92,13 +83,49 @@ public class TracingService implements EventingService {
             error.put("event.object", t);
             error.put("event", "error");
             span.log(error);
+            span.finish();
         }
     }
 
     @Override
+    public void beforeDataFetch(Context context) {
+        final DataFetchingEnvironment env = context.unwrap(DataFetchingEnvironment.class);
+        Span parentSpan = getParentSpan(getTracer(), env);
+
+        Span span = getTracer().buildSpan(getOperationName(env))
+                .asChildOf(parentSpan)
+                .withTag("graphql.executionId", context.getExecutionId())
+                .withTag("graphql.operationType", getOperationNameString(context.getOperationType()))
+                .withTag("graphql.operationName", context.getOperationName().orElse(EMPTY))
+                .withTag("graphql.parent", context.getParentTypeName().orElse(EMPTY))
+                .withTag("graphql.field", context.getFieldName())
+                .withTag("graphql.path", context.getPath())
+                .start();
+        Scope scope = tracer.activateSpan(span);
+
+        GraphQLContext graphQLContext = env.getContext();
+        graphQLContext.put(SPAN_CLASS, parentSpan);
+        graphQLContext.put(SCOPE_CLASS, scope);
+    }
+
+    // FIXME: is the fetcher is asynchronous, this typically ends its span before
+    // the work is actually done - after the fetcher itself returns a future.
+    // We currently don't have a way to find out when
+    // the right moment to close this span is
+    @Override
     public void afterDataFetch(Context context) {
-        Span span = spans.remove(context.getExecutionId());
+        Span span = tracer.activeSpan();
+        Scope scope = ((GraphQLContext) context.unwrap(DataFetchingEnvironment.class).getContext()).get(SCOPE_CLASS);
+        scope.close();
         span.finish();
+    }
+
+    @Override
+    public void errorDataFetch(String executionId, Throwable t) {
+        Span span = spans.get(executionId);
+        if (span != null) {
+            logError(span, t);
+        }
     }
 
     @Override
@@ -115,13 +142,13 @@ public class TracingService implements EventingService {
 
     private Span getParentSpan(Tracer tracer, final DataFetchingEnvironment env) {
         final GraphQLContext localContext = env.getLocalContext();
-        if (localContext != null && localContext.hasKey(Span.class)) {
-            return localContext.get(Span.class);
+        if (localContext != null && localContext.hasKey(SPAN_CLASS)) {
+            return localContext.get(SPAN_CLASS);
         }
 
         final GraphQLContext rootContext = env.getContext();
-        if (rootContext != null && rootContext.hasKey(Span.class)) {
-            return rootContext.get(Span.class);
+        if (rootContext != null && rootContext.hasKey(SPAN_CLASS)) {
+            return rootContext.get(SPAN_CLASS);
         }
 
         return tracer.activeSpan();

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/ComplexOpenTracingTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/ComplexOpenTracingTest.java
@@ -1,0 +1,115 @@
+package io.smallrye.graphql.tests.tracing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.smallrye.graphql.tests.GraphQLAssured;
+
+@RunWith(Arquillian.class)
+public class ComplexOpenTracingTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "tracing-test.war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsResource(new StringAsset("smallrye.graphql.tracing.enabled=true"),
+                        "META-INF/microprofile-config.properties")
+                .addClasses(TracerProducer.class, DummyGraphQLApi.class, Foo.class, Foo2.class, Foo3.class);
+    }
+
+    @ArquillianResource
+    URL testingURL;
+
+    @Inject
+    MockTracer tracer;
+
+    @Before
+    public void prepare() {
+        tracer.reset();
+    }
+
+    @Test
+    public void testThreeTraces() {
+        GraphQLAssured graphQLAssured = new GraphQLAssured(testingURL);
+        String query = "{"
+                + " foo {"
+                + "     foo2 {"
+                + "         foo3 {"
+                + "             value"
+                + "         }"
+                + "     }"
+                + "     foo2uni {"
+                + "         value"
+                + "     }"
+                + "}}";
+
+        // execute three times to create three traces
+        graphQLAssured.post(query);
+        graphQLAssured.post(query);
+        // log one of the responses to facilitate debugging
+        System.out.println("Query response: " + graphQLAssured.post(query));
+        System.out.println("Finished spans: " + tracer.finishedSpans());
+
+        Map<Long, List<MockSpan>> groupedByTraceId = tracer.finishedSpans()
+                .stream()
+                .collect(Collectors.groupingBy(span -> span.context().traceId()));
+        // we created 3 traces, so after grouping by trace ID, we should have 3 groups
+        assertEquals(3, groupedByTraceId.size());
+
+        // and each group should have the same structure because the query was the same
+        for (Map.Entry<Long, List<MockSpan>> entry : groupedByTraceId.entrySet()) {
+            List<MockSpan> spanList = entry.getValue();
+
+            // find the root span of this trace
+            List<MockSpan> spansWithoutParent = spanList.stream().filter(s -> s.parentId() == 0)
+                    .collect(Collectors.toList());
+            assertEquals("Each trace needs to have exactly one span without a parent. List of spans: " + spanList,
+                    1, spansWithoutParent.size());
+            MockSpan parentSpan = spansWithoutParent.get(0);
+
+            assertTrue("Parent span needs to be named GraphQL",
+                    parentSpan.operationName().startsWith("GraphQL"));
+
+            MockSpan fooSpan = findSpan("GraphQL:Query.foo", spanList);
+            assertEquals("/foo", fooSpan.tags().get("graphql.path"));
+
+            MockSpan foo2Span = findSpan("GraphQL:Foo.foo2", spanList);
+            assertEquals("/foo/foo2", foo2Span.tags().get("graphql.path"));
+
+            MockSpan foo3Span = findSpan("GraphQL:Foo2.foo3", spanList);
+            assertEquals("/foo/foo2/foo3", foo3Span.tags().get("graphql.path"));
+
+            MockSpan foo2UniSpan = findSpan("GraphQL:Foo.foo2uni", spanList);
+            assertEquals("/foo/foo2uni", foo2UniSpan.tags().get("graphql.path"));
+        }
+
+    }
+
+    private MockSpan findSpan(String operationName, List<MockSpan> spans) {
+        return spans.stream()
+                .filter(span -> (span.operationName().equals(operationName)))
+                .findFirst()
+                .get();
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/DummyGraphQLApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/DummyGraphQLApi.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.graphql.Query;
 import org.eclipse.microprofile.graphql.Source;
 
 import io.opentracing.Tracer;
+import io.smallrye.mutiny.Uni;
 
 @GraphQLApi
 @ApplicationScoped
@@ -27,6 +28,11 @@ public class DummyGraphQLApi {
         return foo;
     }
 
+    @Query(value = "foo")
+    public Foo foo() {
+        return new Foo();
+    }
+
     @Mutation(value = "mutate")
     public Foo mutation() {
         foo.update();
@@ -36,6 +42,18 @@ public class DummyGraphQLApi {
     @Name("description")
     public String source(@Source Foo foo) {
         return "Awesome";
+    }
+
+    public Foo2 foo2(@Source Foo foo) {
+        return new Foo2(4);
+    }
+
+    public Uni<Foo2> foo2uni(@Source Foo foo) {
+        return Uni.createFrom().item(new Foo2(3));
+    }
+
+    public Foo3 foo3(@Source Foo2 foo2) {
+        return new Foo3(5);
     }
 
 }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/Foo2.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/Foo2.java
@@ -1,0 +1,18 @@
+package io.smallrye.graphql.tests.tracing;
+
+public class Foo2 {
+
+    private int value;
+
+    public Foo2(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/Foo3.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/Foo3.java
@@ -1,0 +1,19 @@
+package io.smallrye.graphql.tests.tracing;
+
+public class Foo3 {
+
+    private int value;
+
+    public Foo3(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/TracerProducer.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/TracerProducer.java
@@ -3,6 +3,7 @@ package io.smallrye.graphql.tests.tracing;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.Typed;
 import javax.inject.Singleton;
 
 import io.opentracing.Tracer;
@@ -13,7 +14,8 @@ public class TracerProducer {
     @Default
     @Produces
     @Singleton
-    public Tracer tracer() {
+    @Typed({ Tracer.class, MockTracer.class })
+    public MockTracer tracer() {
         return new MockTracer();
     }
 }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/TracingTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/tracing/TracingTest.java
@@ -27,7 +27,7 @@ public class TracingTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsResource(new StringAsset("smallrye.graphql.tracing.enabled=true"),
                         "META-INF/microprofile-config.properties")
-                .addClasses(TracerProducer.class, DummyGraphQLApi.class, Foo.class);
+                .addClasses(TracerProducer.class, DummyGraphQLApi.class, Foo.class, Foo2.class, Foo3.class);
     }
 
     @ArquillianResource


### PR DESCRIPTION
Fixes #875 

This improves some issues with tracing, namely:
- The root span of an execution seemed to not be finished properly, and didn't appear in Jaeger
- If an operation involved source methods, the invocation of each source method seemed to be added as a child of the previous one, rather than be on the same level

There is still a lot to improve though:
- An asynchronous data fetcher produces a span that lasts only until the method itself returns, not until the asynchronous computation is finished. I'm not sure how to do that though.
- Similarly, not sure how to handle subscriptions - right now they produce a span until the `@Subscription` method itself returns. But there's probably nothing else to trace in such case, everything else that is involved then is application code.
- It would be cool to define some reasonable hierarchy between fetchers, so for example, when evaluating a source method requires evaluating another source method, the second one would be a child of the first one. But there's currently no straightforward way to detect such hierarchy by the tracing service, or at least not that I'm aware of

How it works after this PR:
Example for a querying a list of users:
```
all {
    name 
    gender 
    secretToken 
    secretToken2 
    car { 
        color 
        year
    }
}
```
`secretToken`, `secretToken2`, `car` and `car.year` are `@Source`s.

![image](https://user-images.githubusercontent.com/937315/125946529-c2017c7f-541a-4398-ae63-dc13f8b658f2.png)

I'm not quite sure I know what I'm doing (tracing is a bit mysterious to me) so suggestions welcome
