### PR TITLE
Remove wildfly feature pack tests from 1.8.x branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,50 +40,6 @@ jobs:
       - name: build with maven
         run: mvn -B formatter:validate impsort:check javadoc:javadoc install --file pom.xml
 
-  wildfly-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [11]
-    name: WildFly GraphQL feature pack tests
-
-    steps:
-      - uses: actions/checkout@v2
-        name: checkout
-
-      - name: checkout WildFly feature pack repository
-        uses: actions/checkout@v2
-        with:
-          repository: wildfly-extras/wildfly-graphql-feature-pack
-          ref: main
-          path: wildfly-graphql-feature-pack
-
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - uses: actions/setup-java@v3.0.0
-        name: set up jdk ${{matrix.java}}
-        with:
-          java-version: ${{matrix.java}}
-          distribution: 'temurin'
-
-      - name: build with maven
-        run: mvn -B install -DskipTests --file pom.xml
-
-      - name: Install xmllint
-        run: sudo apt-get update && sudo apt-get install libxml2-utils
-
-      - name: run WildFly feature pack tests
-        run: |
-          SMALLRYE_VERSION=$(xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' pom.xml) && \
-          echo "SMALLRYE_VERSION=$SMALLRYE_VERSION" && \
-          mvn install -Dversion.io.smallrye.graphql=$SMALLRYE_VERSION --file wildfly-graphql-feature-pack/pom.xml
-
   quarkus-tests:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
We don't intend to ever support SmallRye GraphQL 1.8.x by the feature pack - it will jump from 1.7 straight to 2.0, so no reason to run the tests that would fail anyway