### PR TITLE
Allow passing WebClient to dynamic client builder

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClient.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClient.java
@@ -55,7 +55,8 @@ public class VertxDynamicGraphQLClient implements DynamicGraphQLClient {
     // and a new websocket connection attempted.
     private final AtomicReference<Uni<WebSocketSubprotocolHandler>> webSocketHandler = new AtomicReference<>();
 
-    VertxDynamicGraphQLClient(Vertx vertx, String url, String websocketUrl, boolean executeSingleOperationsOverWebsocket,
+    VertxDynamicGraphQLClient(Vertx vertx, WebClient webClient,
+            String url, String websocketUrl, boolean executeSingleOperationsOverWebsocket,
             MultiMap headers, WebClientOptions options,
             List<WebsocketSubprotocol> subprotocols, Integer subscriptionInitializationTimeout) {
         if (options != null) {
@@ -63,7 +64,11 @@ public class VertxDynamicGraphQLClient implements DynamicGraphQLClient {
         } else {
             this.httpClient = vertx.createHttpClient();
         }
-        this.webClient = WebClient.wrap(httpClient);
+        if (webClient == null) {
+            this.webClient = WebClient.wrap(httpClient);
+        } else {
+            this.webClient = webClient;
+        }
         this.headers = headers;
         this.url = url;
         this.websocketUrl = websocketUrl;

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClientBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClientBuilder.java
@@ -19,6 +19,7 @@ import io.vertx.core.Context;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 /**
@@ -29,6 +30,7 @@ public class VertxDynamicGraphQLClientBuilder implements DynamicGraphQLClientBui
     private static final Logger log = Logger.getLogger(VertxDynamicGraphQLClientBuilder.class);
 
     private Vertx vertx;
+    private WebClient webClient;
     private String url;
     private String websocketUrl;
     private Boolean executeSingleOperationsOverWebsocket;
@@ -46,6 +48,11 @@ public class VertxDynamicGraphQLClientBuilder implements DynamicGraphQLClientBui
 
     public VertxDynamicGraphQLClientBuilder vertx(Vertx vertx) {
         this.vertx = vertx;
+        return this;
+    }
+
+    public VertxDynamicGraphQLClientBuilder webClient(WebClient client) {
+        this.webClient = client;
         return this;
     }
 
@@ -133,8 +140,8 @@ public class VertxDynamicGraphQLClientBuilder implements DynamicGraphQLClientBui
         if (executeSingleOperationsOverWebsocket == null) {
             executeSingleOperationsOverWebsocket = false;
         }
-        return new VertxDynamicGraphQLClient(toUseVertx, url, websocketUrl, executeSingleOperationsOverWebsocket, headersMap,
-                options, subprotocols,
+        return new VertxDynamicGraphQLClient(toUseVertx, webClient, url, websocketUrl,
+                executeSingleOperationsOverWebsocket, headersMap, options, subprotocols,
                 subscriptionInitializationTimeout);
     }
 


### PR DESCRIPTION
@cherrydev, please have a look if this is enough for you. Typesafe client builder already has a method that takes the WebClient.

Fixes #1304 