### PR TITLE
Fix gradle plugin publish configuration

### DIFF
--- a/tools/gradle-plugin/build.gradle
+++ b/tools/gradle-plugin/build.gradle
@@ -1,7 +1,10 @@
 plugins {
-    id 'com.gradle.plugin-publish' version '0.12.0'
+    id 'com.gradle.plugin-publish' version '0.18.0'
     id 'java-gradle-plugin'
 }
+
+group "io.smallrye"
+
 if (JavaVersion.current().isJava9Compatible()) {
     compileJava.options.compilerArgs.addAll(['--release', '8'])
 }
@@ -49,9 +52,13 @@ javadoc {
 }
 
 pluginBundle {
+    group = 'io.smallrye.graphql'
     website = 'http://github.com/smallrye/smallrye-graphql/'
     vcsUrl = 'https://github.com/smallrye/smallrye-graphql'
     tags = ['smallrye', 'graphql', 'microprofile']
+    mavenCoordinates {
+        groupId = project.group
+    }
 }
 
 gradlePlugin {

--- a/tools/gradle-plugin/gradle.properties
+++ b/tools/gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.4.0-SNAPSHOT
+version = 1.4.4

--- a/tools/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/tools/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tools/gradle-plugin/settings.gradle
+++ b/tools/gradle-plugin/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.gradle.enterprise" version "3.1"
+    id "com.gradle.enterprise" version "3.9"
 }
 
 gradleEnterprise {


### PR DESCRIPTION
## Description
As the gradle plugin is not published in the gradle plugin portal, this fixes the gradle properties necessary to this publication to happen.
 - Bumped the gradle and some plugin versions
 - Set the correct groupId for publishing

## Testing
`gradle publishPlugins` inside the plugin folder. (Needs gradle account for this to happen)
 
