### PR TITLE
Skip runner module initialization if we're not running tests as part …

### DIFF
--- a/server/runner/pom.xml
+++ b/server/runner/pom.xml
@@ -88,7 +88,7 @@
                 <version>3.2.0</version>
                 <executions>
                     <execution>
-                        <phase>generate-sources</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>


### PR DESCRIPTION
…of the build

This should allow developers to run `mvn clean compile` (instead of requiring `mvn clean install`) when building a snapshot version that's not present in their local Maven repo.