### PR TITLE
default constructor for UnionType

### DIFF
--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/UnionType.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/UnionType.java
@@ -4,6 +4,9 @@ public final class UnionType extends Reference {
 
     private String description;
 
+    public UnionType() {
+    }
+
     public UnionType(String className, String name, String description) {
         super(className, name, ReferenceType.UNION);
         this.description = description;


### PR DESCRIPTION
When trying to pull the union type changes into quarkus, I ran into a build error

```
java.lang.RuntimeException: java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
	[error]: Build step io.quarkus.deployment.steps.MainClassBuildStep#build threw an exception: java.lang.RuntimeException: Unable to serialize objects of type class io.smallrye.graphql.schema.model.UnionType to bytecode as it has no default constructor
```

@phillip-kruger do you know if there is anything I could have done in this repo to prevent that from happening? Was a test missed somewhere? 