### PR TITLE
Treat extra fields the same way as extension fields

### DIFF
--- a/client/api/src/main/java/io/smallrye/graphql/client/GraphQLError.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/GraphQLError.java
@@ -3,8 +3,6 @@ package io.smallrye.graphql.client;
 import java.util.List;
 import java.util.Map;
 
-import javax.json.JsonValue;
-
 public interface GraphQLError {
 
     /**
@@ -33,5 +31,5 @@ public interface GraphQLError {
      * Any other fields beyond message, locations, path and extensions. These are discouraged by the spec,
      * but if a GraphQL service adds them, they will appear in this map.
      */
-    Map<String, JsonValue> getOtherFields();
+    Map<String, Object> getOtherFields();
 }

--- a/client/api/src/test/java/test/ErrorOrTest.java
+++ b/client/api/src/test/java/test/ErrorOrTest.java
@@ -13,8 +13,6 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.json.JsonValue;
-
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +27,7 @@ class ErrorOrTest {
         }
 
         @Override
-        public Map<String, JsonValue> getOtherFields() {
+        public Map<String, Object> getOtherFields() {
             return Collections.emptyMap();
         }
 

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/GraphQLErrorImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/GraphQLErrorImpl.java
@@ -4,8 +4,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import javax.json.JsonValue;
-
 import io.smallrye.graphql.client.GraphQLError;
 
 public class GraphQLErrorImpl implements GraphQLError {
@@ -13,13 +11,13 @@ public class GraphQLErrorImpl implements GraphQLError {
     private List<Map<String, Integer>> locations;
     private Object[] path;
     private Map<String, Object> extensions;
-    private Map<String, JsonValue> otherFields;
+    private Map<String, Object> otherFields;
 
     public GraphQLErrorImpl() {
     }
 
     public GraphQLErrorImpl(String message, List<Map<String, Integer>> locations, Object[] path, Map<String, Object> extensions,
-            Map<String, JsonValue> otherFields) {
+            Map<String, Object> otherFields) {
         this.message = message;
         this.locations = locations;
         this.path = path;
@@ -44,7 +42,7 @@ public class GraphQLErrorImpl implements GraphQLError {
     }
 
     @Override
-    public Map<String, JsonValue> getOtherFields() {
+    public Map<String, Object> getOtherFields() {
         return otherFields;
     }
 
@@ -64,7 +62,7 @@ public class GraphQLErrorImpl implements GraphQLError {
         this.extensions = extensions;
     }
 
-    public void setOtherFields(Map<String, JsonValue> otherFields) {
+    public void setOtherFields(Map<String, Object> otherFields) {
         this.otherFields = otherFields;
     }
 

--- a/client/implementation/src/test/java/io/smallrye/graphql/client/ResponseReaderTest.java
+++ b/client/implementation/src/test/java/io/smallrye/graphql/client/ResponseReaderTest.java
@@ -12,8 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import javax.json.JsonNumber;
-
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.Test;
 
@@ -176,7 +174,7 @@ public class ResponseReaderTest {
 
         GraphQLError theError = response.getErrors().get(0);
         assertEquals("blabla", theError.getMessage());
-        assertEquals(123456, ((JsonNumber) theError.getOtherFields().get("somethingExtra")).intValue());
+        assertEquals(123456L, theError.getOtherFields().get("somethingExtra"));
         assertEquals("GRAPHQL_VALIDATION_FAILED", theError.getExtensions().get("code"));
         assertEquals(1, theError.getLocations().get(0).get("line"));
         assertEquals(30, theError.getLocations().get(0).get("column"));


### PR DESCRIPTION
Extension fields are returned as `Object`, no need to treat "extra" (meaning beyond the spec) fields differently by returning them as `JsonValue`.