### PR TITLE
Support directives on input objects and input fields

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/SchemaBuilder.java
@@ -150,6 +150,7 @@ public class SchemaBuilder {
     }
 
     private void setupDirectives(Directives directives) {
+        inputTypeCreator.setDirectives(directives);
         typeCreator.setDirectives(directives);
         interfaceCreator.setDirectives(directives);
         enumCreator.setDirectives(directives);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
@@ -18,8 +18,10 @@ import io.smallrye.graphql.schema.ScanningContext;
 import io.smallrye.graphql.schema.creator.FieldCreator;
 import io.smallrye.graphql.schema.helper.DescriptionHelper;
 import io.smallrye.graphql.schema.helper.Direction;
+import io.smallrye.graphql.schema.helper.Directives;
 import io.smallrye.graphql.schema.helper.MethodHelper;
 import io.smallrye.graphql.schema.helper.TypeNameHelper;
+import io.smallrye.graphql.schema.model.DirectiveInstance;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.InputType;
 import io.smallrye.graphql.schema.model.Reference;
@@ -37,6 +39,7 @@ public class InputTypeCreator implements Creator<InputType> {
     private static final Logger LOG = Logger.getLogger(InputTypeCreator.class.getName());
 
     private final FieldCreator fieldCreator;
+    private Directives directives;
 
     public InputTypeCreator(FieldCreator fieldCreator) {
         this.fieldCreator = fieldCreator;
@@ -65,6 +68,9 @@ public class InputTypeCreator implements Creator<InputType> {
         String description = DescriptionHelper.getDescriptionForType(annotations).orElse(null);
 
         InputType inputType = new InputType(classInfo.name().toString(), name, description);
+
+        // Directives
+        inputType.setDirectiveInstances(getDirectiveInstances(annotations));
 
         // Fields
         addFields(inputType, classInfo, reference);
@@ -125,6 +131,14 @@ public class InputTypeCreator implements Creator<InputType> {
         }
 
         return null;
+    }
+
+    public void setDirectives(Directives directives) {
+        this.directives = directives;
+    }
+
+    private List<DirectiveInstance> getDirectiveInstances(Annotations annotations) {
+        return directives.buildDirectiveInstances(dotName -> annotations.getOneOfTheseAnnotations(dotName).orElse(null));
     }
 
     private void addFields(InputType inputType, ClassInfo classInfo, Reference reference) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -462,6 +462,12 @@ public class Bootstrap {
                 .name(inputType.getName())
                 .description(inputType.getDescription());
 
+        // Directives
+        if (inputType.hasDirectiveInstances()) {
+            inputObjectTypeBuilder = inputObjectTypeBuilder
+                    .withDirectives(createGraphQLDirectives(inputType.getDirectiveInstances()));
+        }
+
         // Fields
         if (inputType.hasFields()) {
             inputObjectTypeBuilder = inputObjectTypeBuilder

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/InputDirective.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/InputDirective.java
@@ -1,0 +1,14 @@
+package io.smallrye.graphql.schema;
+
+import static io.smallrye.graphql.api.DirectiveLocation.INPUT_FIELD_DEFINITION;
+import static io.smallrye.graphql.api.DirectiveLocation.INPUT_OBJECT;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import io.smallrye.graphql.api.Directive;
+
+@Retention(RUNTIME)
+@Directive(on = { INPUT_OBJECT, INPUT_FIELD_DEFINITION })
+public @interface InputDirective {
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/InputTestApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/InputTestApi.java
@@ -1,0 +1,24 @@
+package io.smallrye.graphql.schema;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class InputTestApi {
+
+    @Query
+    public int query(InputWithDirectives input) {
+        return 0;
+    }
+
+    @InputDirective
+    public static class InputWithDirectives {
+        @InputDirective
+        public int foo;
+
+        @InputDirective
+        public void setBar(int bar) {
+        }
+    }
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
@@ -18,6 +18,7 @@ import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import io.smallrye.graphql.api.Directive;
@@ -100,6 +101,27 @@ class SchemaTest {
                 "enum EnumWithDirectives @enumDirective {\n" +
                 "  A @enumDirective\n" +
                 "  B\n" +
+                "}\n");
+    }
+
+    @Test
+    void schemaWithInputDirectives() {
+        GraphQLSchema graphQLSchema = createGraphQLSchema(InputDirective.class, InputTestApi.class,
+                InputTestApi.InputWithDirectives.class);
+
+        GraphQLInputObjectType inputWithDirectives = graphQLSchema.getTypeAs("InputWithDirectivesInput");
+        assertNotNull(inputWithDirectives.getDirective("inputDirective"),
+                "Input type InputWithDirectivesInput should have directive @inputDirective");
+        assertNotNull(inputWithDirectives.getField("foo").getDirective("inputDirective"),
+                "Input type field InputWithDirectivesInput.foo should have directive @inputDirective");
+        assertNotNull(inputWithDirectives.getField("bar").getDirective("inputDirective"),
+                "Input type field InputWithDirectivesInput.bar should have directive @inputDirective");
+
+        String schemaString = new SchemaPrinter().print(graphQLSchema);
+        assertSchemaEndsWith(schemaString, "" +
+                "input InputWithDirectivesInput @inputDirective {\n" +
+                "  bar: Int! @inputDirective\n" +
+                "  foo: Int! @inputDirective\n" +
                 "}\n");
     }
 


### PR DESCRIPTION
This PR builds upon the ~still open~ PR #1559.

Adds support for directives on input objects and input fields.

The following API results in the schema below:
```java
@GraphQLApi
public class InputTestApi {

    @Query
    public int query(InputWithDirectives input) {
        return 0;
    }

    @InputDirective
    public static class InputWithDirectives {
        @InputDirective
        public int foo;

        @InputDirective
        public void setBar(int bar) {
        }
    }

}
```

```
input InputWithDirectivesInput @inputDirective {
  bar: Int! @inputDirective
  foo: Int! @inputDirective
}
```