### PR TITLE
Client tests for enums + validate enum logic earlier

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/core/AbstractEnum.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/core/AbstractEnum.java
@@ -1,8 +1,18 @@
 package io.smallrye.graphql.client.dynamic.core;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
 import io.smallrye.graphql.client.core.Enum;
+import io.smallrye.graphql.client.core.exceptions.BuildException;
 
 public abstract class AbstractEnum implements Enum {
+
+    // According to http://spec.graphql.org/June2018/#sec-Enum-Value
+    protected static final Pattern VALID_ENUM_NAME = Pattern.compile("[_A-Za-z][_0-9A-Za-z]*");
+    protected static final List<String> FORBIDDEN_ENUM_NAMES = Arrays.asList(
+            "true", "false", "null");
 
     private String value;
 
@@ -14,6 +24,16 @@ public abstract class AbstractEnum implements Enum {
     }
 
     public void setValue(String value) {
+        validateValue(value);
         this.value = value;
+    }
+
+    protected void validateValue(String value) {
+        if (!VALID_ENUM_NAME.matcher(value).matches()) {
+            throw new BuildException("Enum value '" + this.getValue() + "' is not valid gql name");
+        }
+        if (FORBIDDEN_ENUM_NAMES.contains(value)) {
+            throw new BuildException("Enum is a forbidden name '" + this.getValue() + "'");
+        }
     }
 }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/core/EnumImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/dynamic/core/EnumImpl.java
@@ -1,26 +1,10 @@
 package io.smallrye.graphql.client.dynamic.core;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Pattern;
-
-import io.smallrye.graphql.client.core.exceptions.BuildException;
-
 public class EnumImpl extends AbstractEnum {
-
-    // According to http://spec.graphql.org/June2018/#sec-Enum-Value
-    private static final Pattern VALID_ENUM_NAME = Pattern.compile("[_A-Za-z][_0-9A-Za-z]*");
-    private static final List<String> FORBIDDEN_ENUM_NAMES = Arrays.asList(
-            "true", "false", "null");
 
     @Override
     public String build() {
-        if (!VALID_ENUM_NAME.matcher(this.getValue()).matches()) {
-            throw new BuildException("Enum value '" + this.getValue() + "' is not valid gql name");
-        }
-        if (FORBIDDEN_ENUM_NAMES.contains(this.getValue())) {
-            throw new BuildException("Enum is a forbidden name '" + this.getValue() + "'");
-        }
+        validateValue(this.getValue());
         return this.getValue();
     }
 

--- a/client/tck/src/main/java/tck/graphql/dynamic/core/EnumsTest.java
+++ b/client/tck/src/main/java/tck/graphql/dynamic/core/EnumsTest.java
@@ -1,0 +1,62 @@
+package tck.graphql.dynamic.core;
+
+import static io.smallrye.graphql.client.core.Argument.arg;
+import static io.smallrye.graphql.client.core.Argument.args;
+import static io.smallrye.graphql.client.core.Document.document;
+import static io.smallrye.graphql.client.core.Enum.gqlEnum;
+import static io.smallrye.graphql.client.core.Field.field;
+import static io.smallrye.graphql.client.core.Operation.operation;
+import static io.smallrye.graphql.client.core.OperationType.QUERY;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.graphql.client.core.Document;
+import io.smallrye.graphql.client.core.exceptions.BuildException;
+import tck.graphql.dynamic.helper.AssertGraphQL;
+import tck.graphql.dynamic.helper.Utils;
+
+public class EnumsTest {
+
+    @Test
+    public void enumsTest() {
+        String expectedRequest = Utils.getResourceFileContent("core/enums.graphql");
+
+        Document document = document(
+                operation(QUERY,
+                        field("exams",
+                                args(arg("result", gqlEnum("PASSED"))),
+                                field("score"))));
+
+        String generatedRequest = document.build();
+        AssertGraphQL.assertEquivalentGraphQLRequest(expectedRequest, generatedRequest);
+    }
+
+    @Test
+    public void invalidValue() {
+        try {
+            Document document = document(
+                    operation(QUERY,
+                            field("exams",
+                                    args(arg("result", gqlEnum("wrong { }"))),
+                                    field("score"))));
+            fail("Invalid enum value should not be accepted");
+        } catch (BuildException be) {
+            // OK
+        }
+    }
+
+    @Test
+    public void invalidValueTrue() {
+        try {
+            Document document = document(
+                    operation(QUERY,
+                            field("exams",
+                                    args(arg("result", gqlEnum("true"))),
+                                    field("score"))));
+            fail("Invalid enum value should not be accepted");
+        } catch (BuildException be) {
+            // OK
+        }
+    }
+}

--- a/client/tck/src/main/resources/core/enums.graphql
+++ b/client/tck/src/main/resources/core/enums.graphql
@@ -1,0 +1,5 @@
+query {
+    exams(result: PASSED) {
+        score
+    }
+}


### PR DESCRIPTION
Fixes #1142 

FYI @cherrydev this changes the validation logic (added by you) to happen earlier, it will fail right after calling `Enum.gqlEnum("wrong-value")` rather than later when building the actual `Document`.