### PR TITLE
Support directives on operations and operation arguments

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
@@ -60,6 +60,7 @@ public class SchemaBuilder {
     private final InputTypeCreator inputTypeCreator;
     private final TypeCreator typeCreator;
     private final FieldCreator fieldCreator;
+    private final ArgumentCreator argumentCreator;
     private final InterfaceCreator interfaceCreator;
     private final EnumCreator enumCreator;
     private final ReferenceCreator referenceCreator;
@@ -93,8 +94,7 @@ public class SchemaBuilder {
         enumCreator = new EnumCreator(autoNameStrategy);
         referenceCreator = new ReferenceCreator(autoNameStrategy);
         fieldCreator = new FieldCreator(referenceCreator);
-        ArgumentCreator argumentCreator = new ArgumentCreator(referenceCreator);
-
+        argumentCreator = new ArgumentCreator(referenceCreator);
         inputTypeCreator = new InputTypeCreator(fieldCreator);
         operationCreator = new OperationCreator(referenceCreator, argumentCreator);
         typeCreator = new TypeCreator(referenceCreator, fieldCreator, operationCreator);
@@ -153,6 +153,7 @@ public class SchemaBuilder {
         typeCreator.setDirectives(directives);
         interfaceCreator.setDirectives(directives);
         fieldCreator.setDirectives(directives);
+        argumentCreator.setDirectives(directives);
     }
 
     private void addTypesToSchema(Schema schema) {

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
@@ -154,6 +154,7 @@ public class SchemaBuilder {
         interfaceCreator.setDirectives(directives);
         fieldCreator.setDirectives(directives);
         argumentCreator.setDirectives(directives);
+        operationCreator.setDirectives(directives);
     }
 
     private void addTypesToSchema(Schema schema) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -600,6 +600,11 @@ public class Bootstrap {
             fieldBuilder.argument(autoMapArgument.get());
         }
 
+        // Directives
+        if (operation.hasDirectiveInstances()) {
+            fieldBuilder = fieldBuilder.withDirectives(createGraphQLDirectives(operation.getDirectiveInstances()));
+        }
+
         GraphQLFieldDefinition graphQLFieldDefinition = fieldBuilder.build();
 
         // DataFetcher
@@ -609,6 +614,12 @@ public class Bootstrap {
                 datafetcher);
 
         return graphQLFieldDefinition;
+    }
+
+    private GraphQLDirective[] createGraphQLDirectives(Collection<DirectiveInstance> directiveInstances) {
+        return directiveInstances.stream()
+                .map(this::createGraphQLDirectiveFrom)
+                .toArray(GraphQLDirective[]::new);
     }
 
     private List<GraphQLFieldDefinition> createGraphQLFieldDefinitionsFromFields(Reference owner, Collection<Field> fields) {

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/ArgumentDirective.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/ArgumentDirective.java
@@ -1,0 +1,13 @@
+package io.smallrye.graphql.schema;
+
+import static io.smallrye.graphql.api.DirectiveLocation.ARGUMENT_DEFINITION;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import io.smallrye.graphql.api.Directive;
+
+@Retention(RUNTIME)
+@Directive(on = ARGUMENT_DEFINITION)
+public @interface ArgumentDirective {
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/DirectivesTestApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/DirectivesTestApi.java
@@ -8,7 +8,7 @@ import org.eclipse.microprofile.graphql.Query;
 @GraphQLApi
 public class DirectivesTestApi {
     @Query
-    public TestTypeWithDirectives testTypeWithDirectives(List<String> arg) {
+    public TestTypeWithDirectives queryWithDirectives(@ArgumentDirective List<String> arg) {
         return null;
     }
 }

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/DirectivesTestApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/DirectivesTestApi.java
@@ -3,12 +3,31 @@ package io.smallrye.graphql.schema;
 import java.util.List;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
+
+import io.smallrye.graphql.api.Subscription;
+import io.smallrye.mutiny.Multi;
 
 @GraphQLApi
 public class DirectivesTestApi {
+
     @Query
+    @OperationDirective
     public TestTypeWithDirectives queryWithDirectives(@ArgumentDirective List<String> arg) {
         return null;
     }
+
+    @Mutation
+    @OperationDirective
+    public TestTypeWithDirectives mutationWithDirectives(@ArgumentDirective List<String> arg) {
+        return null;
+    }
+
+    @Subscription
+    @OperationDirective
+    public Multi<TestTypeWithDirectives> subscriptionWithDirectives(@ArgumentDirective List<String> arg) {
+        return Multi.createFrom().empty();
+    }
+
 }

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/OperationDirective.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/OperationDirective.java
@@ -1,0 +1,13 @@
+package io.smallrye.graphql.schema;
+
+import static io.smallrye.graphql.api.DirectiveLocation.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import io.smallrye.graphql.api.Directive;
+
+@Retention(RUNTIME)
+@Directive(on = { QUERY, MUTATION, SUBSCRIPTION })
+public @interface OperationDirective {
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
@@ -31,7 +31,7 @@ class SchemaTest {
     @Test
     void testSchemaWithDirectives() {
         Schema schema = SchemaBuilder
-                .build(scan(Directive.class, IntArrayTestDirective.class, FieldDirective.class,
+                .build(scan(Directive.class, IntArrayTestDirective.class, FieldDirective.class, ArgumentDirective.class,
                         TestTypeWithDirectives.class, DirectivesTestApi.class));
         assertNotNull(schema);
         GraphQLSchema graphQLSchema = Bootstrap.bootstrap(schema, true);
@@ -59,6 +59,9 @@ class SchemaTest {
         GraphQLDirective fieldDirectiveInstance = valueField.getDirective("fieldDirective");
         assertNotNull(fieldDirectiveInstance);
 
+        GraphQLFieldDefinition queryWithDirectives = graphQLSchema.getQueryType().getField("queryWithDirectives");
+        assertNotNull(queryWithDirectives.getArgument("arg").getDirective("argumentDirective"));
+
         String schemaString = new SchemaPrinter().print(graphQLSchema);
         LOG.info(schemaString);
         assertTrue(schemaString.contains("\"test-description\"\n" +
@@ -66,7 +69,7 @@ class SchemaTest {
         assertTrue(schemaString.endsWith("" +
                 "\"Query root\"\n" +
                 "type Query {\n" +
-                "  testTypeWithDirectives(arg: [String]): TestTypeWithDirectives\n" +
+                "  queryWithDirectives(arg: [String] @argumentDirective): TestTypeWithDirectives\n" +
                 "}\n" +
                 "\n" +
                 "type TestTypeWithDirectives @intArrayTestDirective(value : [1, 2, 3]) {\n" +


### PR DESCRIPTION
Adds support for (custom) directives on operations and operation arguments.

The following API results in the schema below:
```kotlin
@GraphQLApi
class PetResource {

    @Query
    @Deprecated
    fun pets(@Deprecated name: String): List<Pet> = emptyList()

}
```

```
"Query root"
type Query {
   pets(name: String @deprecated): [Pet] @deprecated
}
```

This PR fixes #1556