### PR TITLE
Use a map for schemas inside SmallRyeContext to properly support mult…

### DIFF
--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/producer/GraphQLProducer.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/producer/GraphQLProducer.java
@@ -21,16 +21,24 @@ public class GraphQLProducer {
     }
 
     public GraphQLSchema initialize(Schema schema) {
-        this.schema = schema;
-        return initialize();
+        return initialize(schema, false);
     }
 
-    public GraphQLSchema initialize() {
+    public GraphQLSchema initialize(Schema schema, boolean allowMultipleDeployments) {
+        this.schema = schema;
+        return initialize(allowMultipleDeployments);
+    }
 
-        this.graphQLSchema = Bootstrap.bootstrap(schema);
+    public GraphQLSchema initialize(boolean allowMultipleDeployments) {
+
+        this.graphQLSchema = Bootstrap.bootstrap(schema, allowMultipleDeployments);
         this.executionService = new ExecutionService(graphQLSchema, this.schema.getBatchOperations(),
                 schema.hasSubscriptions());
         return this.graphQLSchema;
+    }
+
+    public GraphQLSchema initialize() {
+        return initialize(false);
     }
 
     @Produces

--- a/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/StartupListener.java
+++ b/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/StartupListener.java
@@ -55,7 +55,7 @@ public class StartupListener implements ServletContextListener {
             IndexView index = indexInitializer.createIndex(warURLs);
 
             Schema schema = SchemaBuilder.build(index); // Get the smallrye schema
-            GraphQLSchema graphQLSchema = graphQLProducer.initialize(schema);
+            GraphQLSchema graphQLSchema = graphQLProducer.initialize(schema, true);
 
             sce.getServletContext().setAttribute(SchemaServlet.SCHEMA_PROP, graphQLSchema);
             SmallRyeGraphQLServletLogging.log.initialized();

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -99,8 +99,12 @@ public class Bootstrap {
     private final ClassloadingService classloadingService = ClassloadingService.get();
 
     public static GraphQLSchema bootstrap(Schema schema) {
+        return bootstrap(schema, false);
+    }
+
+    public static GraphQLSchema bootstrap(Schema schema, boolean allowMultipleDeployments) {
         if (schema != null && (schema.hasOperations())) {
-            Bootstrap bootstrap = new Bootstrap(schema);
+            Bootstrap bootstrap = new Bootstrap(schema, allowMultipleDeployments);
             bootstrap.generateGraphQLSchema();
             return bootstrap.graphQLSchema;
         } else {
@@ -109,9 +113,9 @@ public class Bootstrap {
         }
     }
 
-    private Bootstrap(Schema schema) {
+    private Bootstrap(Schema schema, boolean allowMultipleDeployments) {
         this.schema = schema;
-        SmallRyeContext.setSchema(schema);
+        SmallRyeContext.setSchema(schema, allowMultipleDeployments);
         if (!Boolean.getBoolean("test.skip.injection.validation")) {
             verifyInjectionIsAvailable();
         }


### PR DESCRIPTION
…iple applications in one JVM

This is quite ugly, but I don't know how to do this better. It would be much better to store any static  application-specific things in an application-scoped bean rather than using this crap, but this is in the `implementation` module without CDI.

Best would be to avoid any static fields whatsoever.

Fixes #955 
Test coverage will be on the WF feature pack side