### PR TITLE
Support directives on enums and enum values

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
@@ -152,6 +152,7 @@ public class SchemaBuilder {
     private void setupDirectives(Directives directives) {
         typeCreator.setDirectives(directives);
         interfaceCreator.setDirectives(directives);
+        enumCreator.setDirectives(directives);
         fieldCreator.setDirectives(directives);
         argumentCreator.setDirectives(directives);
         operationCreator.setDirectives(directives);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
@@ -15,6 +15,7 @@ import io.smallrye.graphql.schema.helper.Directives;
 import io.smallrye.graphql.schema.helper.IgnoreHelper;
 import io.smallrye.graphql.schema.helper.TypeAutoNameStrategy;
 import io.smallrye.graphql.schema.helper.TypeNameHelper;
+import io.smallrye.graphql.schema.model.DirectiveInstance;
 import io.smallrye.graphql.schema.model.EnumType;
 import io.smallrye.graphql.schema.model.EnumValue;
 import io.smallrye.graphql.schema.model.Reference;
@@ -58,8 +59,7 @@ public class EnumCreator implements Creator<EnumType> {
         EnumType enumType = new EnumType(classInfo.name().toString(), name, maybeDescription.orElse(null));
 
         // Directives
-        enumType.setDirectiveInstances(
-                directives.buildDirectiveInstances(dotName -> annotations.getOneOfTheseAnnotations(dotName).orElse(null)));
+        enumType.setDirectiveInstances(getDirectiveInstances(annotations));
 
         // Values
         List<FieldInfo> fields = classInfo.fields();
@@ -69,12 +69,16 @@ public class EnumCreator implements Creator<EnumType> {
                 if (!field.type().kind().equals(Type.Kind.ARRAY) && !IgnoreHelper.shouldIgnore(annotationsForField, field)) {
                     String description = annotationsForField.getOneOfTheseAnnotationsValue(Annotations.DESCRIPTION)
                             .orElse(null);
-                    enumType.addValue(new EnumValue(description, field.name()));
+                    enumType.addValue(new EnumValue(description, field.name(), getDirectiveInstances(annotationsForField)));
                 }
             }
         }
 
         return enumType;
+    }
+
+    private List<DirectiveInstance> getDirectiveInstances(Annotations annotations) {
+        return directives.buildDirectiveInstances(dotName -> annotations.getOneOfTheseAnnotations(dotName).orElse(null));
     }
 
 }

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
@@ -11,6 +11,7 @@ import org.jboss.logging.Logger;
 import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.helper.DescriptionHelper;
 import io.smallrye.graphql.schema.helper.Direction;
+import io.smallrye.graphql.schema.helper.Directives;
 import io.smallrye.graphql.schema.helper.IgnoreHelper;
 import io.smallrye.graphql.schema.helper.TypeAutoNameStrategy;
 import io.smallrye.graphql.schema.helper.TypeNameHelper;
@@ -28,9 +29,14 @@ public class EnumCreator implements Creator<EnumType> {
     private static final Logger LOG = Logger.getLogger(EnumCreator.class.getName());
 
     private final TypeAutoNameStrategy autoNameStrategy;
+    private Directives directives;
 
     public EnumCreator(TypeAutoNameStrategy autoNameStrategy) {
         this.autoNameStrategy = autoNameStrategy;
+    }
+
+    public void setDirectives(Directives directives) {
+        this.directives = directives;
     }
 
     @Override
@@ -50,6 +56,10 @@ public class EnumCreator implements Creator<EnumType> {
         Optional<String> maybeDescription = DescriptionHelper.getDescriptionForType(annotations);
 
         EnumType enumType = new EnumType(classInfo.name().toString(), name, maybeDescription.orElse(null));
+
+        // Directives
+        enumType.setDirectiveInstances(
+                directives.buildDirectiveInstances(dotName -> annotations.getOneOfTheseAnnotations(dotName).orElse(null)));
 
         // Values
         List<FieldInfo> fields = classInfo.fields();

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/EnumValue.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/EnumValue.java
@@ -1,5 +1,8 @@
 package io.smallrye.graphql.schema.model;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Represents one of an enum's values. Is part of {@link EnumType}.
  *
@@ -9,13 +12,15 @@ public final class EnumValue {
 
     private String description;
     private String value;
+    private List<DirectiveInstance> directiveInstances;
 
     public EnumValue() {
     }
 
-    public EnumValue(String description, String value) {
+    public EnumValue(String description, String value, List<DirectiveInstance> directiveInstances) {
         this.description = description;
         this.value = value;
+        this.directiveInstances = directiveInstances;
     }
 
     public String getDescription() {
@@ -36,6 +41,19 @@ public final class EnumValue {
 
     @Override
     public String toString() {
-        return "EnumValue{" + "description=" + description + ", value=" + value + '}';
+        return "EnumValue{" +
+                "description=" + description +
+                ", value=" + value +
+                ", directiveInstances=" + directiveInstances +
+                '}';
     }
+
+    public boolean hasDirectiveInstances() {
+        return directiveInstances != null && !directiveInstances.isEmpty();
+    }
+
+    public Collection<DirectiveInstance> getDirectiveInstances() {
+        return directiveInstances;
+    }
+
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -32,6 +32,7 @@ import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLEnumValueDefinition;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
@@ -345,7 +346,14 @@ public class Bootstrap {
         }
         // Values
         for (EnumValue value : enumType.getValues()) {
-            enumBuilder = enumBuilder.value(value.getValue(), value.getValue(), value.getDescription());
+            GraphQLEnumValueDefinition.Builder definitionBuilder = GraphQLEnumValueDefinition.newEnumValueDefinition()
+                    .name(value.getValue())
+                    .value(value.getValue())
+                    .description(value.getDescription());
+            if (value.hasDirectiveInstances()) {
+                definitionBuilder = definitionBuilder.withDirectives(createGraphQLDirectives(value.getDirectiveInstances()));
+            }
+            enumBuilder = enumBuilder.value(definitionBuilder.build());
         }
         GraphQLEnumType graphQLEnumType = enumBuilder.build();
         enumMap.put(enumType.getClassName(), graphQLEnumType);

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -339,6 +339,10 @@ public class Bootstrap {
         GraphQLEnumType.Builder enumBuilder = GraphQLEnumType.newEnum()
                 .name(enumType.getName())
                 .description(enumType.getDescription());
+        // Directives
+        if (enumType.hasDirectiveInstances()) {
+            enumBuilder = enumBuilder.withDirectives(createGraphQLDirectives(enumType.getDirectiveInstances()));
+        }
         // Values
         for (EnumValue value : enumType.getValues()) {
             enumBuilder = enumBuilder.value(value.getValue(), value.getValue(), value.getDescription());

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/EnumDirective.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/EnumDirective.java
@@ -1,0 +1,14 @@
+package io.smallrye.graphql.schema;
+
+import static io.smallrye.graphql.api.DirectiveLocation.ENUM;
+import static io.smallrye.graphql.api.DirectiveLocation.ENUM_VALUE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import io.smallrye.graphql.api.Directive;
+
+@Retention(RUNTIME)
+@Directive(on = { ENUM, ENUM_VALUE })
+public @interface EnumDirective {
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/EnumTestApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/EnumTestApi.java
@@ -14,7 +14,8 @@ public class EnumTestApi {
     @EnumDirective
     public enum EnumWithDirectives {
         @EnumDirective
-        A
+        A,
+        B
     }
 
 }

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/EnumTestApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/EnumTestApi.java
@@ -1,0 +1,20 @@
+package io.smallrye.graphql.schema;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class EnumTestApi {
+
+    @Query
+    public int query(EnumWithDirectives enumWithDirectives) {
+        return 0;
+    }
+
+    @EnumDirective
+    public enum EnumWithDirectives {
+        @EnumDirective
+        A
+    }
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
@@ -92,12 +92,15 @@ class SchemaTest {
         GraphQLEnumType enumWithDirectives = graphQLSchema.getTypeAs("EnumWithDirectives");
         assertNotNull(enumWithDirectives.getDirective("enumDirective"),
                 "Enum EnumWithDirectives should have directive @enumDirective");
+        assertNotNull(enumWithDirectives.getValue("A").getDirective("enumDirective"),
+                "Enum value EnumWithDirectives.A should have directive @enumDirective");
 
         String schemaString = new SchemaPrinter().print(graphQLSchema);
-        assertSchemaEndsWith(schemaString,
+        assertSchemaEndsWith(schemaString, "" +
                 "enum EnumWithDirectives @enumDirective {\n" +
-                        "  A\n" +
-                        "}\n");
+                "  A @enumDirective\n" +
+                "  B\n" +
+                "}\n");
     }
 
     private GraphQLSchema createGraphQLSchema(Class<?>... api) {

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
@@ -12,11 +12,11 @@ import java.util.stream.Stream;
 
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
-import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
@@ -26,17 +26,12 @@ import io.smallrye.graphql.execution.SchemaPrinter;
 import io.smallrye.graphql.schema.model.Schema;
 
 class SchemaTest {
-    private static final Logger LOG = Logger.getLogger(SchemaTest.class.getName());
 
     @Test
     void testSchemaWithDirectives() {
-        Schema schema = SchemaBuilder
-                .build(scan(Directive.class, IntArrayTestDirective.class, FieldDirective.class,
-                        ArgumentDirective.class, OperationDirective.class,
-                        TestTypeWithDirectives.class, DirectivesTestApi.class));
-        assertNotNull(schema);
-        GraphQLSchema graphQLSchema = Bootstrap.bootstrap(schema, true);
-        assertNotNull(graphQLSchema);
+        GraphQLSchema graphQLSchema = createGraphQLSchema(
+                Directive.class, IntArrayTestDirective.class, FieldDirective.class, ArgumentDirective.class,
+                OperationDirective.class, TestTypeWithDirectives.class, DirectivesTestApi.class);
 
         GraphQLDirective typeDirective = graphQLSchema.getDirective("intArrayTestDirective");
         assertEquals("intArrayTestDirective", typeDirective.getName());
@@ -65,10 +60,10 @@ class SchemaTest {
         assertOperationWithDirectives(graphQLSchema.getSubscriptionType().getField("subscriptionWithDirectives"));
 
         String schemaString = new SchemaPrinter().print(graphQLSchema);
-        LOG.info(schemaString);
-        assertTrue(schemaString.contains("\"test-description\"\n" +
-                "directive @intArrayTestDirective(value: [Int]) on OBJECT | INTERFACE\n"));
-        assertTrue(schemaString.endsWith("" +
+        assertSchemaContains(schemaString,
+                "\"test-description\"\n" +
+                        "directive @intArrayTestDirective(value: [Int]) on OBJECT | INTERFACE\n");
+        assertSchemaEndsWith(schemaString, "" +
                 "\"Mutation root\"\n" +
                 "type Mutation {\n" +
                 "  mutationWithDirectives(arg: [String] @argumentDirective): TestTypeWithDirectives @operationDirective\n" +
@@ -86,7 +81,39 @@ class SchemaTest {
                 "\n" +
                 "type TestTypeWithDirectives @intArrayTestDirective(value : [1, 2, 3]) {\n" +
                 "  value: String @fieldDirective\n" +
-                "}\n"));
+                "}\n");
+    }
+
+    @Test
+    void schemaWithEnumDirectives() {
+        GraphQLSchema graphQLSchema = createGraphQLSchema(EnumDirective.class, EnumTestApi.class,
+                EnumTestApi.EnumWithDirectives.class);
+
+        GraphQLEnumType enumWithDirectives = graphQLSchema.getTypeAs("EnumWithDirectives");
+        assertNotNull(enumWithDirectives.getDirective("enumDirective"),
+                "Enum EnumWithDirectives should have directive @enumDirective");
+
+        String schemaString = new SchemaPrinter().print(graphQLSchema);
+        assertSchemaEndsWith(schemaString,
+                "enum EnumWithDirectives @enumDirective {\n" +
+                        "  A\n" +
+                        "}\n");
+    }
+
+    private GraphQLSchema createGraphQLSchema(Class<?>... api) {
+        Schema schema = SchemaBuilder.build(scan(api));
+        assertNotNull(schema, "Schema should not be null");
+        GraphQLSchema graphQLSchema = Bootstrap.bootstrap(schema, true);
+        assertNotNull(graphQLSchema, "GraphQLSchema should not be null");
+        return graphQLSchema;
+    }
+
+    private static void assertSchemaContains(String schema, String snippet) {
+        assertTrue(schema.contains(snippet), () -> "<<<\n" + schema + "\n>>> does not contain <<<\n" + snippet + "\n>>>");
+    }
+
+    private static void assertSchemaEndsWith(String schema, String end) {
+        assertTrue(schema.endsWith(end), () -> "<<<\n" + schema + "\n>>> does not end with <<<\n" + end + "\n>>>");
     }
 
     private void assertOperationWithDirectives(GraphQLFieldDefinition operation) {


### PR DESCRIPTION
Adds support for directives on enums and enum values.

The following API results in the schema below:
```java
@GraphQLApi
public class EnumTestApi {

    @Query
    public int query(EnumWithDirectives enumWithDirectives) {
        return 0;
    }

    @EnumDirective
    public enum EnumWithDirectives {
        @EnumDirective
        A,
        B
    }

}

```

```
enum EnumWithDirectives @enumDirective {
  A @enumDirective
  B
}
```