### PR TITLE
Avoid intializing CDI beans in STATIC_INIT

### DIFF
--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CdiLookupService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CdiLookupService.java
@@ -26,4 +26,9 @@ public class CdiLookupService implements LookupService {
     public Object getInstance(Class<?> declaringClass) {
         return CDI.current().select(declaringClass).get();
     }
+
+    @Override
+    public boolean isResolvable(Class<?> declaringClass) {
+        return CDI.current().select(declaringClass).isResolvable();
+    }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -139,10 +139,8 @@ public class Bootstrap {
                 .flatMap(stream -> stream)
                 .distinct().forEach(beanClassName -> {
                     // verify that the bean is injectable
-                    try {
-                        lookupService.getClass(classloadingService.loadClass(beanClassName));
-                    } catch (Exception e) {
-                        throw SmallRyeGraphQLServerMessages.msg.canNotInjectClass(beanClassName, e);
+                    if (!lookupService.isResolvable(classloadingService.loadClass(beanClassName))) {
+                        throw SmallRyeGraphQLServerMessages.msg.canNotInjectClass(beanClassName, null);
                     }
                 });
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/LookupService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/LookupService.java
@@ -40,6 +40,8 @@ public interface LookupService {
 
     Object getInstance(Class<?> declaringClass);
 
+    boolean isResolvable(Class<?> declaringClass);
+
     /**
      * Default Lookup service that gets used when none is provided with SPI.
      * This use reflection
@@ -64,6 +66,11 @@ public interface LookupService {
                     | IllegalArgumentException | InvocationTargetException ex) {
                 throw msg.countNotGetInstance(ex);
             }
+        }
+
+        @Override
+        public boolean isResolvable(Class<?> declaringClass) {
+            return true;
         }
     }
 }


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/issues/20199

Quarkus side will receive a test along with the smallrye-graphql upgrade: https://github.com/jmartisk/quarkus/commit/f480b9a0c97fcb5257d3980cd1f9a7a2209bd7aa