### PR TITLE
Add built-in support for `org.bson.types.ObjectId`

### DIFF
--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
@@ -81,6 +81,7 @@ public class Scalars {
         populateScalar(UUID.class.getName(), STRING, String.class.getName());
         populateScalar(URL.class.getName(), STRING, String.class.getName());
         populateScalar(URI.class.getName(), STRING, String.class.getName());
+        populateScalar("org.bson.types.ObjectId", STRING, String.class.getName());
         populateScalar("javax.json.JsonObject", STRING, String.class.getName());
         populateScalar("javax.json.JsonArray", STRING, String.class.getName());
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/GraphQLScalarTypes.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/GraphQLScalarTypes.java
@@ -65,6 +65,7 @@ public class GraphQLScalarTypes {
 
         SCALAR_MAP.put(String.class.getName(), Scalars.GraphQLString);
         SCALAR_MAP.put(UUID.class.getName(), Scalars.GraphQLString);
+        SCALAR_MAP.put("org.bson.types.ObjectId", Scalars.GraphQLString);
         SCALAR_MAP.put(URL.class.getName(), Scalars.GraphQLString);
         SCALAR_MAP.put(URI.class.getName(), Scalars.GraphQLString);
 

--- a/server/runner/pom.xml
+++ b/server/runner/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>rxjava</artifactId>
             <version>2.2.21</version>
         </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>bson</artifactId>
+            <version>4.5.1</version>
+        </dependency>
         <!-- The UI -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/server/tck/pom.xml
+++ b/server/tck/pom.xml
@@ -109,7 +109,12 @@
             <version>2.13.2</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>bson</artifactId>
+            <version>4.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/scalars/api/AdditionalScalars.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/scalars/api/AdditionalScalars.java
@@ -6,10 +6,13 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.UUID;
 
+import org.bson.types.ObjectId;
+
 public class AdditionalScalars {
     private URI uri;
     private URL url;
     private UUID uuid = UUID.fromString("037f4ba2-6d74-4686-a4ea-90cbd86007c3");
+    private ObjectId objectId = new ObjectId("624fbb9213b47a7f7afe1f89");
 
     public AdditionalScalars() {
         try {
@@ -30,5 +33,9 @@ public class AdditionalScalars {
 
     public UUID getUuid() {
         return uuid;
+    }
+
+    public ObjectId getObjectId() {
+        return objectId;
     }
 }

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/scalars/api/AdditionalScalarsApi.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/scalars/api/AdditionalScalarsApi.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.UUID;
 
+import org.bson.types.ObjectId;
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
@@ -27,6 +28,10 @@ public class AdditionalScalarsApi {
 
     public UUID uuidInput(@Source AdditionalScalars additionalScalars, UUID uuid) {
         return uuid;
+    }
+
+    public ObjectId objectIdInput(@Source AdditionalScalars additionalScalars, ObjectId objectId) {
+        return objectId;
     }
 
     public URL urlDefault(@Source AdditionalScalars additionalScalars, @DefaultValue("https://example.com") URL url) {

--- a/server/tck/src/test/resources/tests/scalars/spec/input.graphql
+++ b/server/tck/src/test/resources/tests/scalars/spec/input.graphql
@@ -3,6 +3,7 @@
     url
     uri
     uuid
+    objectId
     urlInput(url:"https://example.com")
     uriInput(uri:"https://example.com")
     uuidInput(uuid:"037f4ba2-6d74-4686-a4ea-90cbd86007c3")

--- a/server/tck/src/test/resources/tests/scalars/spec/output.json
+++ b/server/tck/src/test/resources/tests/scalars/spec/output.json
@@ -4,6 +4,7 @@
       "url": "https://example.com",
       "uri": "https://example.com",
       "uuid": "037f4ba2-6d74-4686-a4ea-90cbd86007c3",
+      "objectId": "624fbb9213b47a7f7afe1f89",
       "urlInput": "https://example.com",
       "uriInput": "https://example.com",
       "uuidInput": "037f4ba2-6d74-4686-a4ea-90cbd86007c3",


### PR DESCRIPTION
Fix #1343
Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>