### PR TITLE
Adding Blocking/NonBlocking support

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
@@ -546,11 +546,16 @@ public class Annotations {
 
     private static final short ZERO = 0;
 
+    // SmallRye Common Annotations
+    public static final DotName BLOCKING = DotName.createSimple("io.smallrye.common.annotation.Blocking");
+    public static final DotName NON_BLOCKING = DotName.createSimple("io.smallrye.common.annotation.NonBlocking");
+
     // SmallRye GraphQL Annotations (Experimental)
     public static final DotName TO_SCALAR = DotName.createSimple("io.smallrye.graphql.api.ToScalar"); // TODO: Remove
     public static final DotName ADAPT_TO_SCALAR = DotName.createSimple("io.smallrye.graphql.api.AdaptToScalar");
     public static final DotName ADAPT_WITH = DotName.createSimple("io.smallrye.graphql.api.AdaptWith");
     public static final DotName ERROR_CODE = DotName.createSimple("io.smallrye.graphql.api.ErrorCode");
+    public static final DotName DATAFETCHER = DotName.createSimple("io.smallrye.graphql.api.DataFetcher");
     public static final DotName SUBCRIPTION = DotName.createSimple("io.smallrye.graphql.api.Subscription");
     public static final DotName DIRECTIVE = DotName.createSimple("io.smallrye.graphql.api.Directive");
     public static final DotName DEFAULT_NON_NULL = DotName.createSimple("io.smallrye.graphql.api.DefaultNonNull");

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Execute.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Execute.java
@@ -1,0 +1,12 @@
+package io.smallrye.graphql.schema.model;
+
+/**
+ * Execution type
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public enum Execute {
+    BLOCKING,
+    NON_BLOCKING,
+    DEFAULT
+}

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Operation.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Operation.java
@@ -34,14 +34,22 @@ public final class Operation extends Field {
      */
     private Reference sourceFieldOn = null;
 
+    /**
+     * If this should be executed blocking. By default all normal object returns will be blocking, except if marked
+     * with @NonBlocking
+     * And all Uni and CompletionStage will be non blocking by default, except if marked with @Blocking
+     */
+    private Execute execute;
+
     public Operation() {
     }
 
     public Operation(String className, String methodName, String propertyName, String name, Reference reference,
-            final OperationType operationType) {
+            final OperationType operationType, Execute execute) {
         super(methodName, propertyName, name, reference);
         this.className = className;
         this.operationType = operationType;
+        this.execute = execute;
     }
 
     public void setClassName(String className) {
@@ -86,6 +94,14 @@ public final class Operation extends Field {
 
     public boolean isSourceField() {
         return this.sourceFieldOn != null;
+    }
+
+    public Execute getExecute() {
+        return execute;
+    }
+
+    public void setExecute(Execute execute) {
+        this.execute = execute;
     }
 
     @Override

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Schema.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Schema.java
@@ -33,6 +33,9 @@ public final class Schema implements Serializable {
 
     private Map<String, ErrorInfo> errors = new HashMap<>();
 
+    private Map<String, String> wrappedDataFetchers = new HashMap<>();
+    private Map<String, String> fieldDataFetchers = new HashMap<>();
+
     public Schema() {
     }
 
@@ -236,6 +239,38 @@ public final class Schema implements Serializable {
 
     public boolean hasErrors() {
         return !this.errors.isEmpty();
+    }
+
+    public Map<String, String> getWrappedDataFetchers() {
+        return this.wrappedDataFetchers;
+    }
+
+    public void setWrappedDataFetchers(Map<String, String> wrappedDataFetchers) {
+        this.wrappedDataFetchers = wrappedDataFetchers;
+    }
+
+    public void addWrappedDataFetcher(String forReturn, String className) {
+        this.wrappedDataFetchers.put(forReturn, className);
+    }
+
+    public boolean hasWrappedDataFetchers() {
+        return !this.wrappedDataFetchers.isEmpty();
+    }
+
+    public Map<String, String> getFieldDataFetchers() {
+        return this.fieldDataFetchers;
+    }
+
+    public void setFieldDataFetchers(Map<String, String> fieldDataFetchers) {
+        this.fieldDataFetchers = fieldDataFetchers;
+    }
+
+    public void addFieldDataFetcher(String forReturn, String className) {
+        this.fieldDataFetchers.put(forReturn, className);
+    }
+
+    public boolean hasFieldDataFetchers() {
+        return !this.fieldDataFetchers.isEmpty();
     }
 
     public List<Operation> getBatchOperations() {

--- a/server/api/src/main/java/io/smallrye/graphql/api/DataFetcher.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/DataFetcher.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.graphql.api;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.smallrye.common.annotation.Experimental;
+
+@Retention(RUNTIME)
+@Target({ TYPE, ANNOTATION_TYPE })
+@Experimental("Allow you to add a custom datafetcher for a certain return type. Not covered by the specification. " +
+        "Subject to change.")
+public @interface DataFetcher {
+    Class forClass();
+
+    boolean isWrapped() default false;
+}

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/producer/GraphQLProducer.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/producer/GraphQLProducer.java
@@ -3,6 +3,7 @@ package io.smallrye.graphql.cdi.producer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
+import graphql.execution.ExecutionStrategy;
 import graphql.schema.GraphQLSchema;
 import io.smallrye.graphql.bootstrap.Bootstrap;
 import io.smallrye.graphql.execution.ExecutionService;
@@ -21,20 +22,39 @@ public class GraphQLProducer {
     }
 
     public GraphQLSchema initialize(Schema schema) {
-        return initialize(schema, false);
+        return initialize(schema, null, null);
+    }
+
+    public GraphQLSchema initialize(Schema schema, ExecutionStrategy queryExecutionStrategy,
+            ExecutionStrategy mutationExecutionStrategy) {
+        return initialize(schema, false, queryExecutionStrategy, mutationExecutionStrategy);
     }
 
     public GraphQLSchema initialize(Schema schema, boolean allowMultipleDeployments) {
+        return initialize(schema, allowMultipleDeployments, null, null);
+    }
+
+    public GraphQLSchema initialize(Schema schema, boolean allowMultipleDeployments, ExecutionStrategy queryExecutionStrategy,
+            ExecutionStrategy mutationExecutionStrategy) {
         this.schema = schema;
-        return initialize(allowMultipleDeployments);
+        return initialize(allowMultipleDeployments, queryExecutionStrategy, mutationExecutionStrategy);
     }
 
     public GraphQLSchema initialize(boolean allowMultipleDeployments) {
+        return initialize(allowMultipleDeployments, null, null);
+    }
+
+    public GraphQLSchema initialize(boolean allowMultipleDeployments, ExecutionStrategy queryExecutionStrategy,
+            ExecutionStrategy mutationExecutionStrategy) {
 
         this.graphQLSchema = Bootstrap.bootstrap(schema, allowMultipleDeployments);
         this.executionService = new ExecutionService(graphQLSchema, this.schema.getBatchOperations(),
-                schema.hasSubscriptions());
+                schema.hasSubscriptions(), queryExecutionStrategy, mutationExecutionStrategy);
         return this.graphQLSchema;
+    }
+
+    public GraphQLSchema initialize(ExecutionStrategy queryExecutionStrategy, ExecutionStrategy mutationExecutionStrategy) {
+        return initialize(false, queryExecutionStrategy, mutationExecutionStrategy);
     }
 
     public GraphQLSchema initialize() {

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/tracing/TracingService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/tracing/TracingService.java
@@ -181,7 +181,8 @@ public class TracingService implements EventingService {
     }
 
     private static String getOperationName(ExecutionInput executionInput) {
-        if (executionInput.getOperationName() != null && !executionInput.getOperationName().isEmpty()) {
+        if (executionInput != null && executionInput.getOperationName() != null
+                && !executionInput.getOperationName().isEmpty()) {
             return PREFIX + ":" + executionInput.getOperationName();
         }
         return PREFIX;

--- a/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/HttpServletResponseWriter.java
+++ b/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/HttpServletResponseWriter.java
@@ -1,0 +1,39 @@
+package io.smallrye.graphql.entry.http;
+
+import java.io.IOException;
+
+import javax.json.Json;
+import javax.json.JsonWriter;
+import javax.json.JsonWriterFactory;
+import javax.servlet.http.HttpServletResponse;
+
+import io.smallrye.graphql.execution.ExecutionResponse;
+import io.smallrye.graphql.execution.ExecutionResponseWriter;
+
+/**
+ * Writing the response to HTTP servlet
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class HttpServletResponseWriter implements ExecutionResponseWriter {
+    private static final String APPLICATION_JSON_UTF8 = "application/json;charset=UTF-8";
+    private static final JsonWriterFactory jsonWriterFactory = Json.createWriterFactory(null);
+
+    private HttpServletResponse response;
+
+    public HttpServletResponseWriter(HttpServletResponse response) {
+        this.response = response;
+    }
+
+    @Override
+    public void write(ExecutionResponse executionResponse) {
+        if (executionResponse != null) {
+            try (JsonWriter jsonWriter = jsonWriterFactory.createWriter(response.getOutputStream())) {
+                response.setContentType(APPLICATION_JSON_UTF8);
+                jsonWriter.writeObject(executionResponse.getExecutionResultAsJsonObject());
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/DataFetcherFactory.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/DataFetcherFactory.java
@@ -1,5 +1,11 @@
 package io.smallrye.graphql.bootstrap;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -9,11 +15,13 @@ import graphql.schema.DataFetcher;
 import io.smallrye.graphql.execution.datafetcher.CompletionStageDataFetcher;
 import io.smallrye.graphql.execution.datafetcher.DefaultDataFetcher;
 import io.smallrye.graphql.execution.datafetcher.MultiDataFetcher;
+import io.smallrye.graphql.execution.datafetcher.PlugableDataFetcher;
 import io.smallrye.graphql.execution.datafetcher.PublisherDataFetcher;
 import io.smallrye.graphql.execution.datafetcher.UniDataFetcher;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Wrapper;
+import io.smallrye.graphql.spi.DataFetcherService;
 
 /**
  * Create the datafetchers for a certain operation
@@ -21,6 +29,22 @@ import io.smallrye.graphql.schema.model.Wrapper;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class DataFetcherFactory {
+
+    private List<DataFetcherService> dataFetcherServices = new ArrayList<>();
+
+    public DataFetcherFactory() {
+        Iterator<DataFetcherService> i = ServiceLoader.load(DataFetcherService.class).iterator();
+        while (i.hasNext()) {
+            dataFetcherServices.add(i.next());
+        }
+
+        Collections.sort(dataFetcherServices, new Comparator<DataFetcherService>() {
+            @Override
+            public int compare(DataFetcherService o1, DataFetcherService o2) {
+                return o1.getPriority().compareTo(o2.getPriority());
+            }
+        });
+    }
 
     public <T> DataFetcher<T> getDataFetcher(Operation operation) {
         return (DataFetcher<T>) get(operation);
@@ -45,22 +69,118 @@ public class DataFetcherFactory {
         return null;
     }
 
-    // TODO: Have some way to load custom ?    
     private <V> V get(Operation operation) {
         if (isCompletionStage(operation)) {
-            return (V) new CompletionStageDataFetcher(operation);
+            return (V) getCompletionStageDataFetcher(operation);
         } else if (isMutinyUni(operation)) {
-            return (V) new UniDataFetcher(operation);
+            return (V) getUniDataFetcher(operation);
         } else if (isPublisher(operation)) {
-            return (V) new PublisherDataFetcher(operation);
+            return (V) getPublisherDataFetcher(operation);
         } else if (isMutinyMulti(operation)) {
-            return (V) new MultiDataFetcher(operation);
+            return (V) getMultiDataFetcher(operation);
+        } else if (isWrapped(operation)) {
+            return (V) getOtherWrappedDataFetcher(operation);
         }
-        return (V) new DefaultDataFetcher(operation);
+        return (V) getOtherFieldDataFetcher(operation);
+    }
+
+    public PlugableDataFetcher getCompletionStageDataFetcher(Operation operation) {
+
+        for (DataFetcherService dfe : dataFetcherServices) {
+            PlugableDataFetcher df = dfe.getCompletionStageDataFetcher(operation);
+            if (df != null) {
+                return df;
+            }
+        }
+
+        return new CompletionStageDataFetcher(operation);
+    }
+
+    public PlugableDataFetcher getUniDataFetcher(Operation operation) {
+
+        for (DataFetcherService dfe : dataFetcherServices) {
+            PlugableDataFetcher df = dfe.getUniDataFetcher(operation);
+            if (df != null) {
+                return df;
+            }
+        }
+
+        return new UniDataFetcher(operation);
+    }
+
+    public PlugableDataFetcher getPublisherDataFetcher(Operation operation) {
+
+        for (DataFetcherService dfe : dataFetcherServices) {
+            PlugableDataFetcher df = dfe.getPublisherDataFetcher(operation);
+            if (df != null) {
+                return df;
+            }
+        }
+
+        return new PublisherDataFetcher(operation);
+    }
+
+    public PlugableDataFetcher getMultiDataFetcher(Operation operation) {
+
+        for (DataFetcherService dfe : dataFetcherServices) {
+            PlugableDataFetcher df = dfe.getMultiDataFetcher(operation);
+            if (df != null) {
+                return df;
+            }
+        }
+
+        return new MultiDataFetcher(operation);
+    }
+
+    public PlugableDataFetcher getOtherWrappedDataFetcher(Operation operation) {
+
+        for (DataFetcherService dfe : dataFetcherServices) {
+            PlugableDataFetcher df = dfe.getOtherWrappedDataFetcher(operation);
+            if (df != null) {
+                return df;
+            }
+        }
+
+        return getDefaultDataFetcher(operation);
+    }
+
+    public PlugableDataFetcher getOtherFieldDataFetcher(Operation operation) {
+
+        for (DataFetcherService dfe : dataFetcherServices) {
+            PlugableDataFetcher df = dfe.getOtherFieldDataFetcher(operation);
+            if (df != null) {
+                return df;
+            }
+        }
+
+        for (DataFetcherService dfe : dataFetcherServices) {
+            PlugableDataFetcher df = dfe.getDefaultDataFetcher(operation);
+            if (df != null) {
+                return df;
+            }
+        }
+
+        return new DefaultDataFetcher(operation);
+    }
+
+    public PlugableDataFetcher getDefaultDataFetcher(Operation operation) {
+
+        //        for (DataFetcherService dfe : dataFetcherServices) {
+        //            PlugableDataFetcher df = dfe.getOtherFieldDataFetcher(operation);
+        //            if (df != null) {
+        //                return df;
+        //            }
+        //        }
+
+        return getOtherFieldDataFetcher(operation);
     }
 
     private boolean isAsync(Field field) {
         return isCompletionStage(field) || isMutinyUni(field);
+    }
+
+    private boolean isWrapped(Field field) {
+        return field.hasWrapper();
     }
 
     private boolean isCompletionStage(Field field) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponseWriter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponseWriter.java
@@ -1,0 +1,19 @@
+package io.smallrye.graphql.execution;
+
+/**
+ * Write the response to something
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public interface ExecutionResponseWriter {
+
+    public void write(ExecutionResponse er);
+
+    default void fail(Throwable t) {
+        if (t.getClass().isAssignableFrom(RuntimeException.class)) {
+            throw (RuntimeException) t;
+        } else {
+            throw new RuntimeException(t);
+        }
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -2,25 +2,29 @@ package io.smallrye.graphql.execution;
 
 import static io.smallrye.graphql.SmallRyeGraphQLServerLogging.log;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.json.JsonObject;
 
 import org.dataloader.BatchLoaderWithContext;
 import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderFactory;
 import org.dataloader.DataLoaderOptions;
 import org.dataloader.DataLoaderRegistry;
+import org.eclipse.microprofile.context.ThreadContext;
 
 import graphql.ExecutionInput;
 import graphql.ExecutionInput.Builder;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.GraphQLContext;
 import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionStrategy;
 import graphql.execution.SubscriptionExecutionStrategy;
 import graphql.schema.GraphQLSchema;
 import io.smallrye.graphql.api.Context;
@@ -58,8 +62,16 @@ public class ExecutionService {
     private final QueryCache queryCache;
     private final LogPayloadOption payloadOption;
 
+    private final ExecutionStrategy queryExecutionStrategy;
+    private final ExecutionStrategy mutationExecutionStrategy;
+
     public ExecutionService(GraphQLSchema graphQLSchema, List<Operation> batchOperations,
             boolean hasSubscription) {
+        this(graphQLSchema, batchOperations, hasSubscription, null, null);
+    }
+
+    public ExecutionService(GraphQLSchema graphQLSchema, List<Operation> batchOperations,
+            boolean hasSubscription, ExecutionStrategy queryExecutionStrategy, ExecutionStrategy mutationExecutionStrategy) {
 
         this.graphQLSchema = graphQLSchema;
         this.batchOperations = batchOperations;
@@ -68,19 +80,60 @@ public class ExecutionService {
         this.hasSubscription = hasSubscription;
         this.queryCache = new QueryCache();
 
+        this.queryExecutionStrategy = queryExecutionStrategy;
+        this.mutationExecutionStrategy = mutationExecutionStrategy;
+
         Config config = Config.get();
         this.payloadOption = config.logPayload();
     }
 
+    /**
+     * @deprecated - use one on the void method providing a writer.
+     */
+    @Deprecated
     public ExecutionResponse execute(JsonObject jsonInput) {
-        SmallRyeContext context = new SmallRyeContext(jsonInput);
+        try {
+            JsonObjectResponseWriter jsonObjectResponseWriter = new JsonObjectResponseWriter(jsonInput);
+            executeSync(jsonInput, jsonObjectResponseWriter);
+            return jsonObjectResponseWriter.getExecutionResponse();
+        } catch (Throwable t) {
+            if (t.getClass().isAssignableFrom(RuntimeException.class)) {
+                throw (RuntimeException) t;
+            } else {
+                throw new RuntimeException(t);
+            }
+        }
+    }
+
+    public void executeSync(JsonObject jsonInput, ExecutionResponseWriter writer) {
+        executeSync(jsonInput, new HashMap<>(), writer);
+    }
+
+    public void executeSync(JsonObject jsonInput, Map<String, Object> context, ExecutionResponseWriter writer) {
+        execute(jsonInput, context, writer, false);
+    }
+
+    public void executeAsync(JsonObject jsonInput, ExecutionResponseWriter writer) {
+        executeAsync(jsonInput, new HashMap<>(), writer);
+    }
+
+    public void executeAsync(JsonObject jsonInput, Map<String, Object> context, ExecutionResponseWriter writer) {
+        execute(jsonInput, context, writer, true);
+    }
+
+    public void execute(JsonObject jsonInput, ExecutionResponseWriter writer, boolean async) {
+        execute(jsonInput, new HashMap<>(), writer, async);
+    }
+
+    public void execute(JsonObject jsonInput, Map<String, Object> context, ExecutionResponseWriter writer, boolean async) {
+        SmallRyeContext smallRyeContext = new SmallRyeContext(jsonInput);
 
         // ExecutionId
         ExecutionId finalExecutionId = ExecutionId.from(executionIdPrefix + executionId.getAndIncrement());
 
         try {
-            String query = context.getQuery();
-            Optional<Map<String, Object>> variables = context.getVariables();
+            String query = smallRyeContext.getQuery();
+            Optional<Map<String, Object>> variables = smallRyeContext.getVariables();
 
             if (query == null || query.isEmpty()) {
                 throw new RuntimeException("Query can not be null");
@@ -100,13 +153,10 @@ public class ExecutionService {
                         .executionId(finalExecutionId);
 
                 // Variables
-                context.getVariables().ifPresent(executionBuilder::variables);
+                smallRyeContext.getVariables().ifPresent(executionBuilder::variables);
 
                 // Operation name
-                context.getOperationName().ifPresent(executionBuilder::operationName);
-
-                // Context
-                executionBuilder.context(toGraphQLContext(context));
+                smallRyeContext.getOperationName().ifPresent(executionBuilder::operationName);
 
                 // DataLoaders
                 if (batchOperations != null && !batchOperations.isEmpty()) {
@@ -117,29 +167,78 @@ public class ExecutionService {
                 ExecutionInput executionInput = executionBuilder.build();
 
                 // Update context with execution data
-                context = context.withDataFromExecution(executionInput, queryCache);
-                ((GraphQLContext) executionInput.getContext()).put("context", context);
+                smallRyeContext = smallRyeContext.withDataFromExecution(executionInput, queryCache);
+
+                // Context
+                context.put("context", smallRyeContext);
+                executionInput.getGraphQLContext().putAll(context);
 
                 // Notify before
-                eventEmitter.fireBeforeExecute(context);
+                eventEmitter.fireBeforeExecute(smallRyeContext);
+
                 // Execute
-                ExecutionResult executionResult = g.execute(executionInput);
-                // Notify after
-                eventEmitter.fireAfterExecute(context);
-
-                ExecutionResponse executionResponse = new ExecutionResponse(executionResult);
-                if (!payloadOption.equals(LogPayloadOption.off)) {
-                    log.payloadOut(executionResponse.toString());
+                if (async) {
+                    writeAsync(g, executionInput, context, writer);
+                } else {
+                    writeSync(g, executionInput, context, writer);
                 }
-
-                return executionResponse;
             } else {
                 log.noGraphQLMethodsFound();
-                return null;
             }
         } catch (Throwable t) {
             eventEmitter.fireOnExecuteError(finalExecutionId.toString(), t);
-            throw t; // TODO: can I remove that?
+            writer.fail(t);
+        }
+    }
+
+    private void writeAsync(GraphQL graphQL,
+            ExecutionInput executionInput,
+            Map<String, Object> context,
+            ExecutionResponseWriter writer) {
+
+        // Execute
+        ThreadContext threadContext = ThreadContext.builder().build();
+        CompletionStage<ExecutionResult> executionResult = threadContext
+                .withContextCapture(graphQL.executeAsync(executionInput));
+
+        executionResult.whenComplete((t, u) -> {
+            executionInput.getGraphQLContext().putAll(context);
+
+            SmallRyeContext smallryeContext = (SmallRyeContext) context.get("context");
+            SmallRyeContext.setContext(smallryeContext);
+
+            // Notify after
+            eventEmitter.fireAfterExecute(smallryeContext);
+
+            ExecutionResponse executionResponse = new ExecutionResponse(t);
+            if (!payloadOption.equals(LogPayloadOption.off)) {
+                log.payloadOut(executionResponse.toString());
+            }
+            writer.write(executionResponse);
+
+            if (u != null) {
+                writer.fail(u);
+            }
+        });
+    }
+
+    private void writeSync(GraphQL g,
+            ExecutionInput executionInput,
+            Map<String, Object> context,
+            ExecutionResponseWriter writer) {
+        try {
+            ExecutionResult executionResult = g.execute(executionInput);
+            // Notify after
+            eventEmitter.fireAfterExecute((Context) context.get("context"));
+
+            ExecutionResponse executionResponse = new ExecutionResponse(executionResult);
+            if (!payloadOption.equals(LogPayloadOption.off)) {
+                log.payloadOut(executionResponse.toString());
+            }
+
+            writer.write(executionResponse);
+        } catch (Throwable t) {
+            writer.fail(t);
         }
     }
 
@@ -150,17 +249,11 @@ public class ExecutionService {
             SmallRyeBatchLoaderContextProvider ctxProvider = new SmallRyeBatchLoaderContextProvider();
             DataLoaderOptions options = DataLoaderOptions.newOptions()
                     .setBatchLoaderContextProvider(ctxProvider);
-            DataLoader<K, T> dataLoader = DataLoader.newDataLoader(batchLoader, options);
+            DataLoader<K, T> dataLoader = DataLoaderFactory.newDataLoader(batchLoader, options);
             ctxProvider.setDataLoader(dataLoader);
             dataLoaderRegistry.register(batchLoaderHelper.getName(operation), dataLoader);
         }
         return dataLoaderRegistry;
-    }
-
-    private GraphQLContext toGraphQLContext(Context context) {
-        GraphQLContext.Builder builder = GraphQLContext.newContext();
-        builder = builder.of("context", context);
-        return builder.build();
     }
 
     private GraphQL getGraphQL() {
@@ -171,6 +264,13 @@ public class ExecutionService {
                 graphqlBuilder = graphqlBuilder.instrumentation(queryCache);
                 graphqlBuilder = graphqlBuilder.preparsedDocumentProvider(queryCache);
 
+                if (queryExecutionStrategy != null) {
+                    graphqlBuilder = graphqlBuilder.queryExecutionStrategy(queryExecutionStrategy);
+                }
+
+                if (mutationExecutionStrategy != null) {
+                    graphqlBuilder = graphqlBuilder.queryExecutionStrategy(mutationExecutionStrategy);
+                }
                 if (hasSubscription) {
                     graphqlBuilder = graphqlBuilder
                             .subscriptionExecutionStrategy(new SubscriptionExecutionStrategy(new ExceptionHandler()));

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/JsonObjectResponseWriter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/JsonObjectResponseWriter.java
@@ -1,0 +1,99 @@
+package io.smallrye.graphql.execution;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonWriter;
+import javax.json.JsonWriterFactory;
+import javax.json.stream.JsonGenerator;
+
+import org.jboss.logging.Logger;
+
+/**
+ * A default implementation for Execution Response Writer
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class JsonObjectResponseWriter implements ExecutionResponseWriter {
+    protected static final Logger LOG = Logger.getLogger(JsonObjectResponseWriter.class.getName());
+
+    private ExecutionResponse executionResponse = null;
+    private Throwable throwable = null;
+    private final JsonObject input;
+
+    JsonObjectResponseWriter(String graphQL) {
+        this.input = toJsonObject(graphQL);
+    }
+
+    JsonObjectResponseWriter(JsonObject input) {
+        this.input = input;
+    }
+
+    @Override
+    public void write(ExecutionResponse er) {
+        this.executionResponse = er;
+    }
+
+    @Override
+    public void fail(Throwable t) {
+        this.throwable = t;
+    }
+
+    public void logInput() {
+        String prettyInput = getPrettyJson(input);
+        LOG.info(prettyInput);
+    }
+
+    public void logOutput() {
+        if (executionResponse != null) {
+            String prettyData = getPrettyJson(executionResponse.getExecutionResultAsJsonObject());
+            LOG.info(prettyData);
+        } else if (throwable != null) {
+            LOG.error("ERROR", throwable);
+        }
+    }
+
+    public JsonObject getInput() {
+        return this.input;
+    }
+
+    public JsonObject getOutput() {
+        if (this.executionResponse != null) {
+            return this.executionResponse.getExecutionResultAsJsonObject();
+        }
+        return JsonObject.EMPTY_JSON_OBJECT;
+    }
+
+    public ExecutionResponse getExecutionResponse() {
+        return this.executionResponse;
+    }
+
+    private String getPrettyJson(JsonObject jsonObject) {
+
+        JsonWriterFactory writerFactory = Json.createWriterFactory(JSON_PROPERTIES);
+
+        try (StringWriter sw = new StringWriter();
+                JsonWriter jsonWriter = writerFactory.createWriter(sw)) {
+            jsonWriter.writeObject(jsonObject);
+            return sw.toString();
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private JsonObject toJsonObject(String graphQL) {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+        builder.add("query", graphQL);
+        return builder.build();
+    }
+
+    private static final Map<String, Object> JSON_PROPERTIES = new HashMap<>(1);
+    static {
+        JSON_PROPERTIES.put(JsonGenerator.PRETTY_PRINTING, true);
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeBatchLoaderContextProvider.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeBatchLoaderContextProvider.java
@@ -6,7 +6,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.dataloader.BatchLoaderContextProvider;
 import org.dataloader.DataLoader;
 
-// hacky way to pass the SmallRyeContext from data from data fetchers to BatchLoaderEnvironment
+import graphql.GraphQLContext;
+
+// hacky way to pass the GraphQL Context from data from data fetchers to BatchLoaderEnvironment
 public class SmallRyeBatchLoaderContextProvider implements BatchLoaderContextProvider {
 
     /**
@@ -26,14 +28,14 @@ public class SmallRyeBatchLoaderContextProvider implements BatchLoaderContextPro
         return INSTANCES.get(dataLoader);
     }
 
-    private AtomicReference<SmallRyeContext> current = new AtomicReference<>();
+    private AtomicReference<GraphQLContext> current = new AtomicReference<>();
 
-    public void set(SmallRyeContext context) {
+    public void set(GraphQLContext context) {
         current.set(context);
     }
 
     @Override
-    public Object getContext() {
+    public GraphQLContext getContext() {
         return current.getAndSet(null);
     }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContext.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContext.java
@@ -89,7 +89,7 @@ public class SmallRyeContext implements Context {
     }
 
     public SmallRyeContext withDataFromExecution(ExecutionInput executionInput) {
-        return new SmallRyeContext(this.jsonObject, this.dfe, executionInput, this.queryCache, this.field);
+        return withDataFromExecution(executionInput, this.queryCache);
     }
 
     public SmallRyeContext withDataFromExecution(ExecutionInput executionInput, QueryCache queryCache) {
@@ -98,6 +98,10 @@ public class SmallRyeContext implements Context {
 
     public SmallRyeContext withDataFromFetcher(DataFetchingEnvironment dfe, Field field) {
         return new SmallRyeContext(this.jsonObject, dfe, this.executionInput, this.queryCache, field);
+    }
+
+    public SmallRyeContext withDataFromFetcher(Field field) {
+        return withDataFromFetcher(this.dfe, field);
     }
 
     public static void remove() {
@@ -166,6 +170,11 @@ public class SmallRyeContext implements Context {
 
     @Override
     public String getFieldName() {
+
+        if (field != null) {
+            return field.getName();
+        }
+
         if (dfe != null) {
             return dfe.getField().getName();
         }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/ContextAware.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/ContextAware.java
@@ -1,0 +1,51 @@
+package io.smallrye.graphql.execution.datafetcher;
+
+import org.dataloader.BatchLoaderEnvironment;
+import org.dataloader.DataLoader;
+
+import graphql.GraphQLContext;
+import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.execution.context.SmallRyeBatchLoaderContextProvider;
+import io.smallrye.graphql.execution.context.SmallRyeContext;
+import io.smallrye.graphql.schema.model.Field;
+
+public interface ContextAware {
+    static final String CONTEXT = "context";
+
+    default SmallRyeContext getSmallRyeContext(final DataFetchingEnvironment dfe) {
+        GraphQLContext graphQLContext = dfe.getGraphQlContext();
+        return graphQLContext.get(CONTEXT);
+    }
+
+    default SmallRyeContext getSmallRyeContext(final BatchLoaderEnvironment ble) {
+        GraphQLContext graphQLContext = ble.getContext();
+        return graphQLContext.get(CONTEXT);
+    }
+
+    default void updateSmallRyeContext(final DataFetchingEnvironment dfe, SmallRyeContext smallRyeContext) {
+        GraphQLContext graphQLContext = dfe.getGraphQlContext();
+        graphQLContext.put(CONTEXT, smallRyeContext);
+    }
+
+    default SmallRyeContext updateSmallRyeContext(final DataFetchingEnvironment dfe, final Field field) {
+        SmallRyeContext smallRyeContext = getSmallRyeContext(dfe);
+        smallRyeContext = smallRyeContext.withDataFromFetcher(dfe, field);
+        updateSmallRyeContext(dfe, smallRyeContext);
+        return smallRyeContext;
+    }
+
+    default SmallRyeContext updateSmallRyeContext(final BatchLoaderEnvironment ble, final Field field) {
+        GraphQLContext graphQLContext = ble.getContext();
+        SmallRyeContext smallRyeContext = graphQLContext.get(CONTEXT);
+        smallRyeContext = smallRyeContext.withDataFromFetcher(field);
+        graphQLContext.put(CONTEXT, smallRyeContext);
+        return smallRyeContext;
+    }
+
+    default void updateSmallRyeContext(final DataLoader<Object, Object> dataLoader, final DataFetchingEnvironment dfe) {
+        // FIXME: this is potentially brittle because it assumes that the batch loader will execute and
+        //  consume the context before we call this again for a different operation, but I don't know
+        //  how else to pass this context to the matching BatchLoaderEnvironment instance
+        SmallRyeBatchLoaderContextProvider.getForDataLoader(dataLoader).set(dfe.getGraphQlContext());
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/DefaultDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/DefaultDataFetcher.java
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletionStage;
 import org.dataloader.BatchLoaderEnvironment;
 import org.eclipse.microprofile.context.ThreadContext;
 
-import graphql.GraphQLContext;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
 import io.smallrye.graphql.execution.context.SmallRyeContext;
@@ -31,7 +30,7 @@ public class DefaultDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
     @Override
     public <T> T invokeAndTransform(DataFetchingEnvironment dfe, DataFetcherResult.Builder<Object> resultBuilder,
             Object[] transformedArguments) throws Exception {
-        SmallRyeContext context = ((GraphQLContext) dfe.getContext()).get("context");
+        SmallRyeContext context = getSmallRyeContext(dfe);
         try {
             SmallRyeContext.setContext(context);
             Object resultFromMethodCall = operationInvoker.invoke(transformedArguments);
@@ -52,11 +51,11 @@ public class DefaultDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
     public CompletionStage<List<T>> load(List<K> keys, BatchLoaderEnvironment ble) {
         Object[] arguments = batchLoaderHelper.getArguments(keys, ble);
         final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-        final SmallRyeContext context = ble.getContext();
+        final SmallRyeContext smallRyeContext = getSmallRyeContext(ble);
 
         ThreadContext threadContext = ThreadContext.builder().build();
         try {
-            SmallRyeContext.setContext(context);
+            SmallRyeContext.setContext(smallRyeContext);
 
             CompletableFuture<List<T>> reflectionSupplier = CompletableFuture.supplyAsync(() -> {
                 try {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/FieldDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/FieldDataFetcher.java
@@ -4,12 +4,10 @@ import static io.smallrye.graphql.SmallRyeGraphQLServerLogging.log;
 
 import java.lang.reflect.InvocationTargetException;
 
-import graphql.GraphQLContext;
 import graphql.GraphQLException;
 import graphql.TrivialDataFetcher;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.smallrye.graphql.execution.context.SmallRyeContext;
 import io.smallrye.graphql.execution.datafetcher.helper.FieldHelper;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.Reference;
@@ -28,7 +26,7 @@ import io.smallrye.graphql.transformation.AbstractDataFetcherException;
  *           different
  *           subtype of the owner class for each call).
  */
-public class FieldDataFetcher<T> implements DataFetcher<T>, TrivialDataFetcher<T> {
+public class FieldDataFetcher<T> implements DataFetcher<T>, TrivialDataFetcher<T>, ContextAware {
 
     private final FieldHelper fieldHelper;
 
@@ -52,10 +50,8 @@ public class FieldDataFetcher<T> implements DataFetcher<T>, TrivialDataFetcher<T
 
     @Override
     public T get(DataFetchingEnvironment dfe) throws Exception {
-        if (dfe.getContext() != null) {
-            GraphQLContext graphQLContext = dfe.getContext();
-            graphQLContext.put("context", ((SmallRyeContext) graphQLContext.get("context")).withDataFromFetcher(dfe, field));
-        }
+
+        updateSmallRyeContext(dfe, field);
 
         if (this.propertyAccessor == null) {
             // lazy initialize method handle, does not have to be threadsafe

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/MultiDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/MultiDataFetcher.java
@@ -7,7 +7,6 @@ import java.util.function.Function;
 import org.dataloader.BatchLoaderEnvironment;
 import org.eclipse.microprofile.graphql.GraphQLException;
 
-import graphql.GraphQLContext;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
 import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
@@ -36,7 +35,7 @@ public class MultiDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
             DataFetchingEnvironment dfe,
             DataFetcherResult.Builder<Object> resultBuilder,
             Object[] transformedArguments) throws Exception {
-        SmallRyeContext context = ((GraphQLContext) dfe.getContext()).get("context");
+        SmallRyeContext context = getSmallRyeContext(dfe);
         try {
             SmallRyeContext.setContext(context);
             Multi<?> multi = operationInvoker.invoke(transformedArguments);

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/PlugableDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/PlugableDataFetcher.java
@@ -1,0 +1,14 @@
+package io.smallrye.graphql.execution.datafetcher;
+
+import org.dataloader.BatchLoaderWithContext;
+
+import graphql.schema.DataFetcher;
+
+/**
+ * Allows DataFetchers to be plugged
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public interface PlugableDataFetcher<K, T> extends DataFetcher<T>, BatchLoaderWithContext<K, T> {
+
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/PublisherDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/PublisherDataFetcher.java
@@ -8,7 +8,6 @@ import org.dataloader.BatchLoaderEnvironment;
 import org.eclipse.microprofile.graphql.GraphQLException;
 import org.reactivestreams.Publisher;
 
-import graphql.GraphQLContext;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
 import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
@@ -38,7 +37,7 @@ public class PublisherDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
             DataFetchingEnvironment dfe,
             DataFetcherResult.Builder<Object> resultBuilder,
             Object[] transformedArguments) throws Exception {
-        SmallRyeContext context = ((GraphQLContext) dfe.getContext()).get("context");
+        SmallRyeContext context = getSmallRyeContext(dfe);
         try {
             SmallRyeContext.setContext(context);
             Publisher<?> publisher = operationInvoker.invoke(transformedArguments);
@@ -61,6 +60,7 @@ public class PublisherDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
                     })
 
                     .onFailure().recoverWithItem(new Function<Throwable, O>() {
+                        @Override
                         public O apply(Throwable throwable) {
                             eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), throwable);
                             if (throwable instanceof GraphQLException) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/UniDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/UniDataFetcher.java
@@ -6,7 +6,6 @@ import java.util.concurrent.CompletionStage;
 import org.dataloader.BatchLoaderEnvironment;
 import org.eclipse.microprofile.graphql.GraphQLException;
 
-import graphql.GraphQLContext;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
 import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
@@ -35,7 +34,7 @@ public class UniDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
             DataFetchingEnvironment dfe,
             DataFetcherResult.Builder<Object> resultBuilder,
             Object[] transformedArguments) throws Exception {
-        SmallRyeContext context = ((GraphQLContext) dfe.getContext()).get("context");
+        SmallRyeContext context = getSmallRyeContext(dfe);
         try {
             SmallRyeContext.setContext(context);
             Uni<?> uni = operationInvoker.invoke(transformedArguments);

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/DataFetcherService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/DataFetcherService.java
@@ -1,0 +1,42 @@
+package io.smallrye.graphql.spi;
+
+import io.smallrye.graphql.execution.datafetcher.PlugableDataFetcher;
+import io.smallrye.graphql.schema.model.Operation;
+
+/**
+ * DataFetcherService service that will get the datafetchers to use
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public interface DataFetcherService {
+
+    public Integer getPriority();
+
+    default PlugableDataFetcher getCompletionStageDataFetcher(Operation operation) {
+        return null;
+    }
+
+    default PlugableDataFetcher getUniDataFetcher(Operation operation) {
+        return null;
+    }
+
+    default PlugableDataFetcher getPublisherDataFetcher(Operation operation) {
+        return null;
+    }
+
+    default PlugableDataFetcher getMultiDataFetcher(Operation operation) {
+        return null;
+    }
+
+    default PlugableDataFetcher getOtherWrappedDataFetcher(Operation operation) {
+        return null;
+    }
+
+    default PlugableDataFetcher getOtherFieldDataFetcher(Operation operation) {
+        return null;
+    }
+
+    default PlugableDataFetcher getDefaultDataFetcher(Operation operation) {
+        return null;
+    }
+}


### PR DESCRIPTION
Here the highlevel changes:

- Added support for Blocking and NonBlocking annotations
- Added support for plugable DataFetchers
- Deprecate request/response on ExecutionService in favour of providing a writer
- Added option to execute async
- Allow passing in of execution strategies
- Changed BatchLoaderEnvironment to rather carry GraphQLContext vs SmallRyeContext

Context propagation is still very messy. Need to clean that up
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>