### PR TITLE
fix #299: custom GraphQL error `extension` fields

### DIFF
--- a/docs/custom-error-extensions.md
+++ b/docs/custom-error-extensions.md
@@ -1,0 +1,41 @@
+# GraphQL Error Extensions
+
+Exceptions are reported in GraphQL in the `errors` array, next to the `data` field, so it's possible to return partial results, e.g.:
+
+``` json
+{
+  "data": {
+    "superHero": {
+      "name": "Wolverine",
+      "location": null
+    }
+  },
+  "errors": [{
+    "message":"location unknown",
+    "path": ["superHero","location"],
+    "extensions":{"code":"location-unknown"}
+  }]
+}
+```
+
+The `location` field couldn't be returned, and in the `errors`, there's the reason with a few predefined fields,
+and a map of `extensions` that can contain custom details about the error.
+
+You can add your own extensions by implementing the `io.smallrye.graphql.api.ErrorExtensionProvider` interface and
+adding your class name to a file `META-INF/services/io.smallrye.graphql.api.ErrorExtensionProvider` (this is a `ServiceLoader`).
+
+As an example, this class provides an extension named `exception-length` with the length of the simple class name of the exception:
+
+```java
+public class ExceptionLengthErrorExtensionProvider implements ErrorExtensionProvider {
+    @Override
+    public String getKey() {
+        return "exception-length";
+    }
+
+    @Override
+    public JsonNumber mapValueFrom(Throwable exception) {
+        return Json.createValue(exception.getClass().getSimpleName().length());
+    }
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - Server side features:
       - Customizing JSON deserializers: 'custom-json-deserializers.md'
       - Directives: 'directives.md'
+      - Custom error extensions: 'custom-error-extensions.md'
 #  - Power annotations: # Power annotations are unused right now
 #      - Power annotations: 'power-annotations.md'
   - Typesafe client:

--- a/server/api/src/main/java/io/smallrye/graphql/api/ErrorExtensionProvider.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/ErrorExtensionProvider.java
@@ -1,0 +1,13 @@
+package io.smallrye.graphql.api;
+
+import jakarta.json.JsonValue;
+
+/**
+ * To add you own GraphQL error <code>extension</code> fields, you can add your own implementations
+ * of this class via the {@link java.util.ServiceLoader ServiceLoader} mechanism.
+ */
+public interface ErrorExtensionProvider {
+    String getKey();
+
+    JsonValue mapValueFrom(Throwable exception);
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponse.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponse.java
@@ -59,9 +59,7 @@ public class ExecutionResponse {
         // Extensions
         returnObjectBuilder = addExtensionsToResponse(returnObjectBuilder, executionResult);
 
-        JsonObject jsonResponse = returnObjectBuilder.build();
-
-        return jsonResponse;
+        return returnObjectBuilder.build();
     }
 
     public String getExecutionResultAsString() {
@@ -75,10 +73,8 @@ public class ExecutionResponse {
             if (!jsonArray.isEmpty()) {
                 returnObjectBuilder = returnObjectBuilder.add(ERRORS, jsonArray);
             }
-            return returnObjectBuilder;
-        } else {
-            return returnObjectBuilder;
         }
+        return returnObjectBuilder;
     }
 
     private JsonObjectBuilder addDataToResponse(JsonObjectBuilder returnObjectBuilder, ExecutionResult executionResult) {
@@ -123,7 +119,7 @@ public class ExecutionResponse {
      * GraphQL returns a limited set of values ({@code Collection}, {@code Map}, {@code Number}, {@code Boolean}, {@code Enum}),
      * so the json value is build by hand.
      * Additionally, {@code JsonB} is used as a fallback if an different type is encountered.
-     * 
+     *
      * @param pojo a java object, limited to {@code Collection}, {@code Map}, {@code Number}, {@code Boolean} and {@code Enum}
      * @return the json value
      */

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ErrorCodeExtensionProvider.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ErrorCodeExtensionProvider.java
@@ -1,0 +1,36 @@
+package io.smallrye.graphql.execution.error;
+
+import static java.util.Locale.ROOT;
+
+import jakarta.json.Json;
+import jakarta.json.JsonValue;
+
+import io.smallrye.graphql.api.ErrorExtensionProvider;
+import io.smallrye.graphql.schema.model.ErrorInfo;
+import io.smallrye.graphql.spi.config.Config;
+
+public class ErrorCodeExtensionProvider implements ErrorExtensionProvider {
+    @Override
+    public String getKey() {
+        return Config.ERROR_EXTENSION_CODE;
+    }
+
+    @Override
+    public JsonValue mapValueFrom(Throwable exception) {
+        return Json.createValue(errorCode(exception));
+    }
+
+    private String errorCode(Throwable exception) {
+        ErrorInfo errorInfo = ErrorInfoMap.getErrorInfo(exception.getClass().getName());
+        if (errorInfo == null) {
+            return camelToKebab(exception.getClass().getSimpleName().replaceAll("Exception$", ""));
+        } else {
+            return errorInfo.getErrorCode();
+        }
+    }
+
+    private static String camelToKebab(String input) {
+        return String.join("-", input.split("(?=\\p{javaUpperCase})"))
+                .toLowerCase(ROOT);
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ErrorInfoMap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ErrorInfoMap.java
@@ -7,7 +7,7 @@ import io.smallrye.graphql.schema.model.ErrorInfo;
 
 /**
  * Here we create a mapping of all error info that we know about
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class ErrorInfoMap {
@@ -21,10 +21,6 @@ public class ErrorInfoMap {
         if (map != null && !map.isEmpty()) {
             errorInfoMap.putAll(map);
         }
-    }
-
-    public static boolean hasErrorInfo(String className) {
-        return errorInfoMap.containsKey(className);
     }
 
     public static ErrorInfo getErrorInfo(String className) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExceptionNameErrorExtensionProvider.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExceptionNameErrorExtensionProvider.java
@@ -1,0 +1,19 @@
+package io.smallrye.graphql.execution.error;
+
+import jakarta.json.Json;
+import jakarta.json.JsonString;
+
+import io.smallrye.graphql.api.ErrorExtensionProvider;
+import io.smallrye.graphql.spi.config.Config;
+
+public class ExceptionNameErrorExtensionProvider implements ErrorExtensionProvider {
+    @Override
+    public String getKey() {
+        return Config.ERROR_EXTENSION_EXCEPTION;
+    }
+
+    @Override
+    public JsonString mapValueFrom(Throwable exception) {
+        return Json.createValue(exception.getClass().getName());
+    }
+}

--- a/server/implementation/src/main/resources/META-INF/services/io.smallrye.graphql.api.ErrorExtensionProvider
+++ b/server/implementation/src/main/resources/META-INF/services/io.smallrye.graphql.api.ErrorExtensionProvider
@@ -1,0 +1,2 @@
+io.smallrye.graphql.execution.error.ErrorCodeExtensionProvider
+io.smallrye.graphql.execution.error.ExceptionNameErrorExtensionProvider

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/MutinyTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/MutinyTest.java
@@ -11,6 +11,8 @@ import jakarta.json.JsonValue;
 import org.jboss.jandex.IndexView;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.graphql.test.mutiny.CustomException;
+
 public class MutinyTest extends ExecutionTestBase {
 
     protected IndexView getIndex() {
@@ -37,10 +39,11 @@ public class MutinyTest extends ExecutionTestBase {
 
         assertNotNull(errors);
         assertEquals(errors.size(), 1);
-
-        String code = errors.get(0).asJsonObject().getJsonObject("extensions").getString("code");
-
-        assertEquals(code, "custom-error", "expected error code: custom-error");
+        var extensions = errors.get(0).asJsonObject().getJsonObject("extensions");
+        assertEquals("custom-error", extensions.getString("code"), "error code");
+        assertEquals(CustomException.class.getName(), extensions.getString("exception"), "exception");
+        assertEquals("DataFetchingException", extensions.getString("classification"), "classification");
+        assertEquals(CustomException.class.getSimpleName().length(), extensions.getInt("test-extension"), "test extension");
     }
 
     private static final String TEST_QUERY = "{\n" +

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/TestConfig.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/TestConfig.java
@@ -10,7 +10,7 @@ import io.smallrye.graphql.spi.config.LogPayloadOption;
 
 /**
  * Implements the config for testing
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class TestConfig implements Config {
@@ -32,9 +32,9 @@ public class TestConfig implements Config {
 
     @Override
     public Optional<List<String>> getErrorExtensionFields() {
-        return Optional
-                .of(Arrays.asList(new String[] { "exception", "classification", "code", "description",
-                        "validationErrorType", "queryPath" }));
+        return Optional.of(Arrays.asList(
+                "exception", "classification", "code", "description",
+                "validationErrorType", "queryPath", "test-extension"));
     }
 
     @Override
@@ -45,6 +45,7 @@ public class TestConfig implements Config {
     @Override
     public <T> T getConfigValue(String key, Class<T> type, T defaultValue) {
         if (key.equals(TestEventingService.KEY)) {
+            //noinspection unchecked
             return (T) Boolean.TRUE;
         }
         return defaultValue;

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/TestErrorExtensionProvider.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/TestErrorExtensionProvider.java
@@ -1,0 +1,18 @@
+package io.smallrye.graphql.execution;
+
+import jakarta.json.Json;
+import jakarta.json.JsonNumber;
+
+import io.smallrye.graphql.api.ErrorExtensionProvider;
+
+public class TestErrorExtensionProvider implements ErrorExtensionProvider {
+    @Override
+    public String getKey() {
+        return "test-extension";
+    }
+
+    @Override
+    public JsonNumber mapValueFrom(Throwable exception) {
+        return Json.createValue(exception.getClass().getSimpleName().length());
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/mutiny/MutinyBookGraphQLApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/mutiny/MutinyBookGraphQLApi.java
@@ -21,11 +21,12 @@ public class MutinyBookGraphQLApi {
     }
 
     @Query("failedBook")
-    public Uni<Book> failedBook(String name) {
+    public Uni<Book> failedBook(@SuppressWarnings("unused") String name) {
         return Uni.createFrom().failure(new CustomException());
     }
 
-    private static Map<String, Book> BOOKS = new HashMap<>();
+    private static final Map<String, Book> BOOKS = new HashMap<>();
+
     static {
         Book book1 = new Book("0-571-05686-5", "Lord of the Flies", LocalDate.of(1954, Month.SEPTEMBER, 17), "William Golding");
         BOOKS.put(book1.title, book1);

--- a/server/implementation/src/test/resources/META-INF/services/io.smallrye.graphql.api.ErrorExtensionProvider
+++ b/server/implementation/src/test/resources/META-INF/services/io.smallrye.graphql.api.ErrorExtensionProvider
@@ -1,0 +1,1 @@
+io.smallrye.graphql.execution.TestErrorExtensionProvider


### PR DESCRIPTION
Add `ErrorExtensionProvider` via `ServiceLoader` and use it for `code` and `exception` (class name)