### PR TITLE
Support default values for a collection/array of input types

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -355,7 +355,7 @@ public class Bootstrap {
                 .name(interfaceType.getName())
                 .description(interfaceType.getDescription());
 
-        // Fields 
+        // Fields
         if (interfaceType.hasFields()) {
             interfaceTypeBuilder = interfaceTypeBuilder
                     .fields(createGraphQLFieldDefinitionsFromFields(interfaceType,
@@ -422,7 +422,7 @@ public class Bootstrap {
         if (inputType.hasFields()) {
             inputObjectTypeBuilder = inputObjectTypeBuilder
                     .fields(createGraphQLInputObjectFieldsFromFields(inputType.getFields().values()));
-            // Register this input for posible JsonB usage 
+            // Register this input for posible JsonB usage
             JsonInputRegistry.register(inputType);
         }
 
@@ -790,27 +790,27 @@ public class Bootstrap {
         }
 
         if (isJsonString(jsonString)) {
-            Class<?> type;
+            Class<?> deserType;
             Wrapper wrapper = dataFetcherFactory.unwrap(field, false);
 
             if (wrapper != null && wrapper.isCollectionOrArray()) {
-                type = classloadingService.loadClass(field.getWrapper().getWrapperClassName());
-                if (Collection.class.isAssignableFrom(type)) {
-                    type = CollectionCreator.newCollection(field.getWrapper().getWrapperClassName(), 0).getClass();
+                deserType = classloadingService.loadClass(field.getWrapper().getWrapperClassName());
+                if (Collection.class.isAssignableFrom(deserType)) {
+                    deserType = CollectionCreator.newCollection(field.getWrapper().getWrapperClassName(), 0).getClass();
                 }
             } else {
-                type = classloadingService.loadClass(field.getReference().getClassName());
-            }
-            Jsonb jsonB = JsonBCreator.getJsonB(type.getName());
+                Reference reference = getCorrectFieldReference(field);
+                ReferenceType referenceType = reference.getType();
 
-            Reference reference = getCorrectFieldReference(field);
-            ReferenceType referenceType = reference.getType();
-
-            if (referenceType.equals(ReferenceType.INPUT) || referenceType.equals(ReferenceType.TYPE)) { // Complex type
-                return jsonB.fromJson(jsonString, Map.class);
-            } else { // Basic Type
-                return jsonB.fromJson(jsonString, type);
+                if (referenceType.equals(ReferenceType.INPUT) || referenceType.equals(ReferenceType.TYPE)) {
+                    deserType = Map.class;
+                } else {
+                    deserType = classloadingService.loadClass(field.getReference().getClassName());
+                }
             }
+
+            Jsonb jsonB = JsonBCreator.getJsonB(deserType.getName());
+            return jsonB.fromJson(jsonString, deserType);
         }
 
         if (Classes.isNumberLikeType(field.getReference().getGraphQlClassName())) {

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/defaultvalue/api/DefaultValueParrotAPI.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/defaultvalue/api/DefaultValueParrotAPI.java
@@ -4,11 +4,13 @@ import java.util.List;
 
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Input;
+import org.eclipse.microprofile.graphql.NonNull;
 import org.eclipse.microprofile.graphql.Query;
 
 /**
  * Testing Default values
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 @GraphQLApi
@@ -22,5 +24,30 @@ public class DefaultValueParrotAPI {
     @Query
     public List<String> listDefault(@DefaultValue("[\"electric\",\"blue\"]") List<String> values) {
         return values;
+    }
+
+    @Query
+    public Root objectFieldDefaults(@NonNull Root input) {
+        return input;
+    }
+
+    @Input
+    public static class Root {
+        @DefaultValue("[\"dancing\",\"shepard\"]")
+        public String[] stringArray;
+
+        @DefaultValue("[\"poignant\",\"joker\"]")
+        public List<String> stringList;
+
+        @DefaultValue("[{\"field\": \"angry\"}, {\"field\": \"jack\"}]")
+        public Nested[] nestedArray;
+
+        @DefaultValue("[{\"field\": \"big\"}, {\"field\": \"grunt\"}]")
+        public List<Nested> nestedList;
+    }
+
+    @Input
+    public static class Nested {
+        public String field;
     }
 }

--- a/server/tck/src/test/resources/tests/defaultValue/input.graphql
+++ b/server/tck/src/test/resources/tests/defaultValue/input.graphql
@@ -1,6 +1,28 @@
 {
   withvalues1:arrayDefault(values:["foo","bar"])
+
   withoutvalues1:arrayDefault
+
   withvalues2:listDefault(values:["ping","pong"])
+
   withoutvalues2:listDefault
+
+  withfieldvalues1:objectFieldDefaults(input: {
+    stringArray: ["foo", "man"]
+    stringList: ["bar", "zap"]
+    nestedArray: [{field: "lol"}]
+    nestedList: [{field: "bal"}]
+  }) {
+    stringArray
+    stringList
+    nestedArray { field }
+    nestedList { field }
+  }
+
+  withoutfieldvalues1:objectFieldDefaults(input: {}) {
+    stringArray
+    stringList
+    nestedArray { field }
+    nestedList { field }
+  }
 }

--- a/server/tck/src/test/resources/tests/defaultValue/output.json
+++ b/server/tck/src/test/resources/tests/defaultValue/output.json
@@ -15,6 +15,18 @@
     "withoutvalues2": [
       "electric",
       "blue"
-    ]
+    ],
+    "withfieldvalues1": {
+      "stringArray": ["foo", "man"],
+      "stringList": ["bar", "zap"],
+      "nestedArray": [{"field": "lol"}],
+      "nestedList": [{"field": "bal"}]
+    },
+    "withoutfieldvalues1": {
+      "stringArray": ["dancing", "shepard"],
+      "stringList": ["poignant", "joker"],
+      "nestedArray": [{"field": "angry"}, {"field": "jack"}],
+      "nestedList": [{"field": "big"}, {"field": "grunt"}]
+    }
   }
 }


### PR DESCRIPTION
Add support for specifying default values for a collection or an array of custom input types.

Especially, being able to specify a field to have the empty list/array as the default is useful, because then we can avoid null checks. For example:

``` java
@GraphQLApi
public class API {
    @Query
    public String firstNestedFieldOrNull(@NonNull Root input) {
        // no null check needed in accessing input.nestedList
        return input.nestedList.stream().findFirst().map(n -> n.field).orElse(null);
    }

    @Input
    public static class Root {
        @DefaultValue("[]")
        public List<Nested> nestedList;
    }

    @Input
    public static class Nested {
        public String field;
    }
}
```