### PR TITLE
Dynamic client error handling improvements

### DIFF
--- a/client/api/src/main/java/io/smallrye/graphql/client/GraphQLClientException.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/GraphQLClientException.java
@@ -1,11 +1,9 @@
-package io.smallrye.graphql.client.typesafe.api;
+package io.smallrye.graphql.client;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 import java.util.List;
-
-import io.smallrye.graphql.client.GraphQLError;
 
 /**
  * Represents a response that contained application-level errors and thus can't be turned into a domain object.

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/HeaderBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/HeaderBuilder.java
@@ -8,12 +8,12 @@ import java.util.Map;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
+import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.impl.typesafe.reflection.MethodInvocation;
 import io.smallrye.graphql.client.impl.typesafe.reflection.MethodResolver;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
 import io.smallrye.graphql.client.typesafe.api.AuthorizationHeader;
 import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
-import io.smallrye.graphql.client.typesafe.api.GraphQLClientException;
 import io.smallrye.graphql.client.typesafe.api.Header;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
@@ -24,13 +24,13 @@ import javax.json.JsonValue;
 
 import org.jboss.logging.Logger;
 
+import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.impl.GraphQLClientConfiguration;
 import io.smallrye.graphql.client.impl.typesafe.QueryBuilder;
 import io.smallrye.graphql.client.impl.typesafe.ResultBuilder;
 import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.MethodInvocation;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
-import io.smallrye.graphql.client.typesafe.api.GraphQLClientException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Future;

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/ResponseImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/ResponseImpl.java
@@ -11,6 +11,7 @@ import javax.json.JsonObject;
 import javax.json.JsonString;
 import javax.json.JsonValue;
 
+import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.impl.typesafe.json.JsonReader;
@@ -97,6 +98,17 @@ public class ResponseImpl implements Response {
 
     public List<GraphQLError> getErrors() {
         return errors;
+    }
+
+    /**
+     * If there are application errors inside this response, this method converts these errors into a `GraphQLClientException`
+     * and throws it. If there are no errors, then this method does nothing.
+     */
+    // This is currently only in the implementation, if this is deemed useful we might move it up to the `Response` interface
+    public void throwExceptionIfErrors() {
+        if (!errors.isEmpty()) {
+            throw new GraphQLClientException("Errors from service", errors);
+        }
     }
 
     public boolean hasData() {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/ResultBuilder.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/ResultBuilder.java
@@ -17,13 +17,13 @@ import javax.json.JsonPatch;
 import javax.json.JsonPointer;
 import javax.json.JsonValue;
 
+import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.InvalidResponseException;
 import io.smallrye.graphql.client.impl.ResponseReader;
 import io.smallrye.graphql.client.impl.typesafe.json.JsonReader;
 import io.smallrye.graphql.client.impl.typesafe.json.JsonUtils;
 import io.smallrye.graphql.client.impl.typesafe.reflection.MethodInvocation;
 import io.smallrye.graphql.client.typesafe.api.ErrorOr;
-import io.smallrye.graphql.client.typesafe.api.GraphQLClientException;
 
 public class ResultBuilder {
     private final MethodInvocation method;

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonReader.java
@@ -12,12 +12,12 @@ import javax.json.JsonObject;
 import javax.json.JsonString;
 import javax.json.JsonValue;
 
+import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.impl.ResponseReader;
 import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
 import io.smallrye.graphql.client.typesafe.api.ErrorOr;
-import io.smallrye.graphql.client.typesafe.api.GraphQLClientException;
 
 public class JsonReader extends Reader<JsonValue> {
     public static Object readJson(String description, TypeInfo type, JsonValue value, FieldInfo field) {

--- a/client/tck/src/main/java/tck/graphql/typesafe/ErrorBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/ErrorBehavior.java
@@ -13,11 +13,11 @@ import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.NonNull;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.InvalidResponseException;
 import io.smallrye.graphql.client.typesafe.api.ErrorOr;
 import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
-import io.smallrye.graphql.client.typesafe.api.GraphQLClientException;
 
 class ErrorBehavior {
     private final TypesafeGraphQLClientFixture fixture = TypesafeGraphQLClientFixture.load();

--- a/docs/dynamic-client-error-handling.md
+++ b/docs/dynamic-client-error-handling.md
@@ -1,0 +1,11 @@
+# Error handling with dynamic clients
+
+When executing GraphQL operations using a dynamic client, the application receives back an
+instance of `io.smallrye.graphql.client.Response` that encapsulates the whole response from the service,
+including potential errors. Errors are represented as `io.smallrye.graphql.client.GraphQLError`
+and can be inspected after retrieving a list of all errors using `response.getErrors()`.
+
+It is also possible to convert a response's errors into a `io.smallrye.graphql.client.GraphQLClientException`
+by calling `throwExceptionIfErrors()` - the response has to be cast to `ResponseImpl` for this as of now.
+This method will, if there are any errors in the response, convert the errors into a `GraphQLClientException` 
+and throw it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - Error handling: 'typesafe-client-error-handling.md'
   - Dynamic client:
       - Basic usage: 'dynamic-client-usage.md'
+      - Error handling: 'dynamic-client-error-handling.md'
   - Developer tools:
       - Maven plugin: 'maven-plugin.md'
       - Gradle plugin: 'gradle-plugin.md'

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/error/DynamicClientErrorTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/error/DynamicClientErrorTest.java
@@ -1,0 +1,102 @@
+package io.smallrye.graphql.tests.client.dynamic.error;
+
+import static io.smallrye.graphql.client.core.Document.document;
+import static io.smallrye.graphql.client.core.Field.field;
+import static io.smallrye.graphql.client.core.Operation.operation;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.smallrye.graphql.client.GraphQLClientException;
+import io.smallrye.graphql.client.Response;
+import io.smallrye.graphql.client.impl.ResponseImpl;
+import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClient;
+import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClientBuilder;
+
+/**
+ * Test error handling features of the dynamic client
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DynamicClientErrorTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(ErrorApi.class, Dummy.class);
+    }
+
+    @ArquillianResource
+    URL testingURL;
+
+    private static VertxDynamicGraphQLClient client;
+
+    @Before
+    public void prepare() {
+        client = (VertxDynamicGraphQLClient) new VertxDynamicGraphQLClientBuilder()
+                .url(testingURL.toString() + "graphql")
+                .build();
+    }
+
+    /**
+     * Test the `ResponseImpl.throwExceptionIfErrors` method that should throw a `GraphQLClientException` if the Response
+     * contains any errors.
+     */
+    @Test
+    public void convertToGraphQLClientException() throws ExecutionException, InterruptedException {
+        Response response = client.executeSync(document(operation(field("dummy", field("foo"), field("bar")))));
+        try {
+            ((ResponseImpl) response).throwExceptionIfErrors();
+            fail("`throwExceptionIfErrors` call should throw a GraphQLClientException");
+        } catch (GraphQLClientException e) {
+            assertArrayEquals(new Object[] { "dummy", "bar" }, e.getErrors().get(0).getPath());
+        }
+    }
+
+    @GraphQLApi
+    public static class ErrorApi {
+
+        @Query
+        public Dummy dummy() {
+            Dummy dummy = new Dummy();
+            dummy.setFoo(5);
+            return dummy;
+        }
+
+        public Integer bar(@Source Dummy dummy) {
+            throw new RuntimeException("asdf");
+        }
+
+    }
+
+    public static class Dummy {
+
+        private Integer foo;
+
+        public Integer getFoo() {
+            return foo;
+        }
+
+        public void setFoo(Integer foo) {
+            this.foo = foo;
+        }
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientSubscriptionTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientSubscriptionTest.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.smallrye.graphql.client.typesafe.api.GraphQLClientException;
+import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
 import io.smallrye.mutiny.Multi;
 


### PR DESCRIPTION
- allow transforming a `Response` into a `GraphQLClientException`
- add some documentation about this

Breaking change, because it moves the package of `GraphQLClientException` from `*.typesafe` to a common package because it will now be used by both types of clients