### PR TITLE
Use annotationType instead of getClass()

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/FieldInfo.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/FieldInfo.java
@@ -68,7 +68,7 @@ public class FieldInfo {
 
     private String getNonEmptyValue(Annotation jsonbProperty) {
         try {
-            Method method = jsonbProperty.getClass().getMethod("value");
+            Method method = jsonbProperty.annotationType().getMethod("value");
             String value = (String) method.invoke(jsonbProperty);
             return (value == null || value.isEmpty()) ? null : value;
         } catch (Exception e) {


### PR DESCRIPTION
Access type of annotation directly, not through the getClass() that creates a proxy. This allows for the library to be used seamlessly in GraalVM Native applications.