### PR TITLE
Make sure server/integration-tests-jdk16 module gets its version upda…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,11 @@ jobs:
           git config --global user.name "SmallRye CI"
           git config --global user.email "smallrye@googlegroups.com"
           git checkout -b release
-          mvn -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}} -s maven-settings.xml
+          # make sure the server/integration-tests-jdk16 gets its version updated too: include the jdk16plus profile
+          mvn -B release:prepare -Prelease -Pjdk16plus -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}} -s maven-settings.xml
           git checkout ${{github.base_ref}}
           git rebase release
-          mvn -B release:perform -Prelease -s maven-settings.xml
+          mvn -B release:perform -Prelease -Pjdk16plus -s maven-settings.xml
           git push
           git push --tags
 


### PR DESCRIPTION
…ted during release

During release, we're building with JDK 8 so the `server/integration-tests-jdk16` module is not active, so it does not get its version updated. This should hopefully fix it. I can't say with certainty this will work until we actually do a release though.. 