### PR TITLE
Adding payload to `connection_init` message

### DIFF
--- a/client/api/src/main/java/io/smallrye/graphql/client/dynamic/api/DynamicGraphQLClientBuilder.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/dynamic/api/DynamicGraphQLClientBuilder.java
@@ -1,6 +1,7 @@
 package io.smallrye.graphql.client.dynamic.api;
 
 import java.util.Iterator;
+import java.util.Map;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
@@ -17,6 +18,8 @@ public interface DynamicGraphQLClientBuilder {
     DynamicGraphQLClientBuilder configKey(String configKey);
 
     DynamicGraphQLClientBuilder header(String key, String value);
+
+    DynamicGraphQLClientBuilder initPayload(Map<String, Object> payload);
 
     DynamicGraphQLClientBuilder subprotocols(WebsocketSubprotocol... subprotocols);
 

--- a/client/api/src/main/java/io/smallrye/graphql/client/typesafe/api/TypesafeGraphQLClientBuilder.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/typesafe/api/TypesafeGraphQLClientBuilder.java
@@ -74,6 +74,11 @@ public interface TypesafeGraphQLClientBuilder {
      */
     TypesafeGraphQLClientBuilder header(String name, String value);
 
+    /**
+     * Static payload to send with initialization method on subscription.
+     */
+    TypesafeGraphQLClientBuilder initPayload(Map<String, Object> initPayload);
+
     TypesafeGraphQLClientBuilder subprotocols(WebsocketSubprotocol... subprotocols);
 
     /**

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClient.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClient.java
@@ -49,6 +49,7 @@ public class VertxDynamicGraphQLClient implements DynamicGraphQLClient {
 
     private final boolean executeSingleOperationsOverWebsocket;
     private final MultiMap headers;
+    private final Map<String, Object> initPayload;
     private final List<WebsocketSubprotocol> subprotocols;
     private final Integer subscriptionInitializationTimeout;
 
@@ -63,7 +64,7 @@ public class VertxDynamicGraphQLClient implements DynamicGraphQLClient {
 
     VertxDynamicGraphQLClient(Vertx vertx, WebClient webClient,
             String url, String websocketUrl, boolean executeSingleOperationsOverWebsocket,
-            MultiMap headers, WebClientOptions options,
+            MultiMap headers, Map<String, Object> initPayload, WebClientOptions options,
             List<WebsocketSubprotocol> subprotocols, Integer subscriptionInitializationTimeout) {
         if (options != null) {
             this.httpClient = vertx.createHttpClient(options);
@@ -76,7 +77,7 @@ public class VertxDynamicGraphQLClient implements DynamicGraphQLClient {
             this.webClient = webClient;
         }
         this.headers = headers;
-
+        this.initPayload = initPayload;
         if (url != null) {
             if (url.startsWith("stork")) {
                 this.url = new StorkServiceURLSupplier(URI.create(url), false);
@@ -309,7 +310,7 @@ public class VertxDynamicGraphQLClient implements DynamicGraphQLClient {
                                         WebSocket webSocket = result.result();
                                         WebSocketSubprotocolHandler handler = BuiltinWebsocketSubprotocolHandlers
                                                 .createHandlerFor(webSocket.subProtocol(), webSocket,
-                                                        subscriptionInitializationTimeout, () -> {
+                                                        subscriptionInitializationTimeout, initPayload, () -> {
                                                             // if the websocket disconnects, remove the handler so we can try
                                                             // connecting again with a new websocket and handler
                                                             webSocketHandler.set(null);

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClientBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClientBuilder.java
@@ -170,6 +170,11 @@ public class VertxDynamicGraphQLClientBuilder implements DynamicGraphQLClientBui
                 this.headersMap.set(k, v);
             }
         });
+        configuration.getInitPayload().forEach((k, v) -> {
+            if (!this.initPayload.containsKey(k)) {
+                this.initPayload.put(k, v);
+            }
+        });
         if (configuration.getWebsocketSubprotocols() != null) {
             configuration.getWebsocketSubprotocols().forEach(protocol -> {
                 try {

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClientBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClientBuilder.java
@@ -33,12 +33,14 @@ public class VertxDynamicGraphQLClientBuilder implements DynamicGraphQLClientBui
     private Boolean executeSingleOperationsOverWebsocket;
     private String configKey;
     private final MultiMap headersMap;
+    private final Map<String, Object> initPayload;
     private WebClientOptions options;
     private List<WebsocketSubprotocol> subprotocols;
     private Integer subscriptionInitializationTimeout;
 
     public VertxDynamicGraphQLClientBuilder() {
         headersMap = new HeadersMultiMap();
+        initPayload = new HashMap<>();
         headersMap.set("Content-Type", "application/json");
         subprotocols = new ArrayList<>();
     }
@@ -60,6 +62,11 @@ public class VertxDynamicGraphQLClientBuilder implements DynamicGraphQLClientBui
 
     public VertxDynamicGraphQLClientBuilder headers(Map<String, String> headers) {
         headersMap.setAll(headers);
+        return this;
+    }
+
+    public VertxDynamicGraphQLClientBuilder initPayload(Map<String, Object> initPayload) {
+        this.initPayload.putAll(initPayload);
         return this;
     }
 
@@ -143,7 +150,7 @@ public class VertxDynamicGraphQLClientBuilder implements DynamicGraphQLClientBui
             executeSingleOperationsOverWebsocket = false;
         }
         return new VertxDynamicGraphQLClient(toUseVertx, webClient, url, websocketUrl,
-                executeSingleOperationsOverWebsocket, headersMap, options, subprotocols,
+                executeSingleOperationsOverWebsocket, headersMap, initPayload, options, subprotocols,
                 subscriptionInitializationTimeout);
     }
 

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientBuilder.java
@@ -223,6 +223,9 @@ public class VertxTypesafeGraphQLClientBuilder implements TypesafeGraphQLClientB
         if (this.headers == null && configuration.getHeaders() != null) {
             this.headers = configuration.getHeaders();
         }
+        if (this.initPayload == null && configuration.getInitPayload() != null) {
+            this.initPayload = configuration.getInitPayload();
+        }
         if (this.websocketInitializationTimeout == null && configuration.getWebsocketInitializationTimeout() != null) {
             this.websocketInitializationTimeout = configuration.getWebsocketInitializationTimeout();
         }

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientBuilder.java
@@ -38,6 +38,7 @@ public class VertxTypesafeGraphQLClientBuilder implements TypesafeGraphQLClientB
     private String websocketUrl;
     private Boolean executeSingleOperationsOverWebsocket;
     private Map<String, String> headers;
+    private Map<String, Object> initPayload;
     private List<WebsocketSubprotocol> subprotocols;
     private Vertx vertx;
     private HttpClientOptions options;
@@ -98,6 +99,14 @@ public class VertxTypesafeGraphQLClientBuilder implements TypesafeGraphQLClientB
         return this;
     }
 
+    public VertxTypesafeGraphQLClientBuilder initPayload(Map<String, Object> initPayload) {
+        if (this.initPayload == null) {
+            this.initPayload = new LinkedHashMap<>();
+        }
+        this.initPayload.putAll(initPayload);
+        return this;
+    }
+
     public VertxTypesafeGraphQLClientBuilder subprotocols(WebsocketSubprotocol... subprotocols) {
         this.subprotocols.addAll(Arrays.asList(subprotocols));
         return this;
@@ -134,7 +143,8 @@ public class VertxTypesafeGraphQLClientBuilder implements TypesafeGraphQLClientB
         if (executeSingleOperationsOverWebsocket == null) {
             executeSingleOperationsOverWebsocket = false;
         }
-        VertxTypesafeGraphQLClientProxy graphQlClient = new VertxTypesafeGraphQLClientProxy(apiClass, headers, endpoint,
+        VertxTypesafeGraphQLClientProxy graphQlClient = new VertxTypesafeGraphQLClientProxy(apiClass, headers, initPayload,
+                endpoint,
                 websocketUrl, executeSingleOperationsOverWebsocket, httpClient, webClient, subprotocols,
                 websocketInitializationTimeout);
         return apiClass.cast(Proxy.newProxyInstance(getClassLoader(apiClass), new Class<?>[] { apiClass },

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
@@ -63,6 +63,7 @@ class VertxTypesafeGraphQLClientProxy {
     private final ConcurrentMap<String, String> queryCache = new ConcurrentHashMap<>();
 
     private final Map<String, String> additionalHeaders;
+    private final Map<String, Object> initPayload;
     private final ServiceURLSupplier endpoint;
     private final ServiceURLSupplier websocketUrl;
     private final HttpClient httpClient;
@@ -84,6 +85,7 @@ class VertxTypesafeGraphQLClientProxy {
     VertxTypesafeGraphQLClientProxy(
             Class<?> api,
             Map<String, String> additionalHeaders,
+            Map<String, Object> initPayload,
             URI endpoint,
             String websocketUrl,
             boolean executeSingleOperationsOverWebsocket,
@@ -93,6 +95,7 @@ class VertxTypesafeGraphQLClientProxy {
             Integer subscriptionInitializationTimeout) {
         this.api = api;
         this.additionalHeaders = additionalHeaders;
+        this.initPayload = initPayload;
         if (endpoint != null) {
             if (endpoint.getScheme().startsWith("stork")) {
                 this.endpoint = new StorkServiceURLSupplier(endpoint, false);
@@ -230,7 +233,7 @@ class VertxTypesafeGraphQLClientProxy {
                                         WebSocket webSocket = result.result();
                                         WebSocketSubprotocolHandler handler = BuiltinWebsocketSubprotocolHandlers
                                                 .createHandlerFor(webSocket.subProtocol(), webSocket,
-                                                        subscriptionInitializationTimeout, () -> {
+                                                        subscriptionInitializationTimeout, initPayload, () -> {
                                                             webSocketHandler.set(null);
                                                         });
                                         handlerEmitter.complete(handler);

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/BuiltinWebsocketSubprotocolHandlers.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/BuiltinWebsocketSubprotocolHandlers.java
@@ -1,5 +1,7 @@
 package io.smallrye.graphql.client.vertx.websocket;
 
+import java.util.Map;
+
 import io.smallrye.graphql.client.vertx.websocket.graphqltransportws.GraphQLTransportWSSubprotocolHandler;
 import io.smallrye.graphql.client.vertx.websocket.graphqlws.GraphQLWSSubprotocolHandler;
 import io.vertx.core.http.WebSocket;
@@ -7,12 +9,13 @@ import io.vertx.core.http.WebSocket;
 public class BuiltinWebsocketSubprotocolHandlers {
 
     public static WebSocketSubprotocolHandler createHandlerFor(String protocolName, WebSocket webSocket,
-            Integer subscriptionInitializationTimeout, Runnable onClose) {
+            Integer subscriptionInitializationTimeout, Map<String, Object> initPayload, Runnable onClose) {
         switch (protocolName) {
             case "graphql-ws":
                 return new GraphQLWSSubprotocolHandler(webSocket, subscriptionInitializationTimeout, onClose);
             case "graphql-transport-ws":
-                return new GraphQLTransportWSSubprotocolHandler(webSocket, subscriptionInitializationTimeout, onClose);
+                return new GraphQLTransportWSSubprotocolHandler(webSocket, subscriptionInitializationTimeout, initPayload,
+                        onClose);
             default:
                 throw new IllegalArgumentException("Unknown subprotocol: " + protocolName);
         }

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/BuiltinWebsocketSubprotocolHandlers.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/BuiltinWebsocketSubprotocolHandlers.java
@@ -12,7 +12,7 @@ public class BuiltinWebsocketSubprotocolHandlers {
             Integer subscriptionInitializationTimeout, Map<String, Object> initPayload, Runnable onClose) {
         switch (protocolName) {
             case "graphql-ws":
-                return new GraphQLWSSubprotocolHandler(webSocket, subscriptionInitializationTimeout, onClose);
+                return new GraphQLWSSubprotocolHandler(webSocket, subscriptionInitializationTimeout, initPayload, onClose);
             case "graphql-transport-ws":
                 return new GraphQLTransportWSSubprotocolHandler(webSocket, subscriptionInitializationTimeout, initPayload,
                         onClose);

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
@@ -59,7 +59,9 @@ public class GraphQLTransportWSSubprotocolHandler implements WebSocketSubprotoco
     public GraphQLTransportWSSubprotocolHandler(WebSocket webSocket, Integer subscriptionInitializationTimeout,
             Map<String, Object> initPayload, Runnable onClose) {
         this.initPayload = new HashMap<>();
-        this.initPayload.putAll(initPayload);
+        if (initPayload != null) {
+            this.initPayload.putAll(initPayload);
+        }
         this.webSocket = webSocket;
         this.connectionInitializationTimeout = subscriptionInitializationTimeout;
         this.uniOperations = new ConcurrentHashMap<>();

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
@@ -2,7 +2,7 @@ package io.smallrye.graphql.client.vertx.websocket.graphqltransportws;
 
 import java.io.StringReader;
 import java.time.Duration;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -58,7 +58,7 @@ public class GraphQLTransportWSSubprotocolHandler implements WebSocketSubprotoco
 
     public GraphQLTransportWSSubprotocolHandler(WebSocket webSocket, Integer subscriptionInitializationTimeout,
             Map<String, Object> initPayload, Runnable onClose) {
-        this.initPayload = new LinkedHashMap<>();
+        this.initPayload = new HashMap<>();
         this.initPayload.putAll(initPayload);
         this.webSocket = webSocket;
         this.connectionInitializationTimeout = subscriptionInitializationTimeout;

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
@@ -2,6 +2,7 @@ package io.smallrye.graphql.client.vertx.websocket.graphqlws;
 
 import java.io.StringReader;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,8 +48,12 @@ public class GraphQLWSSubprotocolHandler implements WebSocketSubprotocolHandler 
     private final Runnable onClose;
 
     private final OperationIDGenerator operationIdGenerator;
+    private final Map<String, Object> initPayload;
 
-    public GraphQLWSSubprotocolHandler(WebSocket webSocket, Integer subscriptionInitializationTimeout, Runnable onClose) {
+    public GraphQLWSSubprotocolHandler(WebSocket webSocket, Integer subscriptionInitializationTimeout,
+            Map<String, Object> initPayload, Runnable onClose) {
+        this.initPayload = new HashMap<>();
+        this.initPayload.putAll(initPayload);
         this.webSocket = webSocket;
         this.subscriptionInitializationTimeout = subscriptionInitializationTimeout;
         this.uniOperations = new ConcurrentHashMap<>();
@@ -212,8 +217,13 @@ public class GraphQLWSSubprotocolHandler implements WebSocketSubprotocolHandler 
     }
 
     private JsonObject createConnectionInitMessage() {
+        JsonObjectBuilder payloadBuilder = Json.createObjectBuilder();
+        if (!initPayload.isEmpty()) {
+            payloadBuilder.add("payload", Json.createObjectBuilder(initPayload));
+        }
         return Json.createObjectBuilder()
                 .add("type", "connection_init")
+                .addAll(payloadBuilder)
                 .build();
     }
 

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
@@ -53,7 +53,9 @@ public class GraphQLWSSubprotocolHandler implements WebSocketSubprotocolHandler 
     public GraphQLWSSubprotocolHandler(WebSocket webSocket, Integer subscriptionInitializationTimeout,
             Map<String, Object> initPayload, Runnable onClose) {
         this.initPayload = new HashMap<>();
-        this.initPayload.putAll(initPayload);
+        if (initPayload != null) {
+            this.initPayload.putAll(initPayload);
+        }
         this.webSocket = webSocket;
         this.subscriptionInitializationTimeout = subscriptionInitializationTimeout;
         this.uniOperations = new ConcurrentHashMap<>();

--- a/client/implementation-vertx/src/test/java/io/smallrye/graphql/client/vertx/test/SubscriptionInitializationTimeoutTest.java
+++ b/client/implementation-vertx/src/test/java/io/smallrye/graphql/client/vertx/test/SubscriptionInitializationTimeoutTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.graphql.client.vertx.test;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -31,6 +32,7 @@ public class SubscriptionInitializationTimeoutTest {
         try {
             DynamicGraphQLClient client = new VertxDynamicGraphQLClientBuilder()
                     .subprotocols(WebsocketSubprotocol.GRAPHQL_TRANSPORT_WS)
+                    .initPayload(Map.of("token", "secret"))
                     .websocketInitializationTimeout(100)
                     .url("http://localhost:" + server.actualPort())
                     .build();

--- a/client/implementation-vertx/src/test/java/io/smallrye/graphql/client/vertx/test/SubscriptionInitializationTimeoutTest.java
+++ b/client/implementation-vertx/src/test/java/io/smallrye/graphql/client/vertx/test/SubscriptionInitializationTimeoutTest.java
@@ -1,7 +1,6 @@
 package io.smallrye.graphql.client.vertx.test;
 
 import java.time.Duration;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -32,7 +31,6 @@ public class SubscriptionInitializationTimeoutTest {
         try {
             DynamicGraphQLClient client = new VertxDynamicGraphQLClientBuilder()
                     .subprotocols(WebsocketSubprotocol.GRAPHQL_TRANSPORT_WS)
-                    .initPayload(Map.of("token", "secret"))
                     .websocketInitializationTimeout(100)
                     .url("http://localhost:" + server.actualPort())
                     .build();

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/GraphQLClientConfiguration.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/GraphQLClientConfiguration.java
@@ -260,6 +260,11 @@ public class GraphQLClientConfiguration {
         } else if (other.headers != null) {
             other.headers.forEach((key, value) -> this.headers.put(key, value));
         }
+        if (this.initPayload == null) {
+            this.initPayload = other.initPayload;
+        } else if (other.initPayload != null) {
+            other.initPayload.forEach((key, value) -> this.initPayload.put(key, value));
+        }
         if (this.websocketSubprotocols == null) {
             this.websocketSubprotocols = other.websocketSubprotocols;
         } else if (other.websocketSubprotocols != null) {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/GraphQLClientConfiguration.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/GraphQLClientConfiguration.java
@@ -24,6 +24,11 @@ public class GraphQLClientConfiguration {
     private Map<String, String> headers;
 
     /**
+     * Additional payload sent on subscription initialization.
+     */
+    private Map<String, Object> initPayload;
+
+    /**
      * Names of websocket subprotocols that this client will understand. The actual subprotocol to be used
      * will be subject to negotiation with the server.
      */
@@ -117,6 +122,14 @@ public class GraphQLClientConfiguration {
 
     public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
+    }
+
+    public Map<String, Object> getInitPayload() {
+        return initPayload;
+    }
+
+    public void setInitPayload(Map<String, Object> initPayload) {
+        this.initPayload = initPayload;
     }
 
     public List<String> getWebsocketSubprotocols() {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/GraphQLClientsConfiguration.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/GraphQLClientsConfiguration.java
@@ -76,6 +76,7 @@ public class GraphQLClientsConfiguration {
         // HTTP headers
         configuration.setHeaders(getConfiguredHeaders(clientName, mpConfig));
 
+        configuration.setInitPayload(getConfiguredInitPayload(clientName, mpConfig));
         // websocket subprotocols
         Optional<String[]> subprotocolList = mpConfig.getOptionalValue(clientName + "/mp-graphql/subprotocols",
                 String[].class);
@@ -162,9 +163,21 @@ public class GraphQLClientsConfiguration {
 
     /** All headers that where configured via MP Config, e.g. <code>xxx/mp-graphql/header/yyy = zzz</code> */
     public static Map<String, String> getConfiguredHeaders(String configKey, Config config) {
+        String prefix = configKey + "/mp-graphql/header/";
+        return extractMapOfString(config, prefix);
+    }
+
+    /** All headers that where configured via MP Config, e.g. <code>xxx/mp-graphql/initPayload/yyy = zzz</code> */
+    public static Map<String, Object> getConfiguredInitPayload(String configKey, Config config) {
+        Map<String, Object> map = new HashMap<>();
+        String prefix = configKey + "/mp-graphql/initPayload/";
+        map.putAll(extractMapOfString(config, prefix));
+        return map;
+    }
+
+    private static Map<String, String> extractMapOfString(Config config, String prefix) {
         Map<String, String> map = new HashMap<>();
         for (String propertyName : config.getPropertyNames()) {
-            String prefix = configKey + "/mp-graphql/header/";
             if (!propertyName.startsWith(prefix)) {
                 continue;
             }

--- a/docs/client_configuration.md
+++ b/docs/client_configuration.md
@@ -22,3 +22,4 @@ See [Quarkus Documentation](https://quarkus.io/guides/all-config#quarkus-smallry
 | `CLIENT_NAME/mp-graphql/maxRedirects` | 16  | Max number of redirects to follow. Set to 0 to disable redirects. |
 | `CLIENT_NAME/mp-graphql/websocketInitializationTimeout` | none  |  Maximum time in milliseconds that will be allowed to wait for the server to acknowledge a websocket connection. |
 | `CLIENT_NAME/mp-graphql/runSingleOperationsOverWebsocket` | `false`  |  If true, then queries and mutations will run over the websocket transport rather than pure HTTP. Off by default, because it has higher overhead. |
+| `CLIENT_NAME/mp-graphql/initPayload/KEY` | none  | Adds a property named `KEY` to the connect_init message payload when negotiating a subscription. All values will be treated as string. For other types instatiate the API with the builder. |

--- a/docs/client_configuration.md
+++ b/docs/client_configuration.md
@@ -22,4 +22,4 @@ See [Quarkus Documentation](https://quarkus.io/guides/all-config#quarkus-smallry
 | `CLIENT_NAME/mp-graphql/maxRedirects` | 16  | Max number of redirects to follow. Set to 0 to disable redirects. |
 | `CLIENT_NAME/mp-graphql/websocketInitializationTimeout` | none  |  Maximum time in milliseconds that will be allowed to wait for the server to acknowledge a websocket connection. |
 | `CLIENT_NAME/mp-graphql/runSingleOperationsOverWebsocket` | `false`  |  If true, then queries and mutations will run over the websocket transport rather than pure HTTP. Off by default, because it has higher overhead. |
-| `CLIENT_NAME/mp-graphql/initPayload/KEY` | none  | Adds a property named `KEY` to the connect_init message payload when negotiating a subscription. All values will be treated as string. For other types instatiate the API with the builder. |
+| `CLIENT_NAME/mp-graphql/initPayload/KEY` | none  | Adds a property named `KEY` to the `connection_init` message payload when negotiating a websocket connection. All values will be treated as string. For other types instatiate the API with the builder. |


### PR DESCRIPTION
Adding optional payload to the `connection_init` message, only on `graphql-transport-ws` sub protocol. Solving #1587. 

Usage: 

```
DynamicGraphQLClientBuilder.newBuilder()
        .websocketInitializationTimeout(5000)
        .initPayload(Map.of("token", "secret"))
        .url("wss://some.url")
        .build();
```


Tested in quarkus main branch with settings after adding the initPayload to the `GraphQLClientConfig` and necessary changes 
```
quarkus.smallrye-graphql-client."my-client".url=${url}
quarkus.smallrye-graphql-client."my-client".initPayload.token=${token}
```
Signed-off-by: Max Gabrielsson <max.gabrielsson@gmail.com>