### PR TITLE
Rename headers to transportMeta

### DIFF
--- a/client/api/src/main/java/io/smallrye/graphql/client/Response.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/Response.java
@@ -7,17 +7,42 @@ import javax.json.JsonObject;
 
 public interface Response {
 
+    /**
+     * The 'data' object contained in the response.
+     * Can be JsonValue.NULL if the response contains an empty field, or `null` if the response
+     * does not contain this field at all.
+     */
     JsonObject getData();
 
+    /**
+     * List of errors contained in this response.
+     */
     List<GraphQLError> getErrors();
 
+    /**
+     * Transform the contents of the `rootField` from this response into a list of objects
+     * of the requested type.
+     */
     <T> List<T> getList(Class<T> dataType, String rootField);
 
+    /**
+     * Transform the contents of the `rootField` from this response into an object
+     * of the requested type.
+     */
     <T> T getObject(Class<T> dataType, String rootField);
 
+    /**
+     * If this response contains any data, this returns `true`; `false` otherwise.
+     */
     boolean hasData();
 
+    /**
+     * If this response contains at least one error, this returns `true`; `false` otherwise.
+     */
     boolean hasError();
 
-    List<Map.Entry<String, String>> getHeaders();
+    /**
+     * Get transport-specific metadata that came from the server with this response.
+     */
+    List<Map.Entry<String, String>> getTransportMeta();
 }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/ResponseImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/ResponseImpl.java
@@ -115,4 +115,8 @@ public class ResponseImpl implements Response {
     public List<Map.Entry<String, String>> getHeaders() {
         return headers;
     }
+
+    public List<Map.Entry<String, String>> getTransportMeta() {
+        return headers;
+    }
 }


### PR DESCRIPTION
+ add javadocs for `Response`

There's the question whether the transport meta should be `List<Map.Entry<String, String>>` or `Map<String, List<String>>`. Both have pros and cons, so I'm not completely sure. But perhaps we should avoid making the breaking change bigger if it doesn't have a huge benefit?