### PR TITLE
Support async types (and subscriptions) by typesafe client

### DIFF
--- a/client/implementation/pom.xml
+++ b/client/implementation/pom.xml
@@ -29,6 +29,10 @@
         <!-- The API -->
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-graphql-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>smallrye-graphql-client-api</artifactId>
         </dependency>
         <dependency>

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/QueryBuilder.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/QueryBuilder.java
@@ -22,7 +22,17 @@ public class QueryBuilder {
 
     public String build() {
         StringBuilder request = new StringBuilder();
-        request.append(method.isQuery() ? "query " : "mutation ");
+        switch (method.getOperationType()) {
+            case QUERY:
+                request.append("query ");
+                break;
+            case MUTATION:
+                request.append("mutation ");
+                break;
+            case SUBSCRIPTION:
+                request.append("subscription ");
+                break;
+        }
         request.append(method.getName());
         if (method.hasValueParameters())
             request.append(method.valueParameters().map(this::declare).collect(joining(", ", "(", ")")));
@@ -70,7 +80,7 @@ public class QueryBuilder {
 
         if (type.isScalar())
             return "";
-        if (type.isCollection())
+        if (type.isCollection() || type.isAsync())
             return fields(type.getItemType());
         return type.fields()
                 .map(this::field)

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/json/JsonReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/json/JsonReader.java
@@ -36,6 +36,9 @@ public class JsonReader extends Reader<JsonValue> {
     Object read() {
         if (type.isOptional())
             return Optional.ofNullable(readJson(location, type.getItemType(), value, field));
+        if (type.isAsync()) {
+            return readJson(location, type.getItemType(), value, field);
+        }
         if (type.isErrorOr())
             return readErrorOr();
         if (isListOfErrors(value) && !isGraphQlErrorsType())

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/MethodInvocation.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/MethodInvocation.java
@@ -23,6 +23,8 @@ import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
 
+import io.smallrye.graphql.api.Subscription;
+import io.smallrye.graphql.client.core.OperationType;
 import io.smallrye.graphql.client.typesafe.api.Multiple;
 
 public class MethodInvocation {
@@ -50,8 +52,14 @@ public class MethodInvocation {
         return method.toGenericString();
     }
 
-    public boolean isQuery() {
-        return !method.isAnnotationPresent(Mutation.class);
+    public OperationType getOperationType() {
+        if (method.isAnnotationPresent(Mutation.class)) {
+            return OperationType.MUTATION;
+        }
+        if (method.isAnnotationPresent(Subscription.class)) {
+            return OperationType.SUBSCRIPTION;
+        }
+        return OperationType.QUERY;
     }
 
     public String getName() {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/TypeInfo.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/typesafe/impl/reflection/TypeInfo.java
@@ -29,6 +29,8 @@ import java.util.stream.Stream.Builder;
 import org.eclipse.microprofile.graphql.NonNull;
 
 import io.smallrye.graphql.client.typesafe.api.ErrorOr;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 
 public class TypeInfo {
     private final TypeInfo container;
@@ -109,6 +111,18 @@ public class TypeInfo {
                 || Collection.class.isAssignableFrom(getRawType());
     }
 
+    public boolean isAsync() {
+        return isMulti() || isUni();
+    }
+
+    public boolean isMulti() {
+        return Multi.class.isAssignableFrom(getRawType());
+    }
+
+    public boolean isUni() {
+        return Uni.class.isAssignableFrom(getRawType());
+    }
+
     private boolean ifClass(Predicate<Class<?>> predicate) {
         return (type instanceof Class) && predicate.test((Class<?>) type);
     }
@@ -151,7 +165,8 @@ public class TypeInfo {
     }
 
     public boolean isRecord() {
-        return rawType.getSuperclass().getName().equals("java.lang.Record");
+        Class<?> superclass = rawType.getSuperclass();
+        return superclass != null && superclass.getName().equals("java.lang.Record");
     }
 
     public boolean isScalar() {
@@ -265,7 +280,7 @@ public class TypeInfo {
     }
 
     public TypeInfo getItemType() {
-        assert isCollection() || isOptional() || isErrorOr();
+        assert isCollection() || isOptional() || isErrorOr() || isAsync();
         if (itemType == null)
             itemType = new TypeInfo(this, computeItemType(), computeAnnotatedItemType());
         return this.itemType;

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/SubscriptionApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/SubscriptionApi.java
@@ -1,0 +1,28 @@
+package io.smallrye.graphql.tests.client.typesafe.subscription;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+import io.smallrye.graphql.api.Subscription;
+import io.smallrye.mutiny.Multi;
+
+@GraphQLApi
+public class SubscriptionApi {
+
+    // this needs to be here because a GraphQLApi with only subscriptions does not work
+    @Query
+    public String nothing() {
+        return null;
+    }
+
+    @Subscription
+    public Multi<Integer> countToFive() {
+        return Multi.createFrom().range(0, 5);
+    }
+
+    @Subscription
+    public Multi<Integer> failingImmediately() {
+        return Multi.createFrom().failure(new RuntimeException("blabla"));
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/SubscriptionClientApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/SubscriptionClientApi.java
@@ -1,0 +1,18 @@
+package io.smallrye.graphql.tests.client.typesafe.subscription;
+
+import java.io.Closeable;
+
+import io.smallrye.graphql.api.Subscription;
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.mutiny.Multi;
+
+@GraphQLClientApi
+public interface SubscriptionClientApi extends Closeable {
+
+    @Subscription
+    Multi<Integer> countToFive();
+
+    @Subscription
+    Multi<Integer> failingImmediately();
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientSubscriptionTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientSubscriptionTest.java
@@ -1,0 +1,91 @@
+package io.smallrye.graphql.tests.client.typesafe.subscription;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.smallrye.graphql.client.typesafe.vertx.VertxTypesafeGraphQLClientBuilder;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TypesafeClientSubscriptionTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "dynamic-client-subscription-test.war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(SubscriptionApi.class);
+    }
+
+    @ArquillianResource
+    URL testingURL;
+
+    private SubscriptionClientApi client;
+
+    @Before
+    public void prepare() {
+        client = new VertxTypesafeGraphQLClientBuilder()
+                .endpoint(testingURL + "graphql")
+                .build(SubscriptionClientApi.class);
+    }
+
+    @After
+    public void cleanup() {
+        try {
+            client.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testCounting() {
+        List<Integer> result = client.countToFive()
+                .subscribe()
+                .asStream()
+                .collect(Collectors.toList());
+        for (int i = 0; i < 5; i++) {
+            assertEquals((Integer) i, result.get(i));
+        }
+    }
+
+    // TODO, failure handling is not properly implemented yet
+    @Test
+    public void testFailure() throws InterruptedException {
+        CountDownLatch finished = new CountDownLatch(1);
+        final AtomicReference<Integer> obtainedItem = new AtomicReference<>();
+        client.failingImmediately()
+                .subscribe()
+                .with(item -> {
+                    obtainedItem.set(item);
+                    finished.countDown();
+                }, failure -> {
+                    failure.printStackTrace();
+                    finished.countDown();
+                }, () -> {
+                    System.out.println("COMPLETE");
+                    finished.countDown();
+                });
+        finished.await(10, TimeUnit.SECONDS);
+        // how to verify that the multi failed correctly?
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/uni/TypesafeClientUniTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/uni/TypesafeClientUniTest.java
@@ -1,0 +1,79 @@
+package io.smallrye.graphql.tests.client.typesafe.uni;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+import java.time.Duration;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.smallrye.graphql.client.typesafe.vertx.VertxTypesafeGraphQLClientBuilder;
+
+/**
+ * Test for usage of Uni in typesafe clients.
+ * Generally, to the client, it should not matter at all whether the server-side query returns Uni or a synchronous type.
+ * In either case, the client-side counterpart of the method can return a synchronous or an asynchronous type.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TypesafeClientUniTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(UniApi.class);
+    }
+
+    @ArquillianResource
+    URL testingURL;
+
+    private UniClientApi client;
+
+    @Before
+    public void prepare() {
+        client = new VertxTypesafeGraphQLClientBuilder()
+                .endpoint(testingURL.toString() + "graphql")
+                .build(UniClientApi.class);
+    }
+
+    /**
+     * On server side, the query returns a Uni.
+     * On the client side, the query is declared to return a Uni.
+     */
+    @Test
+    public void callAsyncQueryWithAsyncClient() {
+        String response = client.asyncQuery().await().atMost(Duration.ofSeconds(10));
+        assertEquals("async", response);
+    }
+
+    /**
+     * On server side, the query returns a Uni.
+     * On the client side, the query returns the regular (synchronous) type.
+     */
+    @Test
+    public void callAsyncQueryWithSyncClient() {
+        String response = client.getSync();
+        assertEquals("async", response);
+    }
+
+    /**
+     * On server side, the query returns a synchronous type.
+     * On the client side, the query returns a Uni.
+     */
+    @Test
+    public void callSyncQueryWithAsyncClient() {
+        String response = client.asyncMethodForSyncQuery().await().atMost(Duration.ofSeconds(10));
+        assertEquals("sync", response);
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/uni/UniApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/uni/UniApi.java
@@ -1,0 +1,21 @@
+package io.smallrye.graphql.tests.client.typesafe.uni;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+import io.smallrye.mutiny.Uni;
+
+@GraphQLApi
+public class UniApi {
+
+    @Query
+    public Uni<String> asyncQuery() {
+        return Uni.createFrom().item("async");
+    }
+
+    @Query
+    public String syncQuery() {
+        return "sync";
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/uni/UniClientApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/uni/UniClientApi.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.tests.client.typesafe.uni;
+
+import org.eclipse.microprofile.graphql.Query;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.mutiny.Uni;
+
+@GraphQLClientApi
+public interface UniClientApi {
+
+    @Query
+    Uni<String> asyncQuery();
+
+    // This actually points to the same server-side query as `asyncQuery` method, but
+    // the return type here is not async. The client library should not care.
+    @Query("asyncQuery")
+    String getSync();
+
+    @Query("syncQuery")
+    Uni<String> asyncMethodForSyncQuery();
+
+}


### PR DESCRIPTION
Fixes #1108 
Fixes #501

There is still stuff to fix (like supporting `CompletionStage` in addition to `Uni`, and more proper error handling) but should generally work