### PR TITLE
Don't store ValidationFactory in a static field

### DIFF
--- a/docs/server_configuration.md
+++ b/docs/server_configuration.md
@@ -27,7 +27,7 @@ From SmallRye GraphQL
 | `smallrye.graphql.allowGet` | `false`  | Allow HTTP GET Method |
 | `smallrye.graphql.metrics.enabled` | `false` | Enable metrics |
 | `smallrye.graphql.tracing.enabled` | `false` | Enable tracing |
-| `smallrye.graphql.validation.enabled` | `false` | Enable Bean Validation |
+| `smallrye.graphql.validation.enabled` | `true` if Bean Validation is present | Enable Bean Validation. This property is DEPRECATED, setting to `false` won't actually turn off validation. It will be removed in a future release. |
 | `smallrye.graphql.events.enabled`| `true` if one of metrics, tracing or bean validation is true | Enable eventing |
 | `smallrye.graphql.logPayload`| `false` | Log the payload in the log file |
 | `smallrye.graphql.fieldVisibility` |   | To control the field visibility on introspection |

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/validation/ValidationService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/validation/ValidationService.java
@@ -16,7 +16,7 @@ import io.smallrye.graphql.spi.LookupService;
  * Validate input before execution
  */
 public class ValidationService implements EventingService {
-    private static ValidatorFactory VALIDATOR_FACTORY = null;
+    private ValidatorFactory VALIDATOR_FACTORY = null;
     private final LookupService lookupService;
 
     public ValidationService() {


### PR DESCRIPTION
Quick and kinda incomplete fix for  https://github.com/quarkusio/quarkus/issues/26233
Later we want to remove the `ValidationService` and let the Hibernate  Validator interceptor do the work