### PR TITLE
Access Context in EventingService.errorDataFetch and .errorExecute

### DIFF
--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/event/ErrorInfo.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/event/ErrorInfo.java
@@ -1,21 +1,27 @@
 package io.smallrye.graphql.cdi.event;
 
+import io.smallrye.graphql.api.Context;
+
 /**
  * Simple Pojo that hold error info
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class ErrorInfo {
-    private String executionId;
-    private Throwable t;
+    private final Context context;
+    private final Throwable t;
 
-    public ErrorInfo(String executionId, Throwable t) {
-        this.executionId = executionId;
+    ErrorInfo(Context context, Throwable t) {
+        this.context = context;
         this.t = t;
     }
 
+    public Context getContext() {
+        return context;
+    }
+
     public String getExecutionId() {
-        return executionId;
+        return context.getExecutionId();
     }
 
     public Throwable getT() {

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/event/EventsService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/event/EventsService.java
@@ -68,13 +68,13 @@ public class EventsService implements EventingService {
     }
 
     @Override
-    public void errorExecute(String executionId, Throwable t) {
-        fire(new ErrorInfo(executionId, t), ErrorExecute.LITERAL);
+    public void errorExecute(Context context, Throwable t) {
+        fire(new ErrorInfo(context, t), ErrorExecute.LITERAL);
     }
 
     @Override
-    public void errorDataFetch(String executionId, Throwable t) {
-        fire(new ErrorInfo(executionId, t), ErrorDataFetch.LITERAL);
+    public void errorDataFetch(Context context, Throwable t) {
+        fire(new ErrorInfo(context, t), ErrorDataFetch.LITERAL);
     }
 
     @Override

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/tracing/TracingService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/tracing/TracingService.java
@@ -72,8 +72,8 @@ public class TracingService implements EventingService {
     }
 
     @Override
-    public void errorExecute(String executionId, Throwable t) {
-        Span span = spans.remove(executionId);
+    public void errorExecute(Context context, Throwable t) {
+        Span span = spans.remove(context.getExecutionId());
         if (span != null) {
             Map<String, Object> error = new HashMap<>();
             error.put("event.object", t);
@@ -117,8 +117,8 @@ public class TracingService implements EventingService {
     }
 
     @Override
-    public void errorDataFetch(String executionId, Throwable t) {
-        Span span = spans.get(executionId);
+    public void errorDataFetch(Context context, Throwable t) {
+        Span span = spans.get(context.getExecutionId());
         if (span != null) {
             logError(span, t);
         }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -184,7 +184,7 @@ public class ExecutionService {
                 log.noGraphQLMethodsFound();
             }
         } catch (Throwable t) {
-            eventEmitter.fireOnExecuteError(finalExecutionId.toString(), t);
+            eventEmitter.fireOnExecuteError(smallRyeContext, t);
             writer.fail(t);
         }
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractAsyncDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractAsyncDataFetcher.java
@@ -8,6 +8,7 @@ import org.eclipse.microprofile.graphql.GraphQLException;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
 import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
+import io.smallrye.graphql.api.Context;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Type;
 import io.smallrye.graphql.transformation.AbstractDataFetcherException;
@@ -30,6 +31,7 @@ public abstract class AbstractAsyncDataFetcher<K, T> extends AbstractDataFetcher
     @Override
     @SuppressWarnings("unchecked")
     protected <O> O invokeAndTransform(
+            Context context,
             DataFetchingEnvironment dfe,
             DataFetcherResult.Builder<Object> resultBuilder,
             Object[] transformedArguments) throws Exception {
@@ -39,7 +41,7 @@ public abstract class AbstractAsyncDataFetcher<K, T> extends AbstractDataFetcher
                 .onItemOrFailure()
                 .transformToUni((result, throwable, emitter) -> {
                     if (throwable != null) {
-                        eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), throwable);
+                        eventEmitter.fireOnDataFetchError(context, throwable);
                         if (throwable instanceof GraphQLException) {
                             GraphQLException graphQLException = (GraphQLException) throwable;
                             errorResultHelper.appendPartialResult(resultBuilder, dfe, graphQLException);

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/DefaultDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/DefaultDataFetcher.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletionStage;
 
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.api.Context;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Type;
 import io.smallrye.mutiny.Uni;
@@ -26,7 +27,8 @@ public class DefaultDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
     }
 
     @Override
-    public <T> T invokeAndTransform(DataFetchingEnvironment dfe, DataFetcherResult.Builder<Object> resultBuilder,
+    public <T> T invokeAndTransform(Context context, DataFetchingEnvironment dfe,
+            DataFetcherResult.Builder<Object> resultBuilder,
             Object[] transformedArguments) throws Exception {
         Object resultFromMethodCall = operationInvoker.invoke(transformedArguments);
         Object resultFromTransform = fieldHelper.transformOrAdaptResponse(resultFromMethodCall, dfe);

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
@@ -90,9 +90,9 @@ public class EventEmitter {
         }
     }
 
-    public void fireOnExecuteError(String executionId, Throwable t) {
+    public void fireOnExecuteError(Context context, Throwable t) {
         for (EventingService extensionService : enabledServices) {
-            extensionService.errorExecute(executionId, t);
+            extensionService.errorExecute(context, t);
         }
     }
 
@@ -116,9 +116,9 @@ public class EventEmitter {
         }
     }
 
-    public void fireOnDataFetchError(String executionId, Throwable t) {
+    public void fireOnDataFetchError(Context context, Throwable t) {
         for (EventingService extensionService : enabledServices) {
-            extensionService.errorDataFetch(executionId, t);
+            extensionService.errorDataFetch(context, t);
         }
     }
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/EventingService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/EventingService.java
@@ -49,7 +49,15 @@ public interface EventingService {
     default void afterExecute(Context context) {
     }
 
+    /**
+     * @deprecated use {@code errorExecute(Context context, Throwable t)}
+     */
+    @Deprecated
     default void errorExecute(String executionId, Throwable t) {
+    }
+
+    default void errorExecute(Context context, Throwable t) {
+        errorExecute(context.getExecutionId(), t);
     }
 
     default void beforeDataFetch(Context context) {
@@ -61,6 +69,14 @@ public interface EventingService {
     default void afterDataFetch(Context context) {
     }
 
+    /**
+     * @deprecated use {@code errorDataFetch(Context context, Throwable t)}
+     */
+    @Deprecated
     default void errorDataFetch(String executionId, Throwable t) {
+    }
+
+    default void errorDataFetch(Context context, Throwable t) {
+        errorDataFetch(context.getExecutionId(), t);
     }
 }


### PR DESCRIPTION
This is a suggestion adding new versions of EventingService.errorDataFetch and .errorExecute making `Context` available for the implementer.

`errorDataFetch` is called when an error occurs when fetching a field in the query.
It's signature is 
```java
public void errorDataFetch(String executionId, Throwable t)
```
Is there any reason for not exposing the `Context`/`DataFetchingEnvironment` of the execution?

For instance a query like 
```
query twoQueries {
   getA { a }
   getB { b }
} 
```
Only having access to executionId and exception makes it impossible to know whether data fetching operation getA or getB triggered `errorDataFetch`.
