### PR TITLE
Add CDI module as a dependency for the testing-project to verify that…

### DIFF
--- a/tools/maven-plugin-tests/testing-project/pom.xml
+++ b/tools/maven-plugin-tests/testing-project/pom.xml
@@ -22,6 +22,12 @@
             <artifactId>smallrye-graphql</artifactId>
             <version>${plugin.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-cdi</artifactId>
+            <version>${plugin.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
… the maven-plugin works with it

Test coverage improvement covering the fix introduced in https://github.com/smallrye/smallrye-graphql/pull/1103 