### PR TITLE
Make clients honor the JsonbProperty annotation

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/typesafe/vertx/VertxTypesafeGraphQLClientProxy.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/typesafe/vertx/VertxTypesafeGraphQLClientProxy.java
@@ -153,7 +153,11 @@ class VertxTypesafeGraphQLClientProxy {
 
     private JsonObject objectValue(Object object, Stream<FieldInfo> fields) {
         JsonObjectBuilder builder = Json.createObjectBuilder();
-        fields.forEach(field -> builder.add(field.getName(), value(field.get(object))));
+        fields.forEach(field -> {
+            if (field.isIncludeNull() || field.get(object) != null) {
+                builder.add(field.getName(), value(field.get(object)));
+            }
+        });
         return builder.build();
     }
 

--- a/client/tck/src/main/java/tck/graphql/typesafe/MutationBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/MutationBehavior.java
@@ -100,7 +100,7 @@ class MutationBehavior {
         Greeting greeting = api.say(new Greeting(null, 5));
 
         then(fixture.query()).isEqualTo("mutation say($greet: GreetingInput) { say(greet: $greet) {text count} }");
-        then(fixture.variables()).isEqualTo("{'greet':{'text':null,'count':5}}");
+        then(fixture.variables()).isEqualTo("{'greet':{'count':5}}");
         then(greeting).isEqualTo(new Greeting("ho", 3));
     }
 
@@ -190,7 +190,7 @@ class MutationBehavior {
 
         then(fixture.query())
                 .isEqualTo("mutation say($greeting: GreetingContainerInput) { say(greeting: $greeting) {text count} }");
-        then(fixture.variables()).isEqualTo("{'greeting':{'greeting':{'text':null,'count':5},'when':null}}");
+        then(fixture.variables()).isEqualTo("{'greeting':{'greeting':{'count':5}}}");
         then(greeting).isEqualTo(new Greeting("ho", 3));
     }
 


### PR DESCRIPTION
Fixes #1050

!!! This changes the default behavior in the way that null fields (in operation parameters) are NOT included in the documents to be sent to the server !!! To include a field when null, it needs to be annotated with `@JsonbProperty(nillable = true)`