### PR TITLE
Remove CDI requirement from the client

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/dynamic/vertx/VertxDynamicGraphQLClientBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/dynamic/vertx/VertxDynamicGraphQLClientBuilder.java
@@ -1,7 +1,5 @@
 package io.smallrye.graphql.client.dynamic.vertx;
 
-import javax.enterprise.inject.spi.CDI;
-
 import io.smallrye.graphql.client.ErrorMessageProvider;
 import io.smallrye.graphql.client.GraphQLClientConfiguration;
 import io.smallrye.graphql.client.GraphQLClientsConfiguration;
@@ -60,14 +58,7 @@ public class VertxDynamicGraphQLClientBuilder implements DynamicGraphQLClientBui
     @Override
     public DynamicGraphQLClient build() {
         if (configKey != null) {
-            GraphQLClientConfiguration persistentConfig;
-            try {
-                persistentConfig = CDI.current()
-                        .select(GraphQLClientsConfiguration.class).get()
-                        .getClients().get(configKey);
-            } catch (IllegalStateException ex) {
-                persistentConfig = null;
-            }
+            GraphQLClientConfiguration persistentConfig = GraphQLClientsConfiguration.getInstance().getClient(configKey);
             if (persistentConfig != null) {
                 applyConfig(persistentConfig);
             }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/TypesafeClientConfigurationReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/TypesafeClientConfigurationReader.java
@@ -19,10 +19,7 @@ class TypesafeClientConfigurationReader {
 
     TypesafeClientConfigurationReader(Class<?> apiClass) {
         GraphQLClientApi annotation = apiClass.getAnnotation(GraphQLClientApi.class);
-        if (annotation == null) {
-            throw new RuntimeException("Could not find a GraphQLClientApi annotation on " + apiClass);
-        }
-        configKey = !annotation.configKey().isEmpty() ? annotation.configKey() : apiClass.getName();
+        configKey = (annotation != null && !annotation.configKey().isEmpty()) ? annotation.configKey() : apiClass.getName();
         clientConfiguration = new GraphQLClientConfiguration();
 
         // Now, read configuration from config properties.
@@ -34,9 +31,8 @@ class TypesafeClientConfigurationReader {
         if (configuredUrl.isPresent()) {
             clientConfiguration.setUrl(configuredUrl.get());
         } else {
-            String endpointFromAnnotation = annotation.endpoint();
-            if (!endpointFromAnnotation.isEmpty()) {
-                clientConfiguration.setUrl(endpointFromAnnotation);
+            if (annotation != null && !annotation.endpoint().isEmpty()) {
+                clientConfiguration.setUrl(annotation.endpoint());
             }
         }
 

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/cdi/NamedDynamicClients.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/cdi/NamedDynamicClients.java
@@ -10,7 +10,6 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
-import javax.inject.Inject;
 
 import io.smallrye.graphql.client.GraphQLClient;
 import io.smallrye.graphql.client.GraphQLClientsConfiguration;
@@ -22,12 +21,12 @@ public class NamedDynamicClients {
 
     private final String DEFAULT_CLIENT_NAME = "default";
 
-    @Inject
     GraphQLClientsConfiguration globalConfig;
 
     @PostConstruct
     void initialize() {
         createdClients = new HashMap<>();
+        globalConfig = GraphQLClientsConfiguration.getInstance();
     }
 
     private Map<String, DynamicGraphQLClient> createdClients;

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/cdi/TypesafeGraphQLClientExtension.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/cdi/TypesafeGraphQLClientExtension.java
@@ -35,6 +35,6 @@ public class TypesafeGraphQLClientExtension implements Extension {
         for (Class<?> api : apis) {
             afterBeanDiscovery.addBean(new TypesafeGraphQLClientBean<>(api));
         }
-        GraphQLClientsConfiguration.apiClasses(apis, false);
+        GraphQLClientsConfiguration.getInstance().addTypesafeClientApis(apis);
     }
 }

--- a/client/tck/pom.xml
+++ b/client/tck/pom.xml
@@ -28,10 +28,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-graphql-client-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.microprofile.graphql</groupId>
             <artifactId>microprofile-graphql-api</artifactId>
         </dependency>
@@ -69,6 +65,10 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/client/tck/src/main/java/tck/graphql/typesafe/ConfigBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/ConfigBehavior.java
@@ -11,14 +11,25 @@ import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
 
-// FIXME: doesn't work without a CDI container now because the configuration is stored in a CDI bean
-// Do we move this into an integration test module?
-@Disabled
 class ConfigBehavior {
     private final TypesafeGraphQLClientFixture fixture = TypesafeGraphQLClientFixture.load();
 
     @GraphQLClientApi
     interface Api {
+        @SuppressWarnings("UnusedReturnValue")
+        boolean foo();
+    }
+
+    // Can't reuse the Api interface for multiple tests with different configurations, because the property-based configuration for
+    // clients is read only once per JVM/process
+    @GraphQLClientApi
+    interface Api2 {
+        @SuppressWarnings("UnusedReturnValue")
+        boolean foo();
+    }
+
+    @GraphQLClientApi
+    interface Api3 {
         @SuppressWarnings("UnusedReturnValue")
         boolean foo();
     }
@@ -29,33 +40,36 @@ class ConfigBehavior {
                 NoSuchElementException.class);
 
         then(thrown)
-                .hasMessageContaining("SRCFG00014")
+                .hasMessageContaining("SRGQLDC035001")
                 .hasMessageContaining(API_URL_CONFIG_KEY);
     }
 
     @Test
     void shouldLoadEndpointConfig() {
-        System.setProperty(API_URL_CONFIG_KEY, DUMMY_ENDPOINT);
+        System.setProperty(API2_URL_CONFIG_KEY, DUMMY_ENDPOINT);
         try {
             fixture.returnsData("'foo':true");
-            Api api = fixture.builderWithoutEndpointConfig().build(Api.class);
+            Api2 api = fixture.builderWithoutEndpointConfig().build(Api2.class);
 
             api.foo();
 
             then(fixture.endpointUsed()).isEqualTo(DUMMY_ENDPOINT_URI);
         } finally {
-            System.clearProperty(API_URL_CONFIG_KEY);
+            System.clearProperty(API2_URL_CONFIG_KEY);
         }
     }
 
+    // Disabled - client configuration using config keys is currently read only once at startup, thus this won't be discovered
+    // if added so late
+    @Disabled
     @Test
     void shouldLoadEndpointFromKeyConfig() {
         System.setProperty("dummy-config-key/mp-graphql/url", DUMMY_ENDPOINT);
         try {
             fixture.returnsData("'foo':true");
-            Api api = fixture.builderWithoutEndpointConfig()
+            Api3 api = fixture.builderWithoutEndpointConfig()
                     .configKey("dummy-config-key")
-                    .build(Api.class);
+                    .build(Api3.class);
 
             api.foo();
 
@@ -102,6 +116,7 @@ class ConfigBehavior {
     }
 
     private static final String API_URL_CONFIG_KEY = Api.class.getName() + "/mp-graphql/url";
+    private static final String API2_URL_CONFIG_KEY = Api2.class.getName() + "/mp-graphql/url";
     private static final String DUMMY_ENDPOINT = "http://dummy-configured-endpoint";
     private static final URI DUMMY_ENDPOINT_URI = URI.create(DUMMY_ENDPOINT);
 }

--- a/client/tck/src/main/java/tck/graphql/typesafe/ErrorBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/ErrorBehavior.java
@@ -559,6 +559,7 @@ class ErrorBehavior {
         then(error.getErrorCode()).isEqualTo("team-search-disabled");
     }
 
+    @GraphQLClientApi
     interface OrderApi {
         @SuppressWarnings("UnusedReturnValue")
         Order order(@NonNull String id);

--- a/client/tck/src/main/java/tck/graphql/typesafe/ScalarBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/ScalarBehavior.java
@@ -830,6 +830,7 @@ class ScalarBehavior {
         }
     }
 
+    @GraphQLClientApi
     interface StringGettersApi {
         String getGreeting();
 


### PR DESCRIPTION
allow fully running in plain Java SE environment

Fixes #967 

This will need minor changes in Quarkus - the branch for that is https://github.com/jmartisk/quarkus/tree/main-srgql-967 

I reenabled most of the previously disabled tests (disabled because they didn't work due to missing CDI during their runtime), but some of them had a problem with how we generally only try to read the client configuration once per JVM and consider it immutable then, so I changed them a little bit.