### PR TITLE
#400: Add support for GraphQL union type

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
@@ -207,7 +207,7 @@ public class Annotations {
         return new Annotations(annotationMap);
     }
 
-    // 
+    //
 
     /**
      * Used when we are creating operation and arguments for these operations
@@ -580,6 +580,7 @@ public class Annotations {
     public static final DotName INPUT = DotName.createSimple("org.eclipse.microprofile.graphql.Input");
     public static final DotName TYPE = DotName.createSimple("org.eclipse.microprofile.graphql.Type");
     public static final DotName INTERFACE = DotName.createSimple("org.eclipse.microprofile.graphql.Interface");
+    public static final DotName UNION = DotName.createSimple("io.smallrye.graphql.api.Union");
     public static final DotName ENUM = DotName.createSimple("org.eclipse.microprofile.graphql.Enum");
     public static final DotName ID = DotName.createSimple("org.eclipse.microprofile.graphql.Id");
     public static final DotName DESCRIPTION = DotName.createSimple("org.eclipse.microprofile.graphql.Description");

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
@@ -2,6 +2,7 @@ package io.smallrye.graphql.schema;
 
 import static io.smallrye.graphql.schema.Annotations.DIRECTIVE;
 
+import io.smallrye.graphql.schema.creator.type.UnionCreator;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -64,6 +65,7 @@ public class SchemaBuilder {
     private final ReferenceCreator referenceCreator;
     private final OperationCreator operationCreator;
     private final DirectiveTypeCreator directiveTypeCreator;
+    private final UnionCreator unionCreator;
 
     /**
      * This builds the Schema from Jandex
@@ -98,6 +100,7 @@ public class SchemaBuilder {
         typeCreator = new TypeCreator(referenceCreator, fieldCreator, operationCreator);
         interfaceCreator = new InterfaceCreator(referenceCreator, fieldCreator, operationCreator);
         directiveTypeCreator = new DirectiveTypeCreator(referenceCreator);
+        unionCreator = new UnionCreator(referenceCreator);
     }
 
     private Schema generateSchema() {
@@ -130,7 +133,7 @@ public class SchemaBuilder {
         // Add all custom datafetchers
         addDataFetchers(schema);
 
-        // Reset the maps. 
+        // Reset the maps.
         referenceCreator.clear();
 
         return schema;
@@ -162,6 +165,9 @@ public class SchemaBuilder {
         // Add the interface types
         createAndAddToSchema(ReferenceType.INTERFACE, interfaceCreator, schema::addInterface);
 
+        // Add the union types
+        createAndAddToSchema(ReferenceType.UNION, unionCreator, schema::addUnion);
+
         // Add the enum types
         createAndAddToSchema(ReferenceType.ENUM, enumCreator, schema::addEnum);
     }
@@ -182,6 +188,11 @@ public class SchemaBuilder {
         // See if there is any interfaces we missed
         if (findOutstandingAndAddToSchema(ReferenceType.INTERFACE, interfaceCreator, schema::containsInterface,
                 schema::addInterface)) {
+            keepGoing = true;
+        }
+
+        // See if there is any unions we missed
+        if (findOutstandingAndAddToSchema(ReferenceType.UNION, unionCreator, schema::containsUnion, schema::addUnion)) {
             keepGoing = true;
         }
 

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
@@ -2,7 +2,6 @@ package io.smallrye.graphql.schema;
 
 import static io.smallrye.graphql.schema.Annotations.DIRECTIVE;
 
-import io.smallrye.graphql.schema.creator.type.UnionCreator;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -29,6 +28,7 @@ import io.smallrye.graphql.schema.creator.type.EnumCreator;
 import io.smallrye.graphql.schema.creator.type.InputTypeCreator;
 import io.smallrye.graphql.schema.creator.type.InterfaceCreator;
 import io.smallrye.graphql.schema.creator.type.TypeCreator;
+import io.smallrye.graphql.schema.creator.type.UnionCreator;
 import io.smallrye.graphql.schema.helper.BeanValidationDirectivesHelper;
 import io.smallrye.graphql.schema.helper.Directives;
 import io.smallrye.graphql.schema.helper.GroupHelper;

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
@@ -34,9 +34,9 @@ import io.smallrye.graphql.schema.model.Scalars;
 
 /**
  * Here we create references to things that might not yet exist.
- * 
+ *
  * We store all references to be created later.
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class ReferenceCreator {
@@ -46,12 +46,14 @@ public class ReferenceCreator {
     private final Queue<Reference> typeReferenceQueue = new ArrayDeque<>();
     private final Queue<Reference> enumReferenceQueue = new ArrayDeque<>();
     private final Queue<Reference> interfaceReferenceQueue = new ArrayDeque<>();
+    private final Queue<Reference> unionReferenceQueue = new ArrayDeque<>();
 
     // Some maps we populate during scanning
     private final Map<String, Reference> inputReferenceMap = new HashMap<>();
     private final Map<String, Reference> typeReferenceMap = new HashMap<>();
     private final Map<String, Reference> enumReferenceMap = new HashMap<>();
     private final Map<String, Reference> interfaceReferenceMap = new HashMap<>();
+    private final Map<String, Reference> unionReferenceMap = new HashMap<>();
 
     private final TypeAutoNameStrategy autoNameStrategy;
 
@@ -68,16 +70,18 @@ public class ReferenceCreator {
         typeReferenceMap.clear();
         enumReferenceMap.clear();
         interfaceReferenceMap.clear();
+        unionReferenceMap.clear();
 
         inputReferenceQueue.clear();
         typeReferenceQueue.clear();
         enumReferenceQueue.clear();
         interfaceReferenceQueue.clear();
+        unionReferenceQueue.clear();
     }
 
     /**
      * Get the values for a certain type
-     * 
+     *
      * @param referenceType the type
      * @return the references
      */
@@ -87,7 +91,7 @@ public class ReferenceCreator {
 
     /**
      * Get the Type auto name strategy
-     * 
+     *
      * @return the strategy as supplied
      */
     public TypeAutoNameStrategy getTypeAutoNameStrategy() {
@@ -96,7 +100,7 @@ public class ReferenceCreator {
 
     /**
      * Get a reference to a field type for an adapter on a field
-     * 
+     *
      * @param direction the direction
      * @param fieldType the java type
      * @param annotations annotation on this operations method
@@ -111,7 +115,7 @@ public class ReferenceCreator {
     /**
      * Get a reference to a field type for an operation Direction is OUT on a field (and IN on an argument) In the case
      * of operations, there is no fields (only methods)
-     * 
+     *
      * @param fieldType the java type
      * @param annotationsForMethod annotation on this operations method
      * @return a reference to the type
@@ -123,7 +127,7 @@ public class ReferenceCreator {
     /**
      * Get a reference to a argument type for an operation Direction is IN on an argument (and OUT on a field) In the
      * case of operation, there is no field (only methods)
-     * 
+     *
      * @param argumentType the java type
      * @param annotationsForThisArgument annotations on this argument
      * @return a reference to the argument
@@ -145,9 +149,9 @@ public class ReferenceCreator {
 
     /**
      * Get a reference to a field (method response) on an interface
-     * 
+     *
      * Interfaces is only usable on Type, so the direction in OUT.
-     * 
+     *
      * @param methodType the method response type
      * @param annotationsForThisMethod annotations on this method
      * @return a reference to the type
@@ -159,9 +163,9 @@ public class ReferenceCreator {
 
     /**
      * Get a reference to a Field Type for a InputType or Type.
-     * 
+     *
      * We need both the type and the getter/setter method as both is applicable.
-     * 
+     *
      * @param direction in or out
      * @param fieldType the field type
      * @param methodType the method type
@@ -180,7 +184,7 @@ public class ReferenceCreator {
     /**
      * This method create a reference to type that might not yet exist. It also store to be created later, if we do not
      * already know about it.
-     * 
+     *
      * @param direction the direction (in or out)
      * @param classInfo the Java class
      * @param createAdapedToType create the type in the schema
@@ -197,7 +201,7 @@ public class ReferenceCreator {
 
         ReferenceType referenceType = getCorrectReferenceType(classInfo, annotationsForClass, direction);
 
-        if (referenceType.equals(ReferenceType.INTERFACE)) {
+        if (referenceType.equals(ReferenceType.INTERFACE) || referenceType.equals(ReferenceType.UNION)) {
             // Also check that we create all implementations
             Collection<ClassInfo> knownDirectImplementors = ScanningContext.getIndex()
                     .getAllKnownImplementors(classInfo.name());
@@ -229,7 +233,7 @@ public class ReferenceCreator {
 
                 createReference(direction, impl, createAdapedToType, createAdapedWithType,
                         parametrizedTypeArgumentsReferencesImpl,
-                        true);
+                        referenceType.equals(ReferenceType.INTERFACE));
             }
         }
 
@@ -276,8 +280,20 @@ public class ReferenceCreator {
     private static boolean isInterface(ClassInfo classInfo, Annotations annotationsForClass) {
         boolean isJavaInterface = Classes.isInterface(classInfo);
         if (isJavaInterface) {
-            if (annotationsForClass.containsOneOfTheseAnnotations(Annotations.TYPE, Annotations.INPUT)) {
-                // This should be mapped to a type/input and not an interface
+            if (annotationsForClass.containsOneOfTheseAnnotations(Annotations.TYPE, Annotations.INPUT, Annotations.UNION)) {
+                // This should be mapped to a type/input/union and not an interface
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isUnion(ClassInfo classInfo, Annotations annotationsForClass) {
+        boolean isJavaInterface = Classes.isInterface(classInfo);
+        if (isJavaInterface) {
+            if (annotationsForClass.containsOneOfTheseAnnotations(Annotations.TYPE, Annotations.INPUT, Annotations.INTERFACE)) {
+                // This should be mapped to a type/input/interface and not a union
                 return false;
             }
             return true;
@@ -468,6 +484,8 @@ public class ReferenceCreator {
                 return inputReferenceMap;
             case INTERFACE:
                 return interfaceReferenceMap;
+            case UNION:
+                return unionReferenceMap;
             case TYPE:
                 return typeReferenceMap;
             default:
@@ -483,6 +501,8 @@ public class ReferenceCreator {
                 return inputReferenceQueue;
             case INTERFACE:
                 return interfaceReferenceQueue;
+            case UNION:
+                return unionReferenceQueue;
             case TYPE:
                 return typeReferenceQueue;
             default:
@@ -493,6 +513,8 @@ public class ReferenceCreator {
     private static ReferenceType getCorrectReferenceType(ClassInfo classInfo, Annotations annotations, Direction direction) {
         if (isInterface(classInfo, annotations)) {
             return ReferenceType.INTERFACE;
+        } else if (isUnion(classInfo, annotations)) {
+            return ReferenceType.UNION;
         } else if (Classes.isEnum(classInfo)) {
             return ReferenceType.ENUM;
         } else if (direction.equals(Direction.IN)) {

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/UnionCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/UnionCreator.java
@@ -1,0 +1,43 @@
+package io.smallrye.graphql.schema.creator.type;
+
+import io.smallrye.graphql.schema.Annotations;
+import io.smallrye.graphql.schema.creator.ReferenceCreator;
+import io.smallrye.graphql.schema.helper.DescriptionHelper;
+import io.smallrye.graphql.schema.helper.TypeNameHelper;
+import io.smallrye.graphql.schema.model.Reference;
+import io.smallrye.graphql.schema.model.ReferenceType;
+import io.smallrye.graphql.schema.model.UnionType;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.logging.Logger;
+
+import java.util.Optional;
+
+public class UnionCreator implements Creator<UnionType> {
+
+    private static final Logger LOG = Logger.getLogger(UnionCreator.class.getName());
+
+    private final ReferenceCreator referenceCreator;
+
+    public UnionCreator(ReferenceCreator referenceCreator) {
+        this.referenceCreator = referenceCreator;
+    }
+
+    @Override
+    public UnionType create(ClassInfo classInfo, Reference reference) {
+        LOG.debug("Creating union from " + classInfo.name().toString());
+
+        Annotations annotations = Annotations.getAnnotationsForClass(classInfo);
+
+        // Name
+        String name = TypeNameHelper.getAnyTypeName(classInfo,
+                annotations,
+                referenceCreator.getTypeAutoNameStrategy(),
+                ReferenceType.UNION,
+                reference.getClassParametrizedTypes());
+
+        // Description
+        Optional<String> maybeDescription = DescriptionHelper.getDescriptionForType(annotations);
+
+        return new UnionType(classInfo.name().toString(), name, maybeDescription.orElse(null));
+    }
+}

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/UnionCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/UnionCreator.java
@@ -1,5 +1,10 @@
 package io.smallrye.graphql.schema.creator.type;
 
+import java.util.Optional;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.logging.Logger;
+
 import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.creator.ReferenceCreator;
 import io.smallrye.graphql.schema.helper.DescriptionHelper;
@@ -7,10 +12,6 @@ import io.smallrye.graphql.schema.helper.TypeNameHelper;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.UnionType;
-import org.jboss.jandex.ClassInfo;
-import org.jboss.logging.Logger;
-
-import java.util.Optional;
 
 public class UnionCreator implements Creator<UnionType> {
 

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/ReferenceType.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/ReferenceType.java
@@ -2,9 +2,9 @@ package io.smallrye.graphql.schema.model;
 
 /**
  * Type of reference
- * 
+ *
  * Because we refer to types before they might exist, we need an indication of the type
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public enum ReferenceType {
@@ -12,5 +12,6 @@ public enum ReferenceType {
     TYPE,
     ENUM,
     INTERFACE,
+    UNION,
     SCALAR
 }

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Schema.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Schema.java
@@ -29,6 +29,7 @@ public final class Schema implements Serializable {
     private Map<String, InputType> inputs = new HashMap<>();
     private Map<String, Type> types = new HashMap<>();
     private Map<String, Type> interfaces = new HashMap<>();
+    private Map<String, UnionType> unions = new HashMap<>();
     private Map<String, EnumType> enums = new HashMap<>();
 
     private Map<String, ErrorInfo> errors = new HashMap<>();
@@ -199,6 +200,26 @@ public final class Schema implements Serializable {
 
     public boolean hasInterfaces() {
         return !this.interfaces.isEmpty();
+    }
+
+    public Map<String, UnionType> getUnions() {
+        return unions;
+    }
+
+    public void setUnions(Map<String, UnionType> unions) {
+        this.unions = unions;
+    }
+
+    public void addUnion(UnionType unionType) {
+        this.unions.put(unionType.getName(), unionType);
+    }
+
+    public boolean containsUnion(String name) {
+        return this.unions.containsKey(name);
+    }
+
+    public boolean hasUnions() {
+        return !this.unions.isEmpty();
     }
 
     public Map<String, EnumType> getEnums() {

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Type.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Type.java
@@ -7,19 +7,19 @@ import java.util.Set;
 
 /**
  * Represent a GraphQL Type.
- * 
+ *
  * A Type is one of the options for a response, it's a complex type that contains
  * fields that itself is of a certain type.
- * 
+ *
  * It's a Java Bean that we only care about the getter methods and properties.
- * 
+ *
  * A Type is a java bean with fields, but can optionally also have operations (queries)
  * that is done with the Source annotation.
- * 
+ *
  * A Type can also optionally implements interfaces.
- * 
+ *
  * @see <a href="https://spec.graphql.org/draft/#sec-Object">Object</a>
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public final class Type extends Reference {
@@ -33,6 +33,7 @@ public final class Type extends Reference {
     private Map<String, Operation> batchOperations = new LinkedHashMap<>();
 
     private Set<Reference> interfaces = new LinkedHashSet<>();
+    private Set<Reference> unionMemberships = new LinkedHashSet<>();
 
     public Type() {
     }
@@ -131,13 +132,37 @@ public final class Type extends Reference {
     }
 
     public void setIsInterface(boolean isInterface) {
-        isInterface = isInterface;
+        this.isInterface = isInterface;
+    }
+
+    public Set<Reference> getUnionMemberships() {
+        return unionMemberships;
+    }
+
+    public void addUnion(Reference unionType) {
+        this.unionMemberships.add(unionType);
+    }
+
+    public boolean hasUnionMemberships() {
+        return !this.unionMemberships.isEmpty();
+    }
+
+    public boolean isMemberOfUnion(Reference unionType) {
+        for (Reference u : unionMemberships) {
+            if (u.getName().equals(unionType.getName())
+                    && u.getClassName().equals(unionType.getClassName())
+                    && u.getGraphQLClassName().equals(unionType.getGraphQLClassName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
     public String toString() {
         return "Type{" + "description=" + description + ", isInterface=" + isInterface + ", fields=" + fields + ", operations="
-                + operations + ", batchOperations=" + batchOperations + ", interfaces=" + interfaces + '}';
+                + operations + ", batchOperations=" + batchOperations + ", interfaces=" + interfaces + ", unionMemberships="
+                + unionMemberships + '}';
     }
 
 }

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/UnionType.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/UnionType.java
@@ -2,23 +2,23 @@ package io.smallrye.graphql.schema.model;
 
 public final class UnionType extends Reference {
 
-  private String description;
+    private String description;
 
-  public UnionType(String className, String name, String description) {
-    super(className, name, ReferenceType.UNION);
-    this.description = description;
-  }
+    public UnionType(String className, String name, String description) {
+        super(className, name, ReferenceType.UNION);
+        this.description = description;
+    }
 
-  public String getDescription() {
-    return description;
-  }
+    public String getDescription() {
+        return description;
+    }
 
-  public void setDescription(String description) {
-    this.description = description;
-  }
+    public void setDescription(String description) {
+        this.description = description;
+    }
 
-  @Override
-  public String toString() {
-    return "UnionType{" + "description=" + description + '}';
-  }
+    @Override
+    public String toString() {
+        return "UnionType{" + "description=" + description + '}';
+    }
 }

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/UnionType.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/UnionType.java
@@ -1,0 +1,24 @@
+package io.smallrye.graphql.schema.model;
+
+public final class UnionType extends Reference {
+
+  private String description;
+
+  public UnionType(String className, String name, String description) {
+    super(className, name, ReferenceType.UNION);
+    this.description = description;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  @Override
+  public String toString() {
+    return "UnionType{" + "description=" + description + '}';
+  }
+}

--- a/server/api/src/main/java/io/smallrye/graphql/api/Union.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/Union.java
@@ -1,0 +1,17 @@
+package io.smallrye.graphql.api;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import io.smallrye.common.annotation.Experimental;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(TYPE)
+@Experimental("Allow you to mark an interface as a GraphQL Union. Not covered by the specification. " +
+    "Subject to change.")
+public @interface Union {
+
+  String value() default "";
+}

--- a/server/api/src/main/java/io/smallrye/graphql/api/Union.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/Union.java
@@ -3,15 +3,16 @@ package io.smallrye.graphql.api;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import io.smallrye.common.annotation.Experimental;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import io.smallrye.common.annotation.Experimental;
 
 @Retention(RUNTIME)
 @Target(TYPE)
 @Experimental("Allow you to mark an interface as a GraphQL Union. Not covered by the specification. " +
-    "Subject to change.")
+        "Subject to change.")
 public @interface Union {
 
-  String value() default "";
+    String value() default "";
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -421,8 +421,8 @@ public class Bootstrap {
 
     private void createGraphQLUnionType(UnionType unionType) {
         GraphQLUnionType.Builder unionTypeBuilder = GraphQLUnionType.newUnionType()
-            .name(unionType.getName())
-            .description(unionType.getDescription());
+                .name(unionType.getName())
+                .description(unionType.getDescription());
 
         // Members
         for (Type type : schema.getTypes().values()) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/resolver/UnionOutputRegistry.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/resolver/UnionOutputRegistry.java
@@ -1,0 +1,46 @@
+package io.smallrye.graphql.execution.resolver;
+
+import graphql.schema.GraphQLObjectType;
+import io.smallrye.graphql.schema.model.Reference;
+import io.smallrye.graphql.schema.model.Type;
+import io.smallrye.graphql.schema.model.UnionType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class UnionOutputRegistry {
+
+    private static final Map<String, Map<String, GraphQLObjectType>> unionMap = new HashMap<>();
+
+    private UnionOutputRegistry() {
+    }
+
+    public static void register(Type type, GraphQLObjectType graphQLObjectType) {
+        if (type.hasUnionMemberships()) {
+            Set<Reference> memberships = type.getUnionMemberships();
+            for (Reference i : memberships) {
+                String union = i.getName();
+                Map<String, GraphQLObjectType> concreteMap = getConcreteMap(union);
+                concreteMap.put(type.getClassName(), graphQLObjectType);
+                unionMap.put(union, concreteMap);
+            }
+        }
+    }
+
+    public static GraphQLObjectType getGraphQLObjectType(UnionType unionType, String concreteName) {
+        String union = unionType.getName();
+        if (unionMap.containsKey(union)) {
+            return unionMap.get(union).get(concreteName);
+        }
+        return null;
+    }
+
+    private static Map<String, GraphQLObjectType> getConcreteMap(String union) {
+        if (unionMap.containsKey(union)) {
+            return unionMap.get(union);
+        } else {
+            return new HashMap<>();
+        }
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/resolver/UnionOutputRegistry.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/resolver/UnionOutputRegistry.java
@@ -1,13 +1,13 @@
 package io.smallrye.graphql.execution.resolver;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 import graphql.schema.GraphQLObjectType;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.Type;
 import io.smallrye.graphql.schema.model.UnionType;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 
 public class UnionOutputRegistry {
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/resolver/UnionResolver.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/resolver/UnionResolver.java
@@ -1,0 +1,29 @@
+package io.smallrye.graphql.execution.resolver;
+
+import static io.smallrye.graphql.SmallRyeGraphQLServerMessages.msg;
+
+import graphql.TypeResolutionEnvironment;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.TypeResolver;
+import io.smallrye.graphql.schema.model.UnionType;
+
+public class UnionResolver implements TypeResolver {
+
+    private final UnionType unionType;
+
+    public UnionResolver(UnionType unionType) {
+        this.unionType = unionType;
+    }
+
+    @Override
+    public GraphQLObjectType getType(TypeResolutionEnvironment tre) {
+        String concreteClassName = tre.getObject().getClass().getName();
+
+        GraphQLObjectType graphQLObjectType = UnionOutputRegistry.getGraphQLObjectType(unionType, concreteClassName);
+        if (graphQLObjectType != null) {
+            return graphQLObjectType;
+        } else {
+            throw msg.concreteClassNotFoundForInterface(concreteClassName, unionType.getName());
+        }
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionUnionsTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionUnionsTest.java
@@ -1,0 +1,90 @@
+package io.smallrye.graphql.execution;
+
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test against unions
+ *
+ * @author Craig Day (cday@zendesk.com)
+ */
+public class ExecutionUnionsTest extends ExecutionTestBase {
+
+    @Test
+    public void testBasicUnion() {
+        JsonObject data = executeAndGetData(TEST_BASIC_UNION);
+        JsonObject testObject = data.getJsonObject("basicUnion");
+
+        assertNotNull(testObject);
+
+        assertFalse(testObject.isNull("name"), "name should not be null");
+        assertEquals("my name", testObject.getString("name"));
+    }
+
+    @Test
+    public void testUnionOfInterfacesReturningDirectImplementer() {
+        JsonObject data = executeAndGetData(TEST_NESTED_INTERFACE_DIRECT_IMPL);
+        JsonObject testObject = data.getJsonObject("unionOfInterfacesDirectImplementor");
+
+        assertNotNull(testObject);
+
+        assertFalse(testObject.isNull("message"), "message should not be null");
+        assertEquals("im in many unions", testObject.getString("message"));
+    }
+
+    @Test
+    public void testUnionOfInterfacesReturningNestedInterfaceImpl1() {
+        JsonObject data = executeAndGetData(TEST_NESTED_INTERFACE_1);
+        JsonObject testObject = data.getJsonObject("unionOfInterfacesNestedInterface1");
+
+        assertNotNull(testObject);
+
+        assertFalse(testObject.isNull("name"), "name should not be null");
+        assertEquals("my name", testObject.getString("name"));
+    }
+
+    @Test
+    public void testUnionOfInterfacesReturningNestedInterfaceImpl2() {
+        JsonObject data = executeAndGetData(TEST_NESTED_INTERFACE_2);
+        JsonObject testObject = data.getJsonObject("unionOfInterfacesNestedInterface2");
+
+        assertNotNull(testObject);
+
+        assertFalse(testObject.isNull("color"), "color should not be null");
+        assertEquals("purple", testObject.getString("color"));
+    }
+
+    private static final String TEST_BASIC_UNION = "{\n" +
+            "  basicUnion {\n" +
+            "    ... on UnionMember {\n" +
+            "      name\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+    private static final String TEST_NESTED_INTERFACE_DIRECT_IMPL = "{\n" +
+            "  unionOfInterfacesDirectImplementor {\n" +
+            "    ... on MemberOfManyUnions {\n" +
+            "      message\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+    private static final String TEST_NESTED_INTERFACE_1 = "{\n" +
+            "  unionOfInterfacesNestedInterface1 {\n" +
+            "    ... on ObjectWithName {\n" +
+            "      name\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+    private static final String TEST_NESTED_INTERFACE_2 = "{\n" +
+            "  unionOfInterfacesNestedInterface2 {\n" +
+            "    ... on ObjectWithColor {\n" +
+            "      color\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionUnionsTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionUnionsTest.java
@@ -1,9 +1,10 @@
 package io.smallrye.graphql.execution;
 
-import jakarta.json.JsonObject;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Test against unions

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/MemberOfManyUnions.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/MemberOfManyUnions.java
@@ -1,0 +1,21 @@
+package io.smallrye.graphql.test;
+
+public class MemberOfManyUnions implements TestUnion, UnionOfInterfaces {
+
+    private String message;
+
+    public MemberOfManyUnions() {
+    }
+
+    public MemberOfManyUnions(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/ObjectWithColor.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/ObjectWithColor.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.test;
+
+public class ObjectWithColor implements UnionInterfaceTwo {
+
+    private String color;
+
+    public ObjectWithColor() {
+    }
+
+    public ObjectWithColor(String color) {
+        this.color = color;
+    }
+
+    @Override
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/ObjectWithName.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/ObjectWithName.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.test;
+
+public class ObjectWithName implements UnionInterfaceOne {
+
+    private String name;
+
+    public ObjectWithName() {
+    }
+
+    public ObjectWithName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/TestEndpoint.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/TestEndpoint.java
@@ -16,7 +16,7 @@ import io.smallrye.graphql.execution.context.SmallRyeContextManager;
 
 /**
  * Basic test endpoint
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 @GraphQLApi
@@ -55,6 +55,26 @@ public class TestEndpoint {
     @Query
     public InterfaceWithOneGenericsParam<Integer> getGeneric2() {
         return new ClassWithOneGenericsParam<>(22, "my name");
+    }
+
+    @Query
+    public TestUnion basicUnion() {
+        return new UnionMember("my name");
+    }
+
+    @Query
+    public UnionOfInterfaces unionOfInterfacesDirectImplementor() {
+        return new MemberOfManyUnions("im in many unions");
+    }
+
+    @Query
+    public UnionOfInterfaces unionOfInterfacesNestedInterface1() {
+        return new ObjectWithName("my name");
+    }
+
+    @Query
+    public UnionOfInterfaces unionOfInterfacesNestedInterface2() {
+        return new ObjectWithColor("purple");
     }
 
     // This method will be ignored, with a WARN in the log, due to below duplicate

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/TestUnion.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/TestUnion.java
@@ -1,0 +1,8 @@
+package io.smallrye.graphql.test;
+
+import io.smallrye.graphql.api.Union;
+
+@Union
+public interface TestUnion {
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/UnionInterfaceOne.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/UnionInterfaceOne.java
@@ -1,0 +1,9 @@
+package io.smallrye.graphql.test;
+
+import org.eclipse.microprofile.graphql.Interface;
+
+@Interface
+public interface UnionInterfaceOne extends UnionOfInterfaces {
+
+    String getName();
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/UnionInterfaceTwo.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/UnionInterfaceTwo.java
@@ -1,0 +1,9 @@
+package io.smallrye.graphql.test;
+
+import org.eclipse.microprofile.graphql.Interface;
+
+@Interface
+public interface UnionInterfaceTwo extends UnionOfInterfaces {
+
+    String getColor();
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/UnionMember.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/UnionMember.java
@@ -2,13 +2,13 @@ package io.smallrye.graphql.test;
 
 public class UnionMember implements TestUnion {
 
-  String name;
+    String name;
 
-  public UnionMember(String name) {
-    this.name = name;
-  }
+    public UnionMember(String name) {
+        this.name = name;
+    }
 
-  public String getName() {
-    return name;
-  }
+    public String getName() {
+        return name;
+    }
 }

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/UnionMember.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/UnionMember.java
@@ -1,0 +1,14 @@
+package io.smallrye.graphql.test;
+
+public class UnionMember implements TestUnion {
+
+  String name;
+
+  public UnionMember(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/UnionOfInterfaces.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/UnionOfInterfaces.java
@@ -1,0 +1,7 @@
+package io.smallrye.graphql.test;
+
+import io.smallrye.graphql.api.Union;
+
+@Union
+public interface UnionOfInterfaces {
+}


### PR DESCRIPTION
I eagerly started with [defining the spec](https://github.com/eclipse/microprofile-graphql/pull/459), but also wanted to get an implementation done. 

This adds support for creating GraphQL union types using an annotation `@Union` on a Java interface. I chose an empty Java interface so there would be an explicit layer of abstraction to represent the union itself. 

Example: 

```java
@Union 
interface MyUnion {
}

class Foo implements MyUnion {
  String getName();
}

class Bar implements MyUnion {
  int getCount();
}
```
would create
```graphql
type Foo {
  name: String
}

type Bar {
  count: Int
}

union MyUnion = Foo | Bar
```

An alternative could have been to directly annotate a type with the name of the union(s) it should be a member of, then generate the union from there.

<details>
  <summary>Expand for alternative Java example</summary>
  
```java
  @Union("MyUnion")
  class Foo {
    String getName();
  }
  
  @Union("MyUnion")
  class Bar {
    int getCount();
  }
  ```
</details>

Event thought this is a little less code, I didn't like it because the `@Union` annotation no longer describes an object directly, rather a relationship between objects. This relationship now only exists in the world of strings, and has no concrete representation in code.

For lots more thoughts, see the PR description here: https://github.com/eclipse/microprofile-graphql/pull/459

Resolves #400 