### PR TITLE
Support records as inputs in clients

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [8, 11, 16]
     name: build with jdk ${{matrix.java}}
 
     steps:

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/ErrorImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/ErrorImpl.java
@@ -70,7 +70,7 @@ public class ErrorImpl implements Error {
 
     @Override
     public String toString() {
-        String other = otherFields.isEmpty() ? "" : ", otherFields=" + otherFields;
+        String other = (otherFields == null || otherFields.isEmpty()) ? "" : ", otherFields=" + otherFields;
         return "GraphQLError{message=" + message +
                 ", locations=" + locations +
                 ", path=" + Arrays.toString(path) +

--- a/pom.xml
+++ b/pom.xml
@@ -411,5 +411,21 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>jdk16plus</id>
+            <activation>
+                <jdk>[16,)</jdk>
+            </activation>
+            <modules>
+                <module>server/integration-tests-jdk16</module>
+            </modules>
+            <properties>
+                <!-- FIXME: hack to allow powerannotations TCK to pass on JDK 16 -->
+                <powerannotations.tck.argLine>--add-opens java.base/java.util=ALL-UNNAMED</powerannotations.tck.argLine>
+                <!-- FIXME: find out why Gradle build doesn't work on JDK 16 in GH actions,
+                        but seems to work locally -->
+                <skip.gradle.build>true</skip.gradle.build>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/power-annotations/tck/pom.xml
+++ b/power-annotations/tck/pom.xml
@@ -52,6 +52,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <groups>!InheritedAnnotationsTestSuite &amp; !TypeToMemberAnnotationsTestSuite</groups>
+                    <!-- FIXME: this is a dirty hack to make the TCK pass on JDK 16 -->
+                    <argLine>${powerannotations.tck.argLine}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/server/integration-tests-jdk16/pom.xml
+++ b/server/integration-tests-jdk16/pom.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>smallrye-graphql-server-parent</artifactId>
+        <groupId>io.smallrye</groupId>
+        <version>1.3.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>smallrye-graphql-integration-tests-jdk16</artifactId>
+    <name>SmallRye: GraphQL Server :: Integration Tests :: Java 16+ tests</name>
+
+    <properties>
+        <maven.compiler.target>16</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Dynamic client -->
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-implementation-vertx</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- The API is copied into SmallRye for now -->
+        <!--        <dependency>-->
+        <!--            <groupId>org.eclipse.microprofile.graphql</groupId>-->
+        <!--            <artifactId>microprofile-graphql-client-api</artifactId>-->
+        <!--            <scope>test</scope>-->
+        <!--        </dependency>-->
+
+        <!-- Container -->
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-jetty-embedded-9</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-deploy</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>javax-websocket-client-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>javax-websocket-server-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.servlet</groupId>
+            <artifactId>weld-servlet-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-opentracing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.context-propagation</groupId>
+            <artifactId>microprofile-context-propagation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-context-propagation</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny-smallrye-context-propagation</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.graphql</groupId>
+            <artifactId>microprofile-graphql-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reuseForks>false</reuseForks>
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
+            <!-- FIXME: There's no version of impsort plugin yet that properly supports
+                Java 16 sources. Exclude impsort on this module for now. -->
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>16</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/server/integration-tests-jdk16/src/main/java/io/smallrye/graphql/tests/SmallRyeGraphQLArchiveProcessor.java
+++ b/server/integration-tests-jdk16/src/main/java/io/smallrye/graphql/tests/SmallRyeGraphQLArchiveProcessor.java
@@ -1,0 +1,39 @@
+package io.smallrye.graphql.tests;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+/**
+ * Creates the deployable unit with all the needed dependencies.
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class SmallRyeGraphQLArchiveProcessor implements ApplicationArchiveProcessor {
+
+    @Override
+    public void process(Archive<?> applicationArchive, TestClass testClass) {
+
+        if (applicationArchive instanceof WebArchive) {
+            WebArchive testDeployment = (WebArchive) applicationArchive;
+
+            final File[] dependencies = Maven.resolver()
+                    .loadPomFromFile("pom.xml")
+                    .resolve("io.smallrye:smallrye-graphql-servlet")
+                    .withoutTransitivity()
+                    .asFile();
+            // Make sure it's unique
+            Set<File> dependenciesSet = new LinkedHashSet<>(Arrays.asList(dependencies));
+            testDeployment.addAsLibraries(dependenciesSet.toArray(new File[] {}));
+        }
+
+        System.out.println(applicationArchive.toString(true));
+    }
+}

--- a/server/integration-tests-jdk16/src/main/java/io/smallrye/graphql/tests/SmallRyeGraphQLExtension.java
+++ b/server/integration-tests-jdk16/src/main/java/io/smallrye/graphql/tests/SmallRyeGraphQLExtension.java
@@ -1,0 +1,17 @@
+package io.smallrye.graphql.tests;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * Activating the extension
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class SmallRyeGraphQLExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(ApplicationArchiveProcessor.class, SmallRyeGraphQLArchiveProcessor.class);
+    }
+
+}

--- a/server/integration-tests-jdk16/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/server/integration-tests-jdk16/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+io.smallrye.graphql.tests.SmallRyeGraphQLExtension

--- a/server/integration-tests-jdk16/src/test/java/io/smallrye/graphql/tests/client/RecordAsInputToDynamicClientTest.java
+++ b/server/integration-tests-jdk16/src/test/java/io/smallrye/graphql/tests/client/RecordAsInputToDynamicClientTest.java
@@ -1,0 +1,97 @@
+package io.smallrye.graphql.tests.client;
+
+import io.smallrye.graphql.client.Response;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
+import io.smallrye.graphql.client.dynamic.vertx.VertxDynamicGraphQLClientBuilder;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Verify that dynamic clients can parse Java records from responses
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class RecordAsInputToDynamicClientTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(SimpleRecord.class);
+    }
+
+    @ArquillianResource
+    URL testingURL;
+
+    @Test
+    public void testSimpleRecord() throws Exception {
+        try (DynamicGraphQLClient client = new VertxDynamicGraphQLClientBuilder()
+                .url(testingURL.toString() + "graphql").build()) {
+            Response response = client.executeSync("query { simple {a b} }");
+            SimpleRecord result = response.getObject(SimpleRecord.class, "simple");
+            assertEquals("a", result.a());
+            assertEquals("b", result.b());
+        }
+
+    }
+
+    /**
+     * Try selecting only a subset of fields supported by the record.
+     */
+    @Test
+    public void testPartial() throws Exception {
+        try (DynamicGraphQLClient client = new VertxDynamicGraphQLClientBuilder()
+                .url(testingURL.toString() + "graphql").build()) {
+            Response response = client.executeSync("query { simple {a} }");
+            SimpleRecord result = response.getObject(SimpleRecord.class, "simple");
+            assertEquals("a", result.a());
+            assertNull(result.b());
+        }
+
+    }
+
+    /**
+     * Just to be sure that if I reverse the order of fields in the query,
+     * they won't get mixed up on the client side.
+     */
+    @Test
+    public void testReversed() throws Exception {
+        try (DynamicGraphQLClient client = new VertxDynamicGraphQLClientBuilder()
+                .url(testingURL.toString() + "graphql").build()) {
+            Response response = client.executeSync("query { simple {b a} }");
+            SimpleRecord result = response.getObject(SimpleRecord.class, "simple");
+            assertEquals("a", result.a());
+            assertEquals("b", result.b());
+        }
+
+    }
+
+    @GraphQLApi
+    public static class Api {
+
+        @Query
+        public SimpleRecord simple() {
+            return new SimpleRecord("a", "b");
+        }
+
+    }
+
+    public record SimpleRecord(String a, String b) {
+    }
+
+}

--- a/server/integration-tests-jdk16/src/test/java/io/smallrye/graphql/tests/client/RecordAsInputToTypesafeClientTest.java
+++ b/server/integration-tests-jdk16/src/test/java/io/smallrye/graphql/tests/client/RecordAsInputToTypesafeClientTest.java
@@ -1,0 +1,67 @@
+package io.smallrye.graphql.tests.client;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.graphql.client.typesafe.api.TypesafeGraphQLClientBuilder;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class RecordAsInputToTypesafeClientTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(SimpleRecord.class);
+    }
+
+    @ArquillianResource
+    URL testingURL;
+
+    @Test
+    public void testSimpleRecord() {
+        ClientApi client = TypesafeGraphQLClientBuilder.newBuilder()
+                .endpoint(testingURL.toString() + "graphql")
+                .build(ClientApi.class);
+        SimpleRecord result = client.simple();
+        assertEquals("a", result.a());
+        assertEquals("b", result.b());
+    }
+
+    @GraphQLClientApi
+    public interface ClientApi {
+
+        @Query
+        SimpleRecord simple();
+
+    }
+
+    @GraphQLApi
+    public static class Api implements ClientApi {
+
+        @Query
+        public SimpleRecord simple() {
+            return new SimpleRecord("a", "b");
+        }
+
+    }
+
+    public record SimpleRecord(String a, String b) {
+    }
+
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -29,5 +29,5 @@
         <module>integration-tests</module>
         <module>federation</module>
     </modules>
-    
+
 </project>

--- a/server/runner/pom.xml
+++ b/server/runner/pom.xml
@@ -149,7 +149,17 @@
                         </users>
                     </add-user>
                 </configuration>
-            </plugin>    
+            </plugin>
+
+            <!-- not completely sure about this, but this is needed to build successfully on JDK 16 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/tools/gradle-plugin/pom.xml
+++ b/tools/gradle-plugin/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <gradle.executable>./gradlew</gradle.executable>
         <gradle.task>build</gradle.task>
-        <skip.gradle.build>false</skip.gradle.build>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Part of the solution for #971 

Adds an integration testing module that uses Java 16 source, therefore we can use that to test anything that uses language features from newer Java versions than 8 (the baseline of our build). This module is activated only when building with JDK >= 16.

Adds a JDK 16 job to the CI.