### PR TITLE
Draft: Add annotations to mark classes/packages as non-null and fields as nullable

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
@@ -553,7 +553,7 @@ public class Annotations {
     public static final DotName ERROR_CODE = DotName.createSimple("io.smallrye.graphql.api.ErrorCode");
     public static final DotName SUBCRIPTION = DotName.createSimple("io.smallrye.graphql.api.Subscription");
     public static final DotName DIRECTIVE = DotName.createSimple("io.smallrye.graphql.api.Directive");
-    public static final DotName ALL_NON_NULL = DotName.createSimple("io.smallrye.graphql.api.AllNonNull");
+    public static final DotName DEFAULT_NON_NULL = DotName.createSimple("io.smallrye.graphql.api.DefaultNonNull");
     public static final DotName NULLABLE = DotName.createSimple("io.smallrye.graphql.api.Nullable");
 
     // MicroProfile GraphQL Annotations

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/WrapperCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/WrapperCreator.java
@@ -7,6 +7,7 @@ import org.jboss.jandex.Type;
 import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.Classes;
 import io.smallrye.graphql.schema.helper.NonNullHelper;
+import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.Wrapper;
 import io.smallrye.graphql.schema.model.WrapperType;
 

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/NonNullHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/NonNullHelper.java
@@ -77,7 +77,7 @@ public class NonNullHelper {
     }
 
     private static boolean hasNonNullOnClassOrPackage(Annotations annotations) {
-        return annotations.containsOneOfTheseInheritableAnnotations(Annotations.ALL_NON_NULL);
+        return annotations.containsOneOfTheseInheritableAnnotations(Annotations.DEFAULT_NON_NULL);
     }
 
     private static boolean hasDefaultValue(Annotations annotations) {

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/NonNullHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/NonNullHelper.java
@@ -4,6 +4,7 @@ import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
 import io.smallrye.graphql.schema.Annotations;
+import io.smallrye.graphql.schema.Classes;
 
 /**
  * Helping to figure out of some should be marked as Non null
@@ -39,7 +40,12 @@ public class NonNullHelper {
      */
     public static boolean markAsNonNull(Type type, Annotations annotations, boolean ignorePrimitiveCheck) {
         // check if the @NonNull annotation is present
-        boolean hasNonNull = hasNonNull(annotations);
+        boolean hasNonNull = hasNonNull(annotations) || hasNonNullOnClassOrPackage(annotations);
+
+        if (Classes.isOptional(type) || hasNullable(annotations)) {
+            hasNonNull = false;
+        }
+
         // true if this is a primitive
         if (!ignorePrimitiveCheck && type.kind().equals(Type.Kind.PRIMITIVE)) {
             hasNonNull = true; // By implication
@@ -64,6 +70,14 @@ public class NonNullHelper {
                 Annotations.BEAN_VALIDATION_NOT_EMPTY,
                 Annotations.BEAN_VALIDATION_NOT_BLANK,
                 Annotations.KOTLIN_NOT_NULL);
+    }
+
+    private static boolean hasNullable(Annotations annotations) {
+        return annotations.containsOneOfTheseAnnotations(Annotations.NULLABLE);
+    }
+
+    private static boolean hasNonNullOnClassOrPackage(Annotations annotations) {
+        return annotations.containsOneOfTheseInheritableAnnotations(Annotations.ALL_NON_NULL);
     }
 
     private static boolean hasDefaultValue(Annotations annotations) {

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/AnnotationsTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/AnnotationsTest.java
@@ -1,0 +1,32 @@
+package io.smallrye.graphql.schema;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.graphql.schema.helper.package_nonnull.PackageNonNullTestApi;
+
+class AnnotationsTest {
+
+    @AfterEach
+    void tearDown() {
+        ScanningContext.remove();
+    }
+
+    @Test
+    void name() {
+        final Index index = IndexCreator.indexWithPackage(PackageNonNullTestApi.class);
+        ScanningContext.register(index);
+
+        ClassInfo classByName = index.getClassByName(DotName.createSimple(PackageNonNullTestApi.class.getName()));
+        MethodInfo optionalString = classByName.method("optionalString");
+
+        final Annotations annotationsForMethod = Annotations.getAnnotationsForMethod(optionalString);
+        assertFalse(annotationsForMethod.parentAnnotations.isEmpty());
+    }
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/IndexCreator.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/IndexCreator.java
@@ -19,4 +19,24 @@ public class IndexCreator {
         }
         return indexer.complete();
     }
+
+    public static Index indexWithPackage(Class<?>... clazzes) {
+        final Indexer indexer = new Indexer();
+        for (Class<?> clazz : clazzes) {
+            try {
+                indexer.indexClass(clazz);
+
+                String packageInfo = clazz.getName().replace(clazz.getSimpleName(), "package-info");
+
+                InputStream stream = IndexCreator.class.getClassLoader()
+                        .getResourceAsStream(packageInfo.replace('.', '/') + ".class");
+                if (stream != null) {
+                    indexer.index(stream);
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return indexer.complete();
+    }
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/FieldCreatorTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/FieldCreatorTest.java
@@ -6,10 +6,12 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.jboss.jandex.*;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import io.smallrye.graphql.schema.IndexCreator;
+import io.smallrye.graphql.schema.ScanningContext;
 import io.smallrye.graphql.schema.helper.Direction;
 import io.smallrye.graphql.schema.helper.TypeAutoNameStrategy;
 import io.smallrye.graphql.schema.model.Field;
@@ -120,6 +122,7 @@ class FieldCreatorTest {
             return null;
         }
         Index complete = IndexCreator.index(SimplePojo.class);
+        ScanningContext.register(complete);
 
         ClassInfo classByName = complete.getClassByName(DotName.createSimple(SimplePojo.class.getName()));
         return classByName.field(name);
@@ -130,9 +133,15 @@ class FieldCreatorTest {
             return null;
         }
         Index complete = IndexCreator.index(SimplePojo.class);
+        ScanningContext.register(complete);
 
         ClassInfo classByName = complete.getClassByName(DotName.createSimple(SimplePojo.class.getName()));
         return classByName.firstMethod(name);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ScanningContext.remove();
     }
 
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/FieldNameTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/FieldNameTest.java
@@ -8,9 +8,11 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.schema.Annotations;
+import io.smallrye.graphql.schema.ScanningContext;
 import io.smallrye.graphql.schema.creator.fieldnameapp.SomeObjectAnnotatedGetters;
 import io.smallrye.graphql.schema.helper.Direction;
 
@@ -20,6 +22,7 @@ public class FieldNameTest {
         Indexer indexer = new Indexer();
         indexDirectory(indexer, "io/smallrye/graphql/schema/creator/fieldnameapp");
         IndexView index = indexer.complete();
+        ScanningContext.register(index);
 
         ClassInfo classInfo = index.getClassByName(DotName.createSimple(SomeObjectAnnotatedGetters.class.getName()));
         // @Name
@@ -41,5 +44,10 @@ public class FieldNameTest {
         methodInfo = classInfo.method("getFieldName");
         annotations = Annotations.getAnnotationsForMethod(methodInfo);
         assertEquals("fieldName", FieldCreator.getFieldName(Direction.OUT, annotations, "fieldName"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        ScanningContext.remove();
     }
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/OperationCreatorTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/OperationCreatorTest.java
@@ -7,9 +7,11 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.schema.IndexCreator;
+import io.smallrye.graphql.schema.ScanningContext;
 import io.smallrye.graphql.schema.helper.TypeAutoNameStrategy;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.OperationType;
@@ -25,6 +27,7 @@ public class OperationCreatorTest {
     @Test
     public void testFailOnNonPublicOperation() throws Exception {
         Index complete = IndexCreator.index(TestApi.class);
+        ScanningContext.register(complete);
 
         ClassInfo classByName = complete.getClassByName(DotName.createSimple(TestApi.class.getName()));
         MethodInfo method = classByName.method("nonPublicQuery");
@@ -39,6 +42,7 @@ public class OperationCreatorTest {
     @Test
     public void testPublicOperation() throws Exception {
         Index complete = IndexCreator.index(TestApi.class);
+        ScanningContext.register(complete);
 
         ClassInfo classByName = complete.getClassByName(DotName.createSimple(TestApi.class.getName()));
         MethodInfo method = classByName.method("publicQuery");
@@ -46,6 +50,11 @@ public class OperationCreatorTest {
         final Operation operation = operationCreator().createOperation(method, OperationType.QUERY, null);
 
         assertEquals("publicQuery", operation.getName());
+    }
+
+    @AfterEach
+    void tearDown() {
+        ScanningContext.remove();
     }
 
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/FormatHelperTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/FormatHelperTest.java
@@ -9,11 +9,13 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.AsyncApi;
 import io.smallrye.graphql.schema.IndexCreator;
+import io.smallrye.graphql.schema.ScanningContext;
 import io.smallrye.graphql.schema.model.Transformation;
 
 public class FormatHelperTest {
@@ -21,6 +23,7 @@ public class FormatHelperTest {
     @Test
     public void testFormattedLocalDate() throws Exception {
         Index complete = IndexCreator.index(AsyncApi.class);
+        ScanningContext.register(complete);
 
         ClassInfo classByName = complete.getClassByName(DotName.createSimple(AsyncApi.class.getName()));
         MethodInfo nonNullString = classByName.method("formattedLocalDate");
@@ -37,6 +40,7 @@ public class FormatHelperTest {
     @Test
     public void testFormattedCompletionStage() throws Exception {
         Index complete = IndexCreator.index(AsyncApi.class);
+        ScanningContext.register(complete);
 
         ClassInfo classByName = complete.getClassByName(DotName.createSimple(AsyncApi.class.getName()));
         MethodInfo nonNullString = classByName.method("formattedCompletionStage");
@@ -48,5 +52,10 @@ public class FormatHelperTest {
 
         Transformation transformInfo = format.get();
         assertEquals("yyyy-MM-dd", transformInfo.getFormat());
+    }
+
+    @AfterEach
+    void tearDown() {
+        ScanningContext.remove();
     }
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/NonNullHelperTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/NonNullHelperTest.java
@@ -1,5 +1,6 @@
 package io.smallrye.graphql.schema.helper;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -8,17 +9,27 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.AsyncApi;
 import io.smallrye.graphql.schema.IndexCreator;
+import io.smallrye.graphql.schema.ScanningContext;
+import io.smallrye.graphql.schema.helper.class_nonnull.ClassNonNullTestApi;
+import io.smallrye.graphql.schema.helper.package_nonnull.PackageNonNullTestApi;
 
 public class NonNullHelperTest {
+    @AfterEach
+    void tearDown() {
+        ScanningContext.remove();
+    }
 
     @Test
     public void testNonNullString() throws Exception {
         Index complete = IndexCreator.index(AsyncApi.class);
+        ScanningContext.register(complete);
 
         ClassInfo classByName = complete.getClassByName(DotName.createSimple(AsyncApi.class.getName()));
         MethodInfo nonNullString = classByName.method("nonNullString");
@@ -47,6 +58,7 @@ public class NonNullHelperTest {
     @Test
     public void testNullableString() throws Exception {
         Index complete = IndexCreator.index(AsyncApi.class);
+        ScanningContext.register(complete);
 
         ClassInfo classByName = complete.getClassByName(DotName.createSimple(AsyncApi.class.getName()));
         MethodInfo nonNullString = classByName.method("string");
@@ -60,6 +72,7 @@ public class NonNullHelperTest {
     @Test
     public void testNonNullCompletionStage() throws Exception {
         Index complete = IndexCreator.index(AsyncApi.class);
+        ScanningContext.register(complete);
 
         ClassInfo classByName = complete.getClassByName(DotName.createSimple(AsyncApi.class.getName()));
         MethodInfo nonNullString = classByName.method("nonNullCompletionStage");
@@ -68,6 +81,70 @@ public class NonNullHelperTest {
         Annotations annotationsForMethod = Annotations.getAnnotationsForMethod(nonNullString);
 
         assertTrue(NonNullHelper.markAsNonNull(type, annotationsForMethod));
+    }
+
+    @Nested
+    class PackageNonNullTest {
+
+        private void test(String methodName, boolean expected) {
+            Index complete = IndexCreator.indexWithPackage(PackageNonNullTestApi.class);
+            ScanningContext.register(complete);
+
+            ClassInfo classByName = complete.getClassByName(DotName.createSimple(PackageNonNullTestApi.class.getName()));
+            MethodInfo method = classByName.method(methodName);
+            Type type = method.returnType();
+
+            Annotations annotationsForMethod = Annotations.getAnnotationsForMethod(method);
+
+            assertEquals(expected, NonNullHelper.markAsNonNull(type, annotationsForMethod));
+        }
+
+        @Test
+        public void testNonNullPerPackageString() {
+            test("string", true);
+        }
+
+        @Test
+        public void testOptionalString() {
+            test("optionalString", false);
+        }
+
+        @Test
+        public void testNonNullOptionalString() {
+            test("nullableString", false);
+        }
+    }
+
+    @Nested
+    class ClassNonNullTest {
+
+        private void test(String methodName, boolean expected) {
+            Index complete = IndexCreator.indexWithPackage(ClassNonNullTestApi.class);
+            ScanningContext.register(complete);
+
+            ClassInfo classByName = complete.getClassByName(DotName.createSimple(ClassNonNullTestApi.class.getName()));
+            MethodInfo method = classByName.method(methodName);
+            Type type = method.returnType();
+
+            Annotations annotationsForMethod = Annotations.getAnnotationsForMethod(method);
+
+            assertEquals(expected, NonNullHelper.markAsNonNull(type, annotationsForMethod));
+        }
+
+        @Test
+        public void testNonNullPerPackageString() {
+            test("string", true);
+        }
+
+        @Test
+        public void testOptionalString() {
+            test("optionalString", false);
+        }
+
+        @Test
+        public void testNonNullOptionalString() {
+            test("nullableString", false);
+        }
     }
 
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/class_nonnull/ClassNonNullTestApi.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/class_nonnull/ClassNonNullTestApi.java
@@ -1,0 +1,24 @@
+package io.smallrye.graphql.schema.helper.class_nonnull;
+
+import java.util.Optional;
+
+import io.smallrye.graphql.api.AllNonNull;
+import io.smallrye.graphql.api.Nullable;
+
+@AllNonNull
+public class ClassNonNullTestApi {
+
+    public String string() {
+        return "";
+    }
+
+    public Optional<String> optionalString() {
+        return Optional.empty();
+    }
+
+    @Nullable
+    public String nullableString() {
+        return "";
+    }
+
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/class_nonnull/ClassNonNullTestApi.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/class_nonnull/ClassNonNullTestApi.java
@@ -2,10 +2,10 @@ package io.smallrye.graphql.schema.helper.class_nonnull;
 
 import java.util.Optional;
 
-import io.smallrye.graphql.api.AllNonNull;
+import io.smallrye.graphql.api.DefaultNonNull;
 import io.smallrye.graphql.api.Nullable;
 
-@AllNonNull
+@DefaultNonNull
 public class ClassNonNullTestApi {
 
     public String string() {

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/package_nonnull/PackageNonNullTestApi.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/package_nonnull/PackageNonNullTestApi.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.schema.helper.package_nonnull;
+
+import java.util.Optional;
+
+import io.smallrye.graphql.api.Nullable;
+
+public class PackageNonNullTestApi {
+
+    public String string() {
+        return "";
+    }
+
+    public Optional<String> optionalString() {
+        return Optional.empty();
+    }
+
+    @Nullable
+    public String nullableString() {
+        return "";
+    }
+
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/package_nonnull/package-info.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/package_nonnull/package-info.java
@@ -1,0 +1,4 @@
+@AllNonNull
+package io.smallrye.graphql.schema.helper.package_nonnull;
+
+import io.smallrye.graphql.api.AllNonNull;

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/package_nonnull/package-info.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/package_nonnull/package-info.java
@@ -1,4 +1,4 @@
-@AllNonNull
+@DefaultNonNull
 package io.smallrye.graphql.schema.helper.package_nonnull;
 
-import io.smallrye.graphql.api.AllNonNull;
+import io.smallrye.graphql.api.DefaultNonNull;

--- a/server/api/src/main/java/io/smallrye/graphql/api/AllNonNull.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/AllNonNull.java
@@ -1,0 +1,18 @@
+package io.smallrye.graphql.api;
+
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.smallrye.common.annotation.Experimental;
+
+@Retention(RUNTIME)
+@Target({ TYPE, PACKAGE })
+@Experimental("Allow you to mark all fields in a class/package as non-null. Not covered by the specification. " +
+        "Subject to change.")
+public @interface AllNonNull {
+
+}

--- a/server/api/src/main/java/io/smallrye/graphql/api/DefaultNonNull.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/DefaultNonNull.java
@@ -13,6 +13,6 @@ import io.smallrye.common.annotation.Experimental;
 @Target({ TYPE, PACKAGE })
 @Experimental("Allow you to mark all fields in a class/package as non-null. Not covered by the specification. " +
         "Subject to change.")
-public @interface AllNonNull {
+public @interface DefaultNonNull {
 
 }

--- a/server/api/src/main/java/io/smallrye/graphql/api/Nullable.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/Nullable.java
@@ -1,0 +1,18 @@
+package io.smallrye.graphql.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.smallrye.common.annotation.Experimental;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE_USE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Documented
+@Experimental("Allow you to mark a fields as nullable, overrides @AllNonNull. Not covered by the specification. " +
+        "Subject to change.")
+public @interface Nullable {
+
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/SmallRyeGraphQLArchiveProcessor.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/SmallRyeGraphQLArchiveProcessor.java
@@ -29,6 +29,8 @@ import io.smallrye.graphql.test.apps.jackson.api.JacksonApi;
 import io.smallrye.graphql.test.apps.jsonp.api.JsonPApi;
 import io.smallrye.graphql.test.apps.mapping.api.MappingResource;
 import io.smallrye.graphql.test.apps.mutiny.api.MutinyApi;
+import io.smallrye.graphql.test.apps.nonnull.api.NonNullClass;
+import io.smallrye.graphql.test.apps.nonnull.api.nonnull_package.NonNullPackageClass;
 import io.smallrye.graphql.test.apps.optional.api.OptionalTestingApi;
 import io.smallrye.graphql.test.apps.profile.api.ProfileGraphQLApi;
 import io.smallrye.graphql.test.apps.scalars.api.AdditionalScalarsApi;
@@ -107,6 +109,8 @@ public class SmallRyeGraphQLArchiveProcessor implements ApplicationArchiveProces
             war.addPackage(CollectionResource.class.getPackage());
             war.addPackage(JacksonApi.class.getPackage());
             war.addPackage(AdapterResource.class.getPackage());
+            war.addPackage(NonNullClass.class.getPackage());
+            war.addPackage(NonNullPackageClass.class.getPackage());
         }
     }
 }

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/NonNullApi.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/NonNullApi.java
@@ -1,0 +1,21 @@
+package io.smallrye.graphql.test.apps.nonnull.api;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+import io.smallrye.graphql.test.apps.nonnull.api.nonnull_package.NonNullPackageClass;
+
+@GraphQLApi
+public class NonNullApi {
+
+    @Query
+    public NonNullClass nonNullClass(NonNullClass nonNullClass) {
+        return new NonNullClass();
+    }
+
+    @Query
+    public NonNullPackageClass nonNullPackageClass(NonNullPackageClass nonNullPackageClass) {
+        return new NonNullPackageClass();
+    }
+
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/NonNullClass.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/NonNullClass.java
@@ -1,0 +1,23 @@
+package io.smallrye.graphql.test.apps.nonnull.api;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.graphql.Input;
+import org.eclipse.microprofile.graphql.Type;
+
+import io.smallrye.graphql.api.AllNonNull;
+import io.smallrye.graphql.api.Nullable;
+
+@AllNonNull
+@Type
+@Input
+public class NonNullClass {
+
+    public String nonNullString = "";
+
+    public Optional<String> optionalString = Optional.empty();
+
+    @Nullable
+    public String nullableString = null;
+
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/NonNullClass.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/NonNullClass.java
@@ -1,14 +1,16 @@
 package io.smallrye.graphql.test.apps.nonnull.api;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.microprofile.graphql.Input;
 import org.eclipse.microprofile.graphql.Type;
 
-import io.smallrye.graphql.api.AllNonNull;
+import io.smallrye.graphql.api.DefaultNonNull;
 import io.smallrye.graphql.api.Nullable;
 
-@AllNonNull
+@DefaultNonNull
 @Type
 @Input
 public class NonNullClass {
@@ -19,5 +21,7 @@ public class NonNullClass {
 
     @Nullable
     public String nullableString = null;
+
+    public List<String> strings = Collections.emptyList();
 
 }

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/nonnull_package/NonNullPackageClass.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/nonnull_package/NonNullPackageClass.java
@@ -1,5 +1,7 @@
 package io.smallrye.graphql.test.apps.nonnull.api.nonnull_package;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.microprofile.graphql.Input;
@@ -17,5 +19,7 @@ public class NonNullPackageClass {
 
     @Nullable
     public String nullableString = null;
+
+    public List<String> strings = Collections.emptyList();
 
 }

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/nonnull_package/NonNullPackageClass.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/nonnull_package/NonNullPackageClass.java
@@ -1,0 +1,21 @@
+package io.smallrye.graphql.test.apps.nonnull.api.nonnull_package;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.graphql.Input;
+import org.eclipse.microprofile.graphql.Type;
+
+import io.smallrye.graphql.api.Nullable;
+
+@Type
+@Input
+public class NonNullPackageClass {
+
+    public String nonNullString = "";
+
+    public Optional<String> optionalString = Optional.empty();
+
+    @Nullable
+    public String nullableString = null;
+
+}

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/nonnull_package/package-info.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/nonnull_package/package-info.java
@@ -1,4 +1,4 @@
-@AllNonNull
+@DefaultNonNull
 package io.smallrye.graphql.test.apps.nonnull.api.nonnull_package;
 
-import io.smallrye.graphql.api.AllNonNull;
+import io.smallrye.graphql.api.DefaultNonNull;

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/nonnull_package/package-info.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/nonnull/api/nonnull_package/package-info.java
@@ -1,0 +1,4 @@
+@AllNonNull
+package io.smallrye.graphql.test.apps.nonnull.api.nonnull_package;
+
+import io.smallrye.graphql.api.AllNonNull;

--- a/server/tck/src/test/resources/tests/nonNullTests.csv
+++ b/server/tck/src/test/resources/tests/nonNullTests.csv
@@ -1,0 +1,16 @@
+# test @AllNonNull
+1| type NonNullClass                |   nonNullString: String!      |   nonNullString in @AllNonNull-class should be String!
+2| type NonNullClass                |   optionalString: String      |   optionalString in @AllNonNull-class should be String
+3| type NonNullClass                |   nullableString: String      |   nullableString in @AllNonNull-class should be String
+
+4| type NonNullPackageClass         |   nonNullString: String!      |   nonNullString in @AllNonNull-package should be String!
+5| type NonNullPackageClass         |   optionalString: String      |   optionalString in @AllNonNull-package should be String
+6| type NonNullPackageClass         |   nullableString: String      |   nullableString in @AllNonNull-package should be String
+
+7| input NonNullClassInput          |   nonNullString: String!      |   nonNullString in @AllNonNull-class should be String!
+8| input NonNullClassInput          |   optionalString: String      |   optionalString in @AllNonNull-class should be String
+9| input NonNullClassInput          |   nullableString: String      |   nullableString in @AllNonNull-class should be String
+
+10| input NonNullPackageClassInput  |   nonNullString: String!      |   nonNullString in @AllNonNull-package should be String!
+11| input NonNullPackageClassInput  |   optionalString: String      |   optionalString in @AllNonNull-package should be String
+12| input NonNullPackageClassInput  |   nullableString: String      |   nullableString in @AllNonNull-package should be String


### PR DESCRIPTION
Just a first draft, would like some feedback.
`@AllNonNull` on a class or package marks all fields/parameters in that class/package as non-null.
Using `Optional` or annotating the field with `@Nullable` makes this field nullable again.

Currently this would apply to all fields and parameters, which may not be appropriate.
Also, it might be handy to make exceptions for wrapper types. `Integer` would then always be nullable, `int` would be the alternative for non-null.

----

Code like this:

```java
@AllNonNull
public class NonNullClass {

    public String nonNullString = "";

    public Optional<String> optionalString = Optional.empty();

    @Nullable
    public String nullableString = null;

}
```

would then result in a schema like:

```graphql
type NonNullClass {
  nonNullString: String!
  optionalString: String
  nullableString: String
}
```

----

see #923