### PR TITLE
Remove reference to deprecated BeanManager#fireEvent()

### DIFF
--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/event/EventsService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/event/EventsService.java
@@ -18,7 +18,7 @@ import io.smallrye.graphql.spi.EventingService;
 /**
  * Implements the EventingService interface and use CDI Events
  * This allows users to take part in the events.
- * 
+ *
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 @Priority(Priorities.FIRST_IN_LAST_OUT + 200)
@@ -88,7 +88,7 @@ public class EventsService implements EventingService {
             if (current != null) {
                 BeanManager beanManager = current.getBeanManager();
                 if (beanManager != null) {
-                    beanManager.fireEvent(o, annotation);
+                    beanManager.getEvent().select(annotation).fire(o);
                 }
             }
         } catch (java.lang.IllegalStateException ise) {


### PR DESCRIPTION
This method is gone in CDI 4.0.

I would appreciate if this could go into the next SmallRye GraphQL release (and the Jakarta port) as it makes some tests fail since the migration to CDI 4.0 in the Jakarta branch.