### PR TITLE
Remove websocket-client-impl from integration tests

### DIFF
--- a/server/integration-tests/pom.xml
+++ b/server/integration-tests/pom.xml
@@ -79,11 +79,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>javax-websocket-client-impl</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>javax-websocket-server-impl</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
it's no longer used, we use the vert.x implementation 