### PR TITLE
Support receiving the global Vertx instance as a static field

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/VertxManager.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/VertxManager.java
@@ -1,0 +1,75 @@
+package io.smallrye.graphql.client.vertx;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+public class VertxManager {
+
+    private static volatile Vertx globalInstance;
+    private static volatile Vertx customInstance;
+
+    private static final Logger log = Logger.getLogger(VertxManager.class);
+
+    /**
+     * The priority where to obtain a Vert.x instance:
+     * 1. The instance passed by the user to the client builder (not handled by this class)
+     * 2. The global Vertx instance that was set by calling `setFromGlobal`
+     * 3. Attempt to locate Vertx using the current thread context
+     * 4. Create our own custom instance (in case that multiple clients fall
+     * through into here, use only one instance for all)
+     */
+    public static Vertx get() {
+        // case 2
+        if (globalInstance != null) {
+            log.debug("Using the global Vert.x instance");
+            return globalInstance;
+        }
+
+        // case 3
+        Vertx fromContext = getFromContext();
+        if (fromContext != null) {
+            log.debug("Using Vert.x instance " + fromContext.toString() + " found in the context");
+            return fromContext;
+        }
+
+        // case 4
+        return getOrCreateCustom();
+    }
+
+    public static void setFromGlobal(Vertx vertx) {
+        globalInstance = vertx;
+    }
+
+    public static Future<Void> closeCustomInstance() {
+        if (customInstance != null) {
+            return customInstance.close();
+        } else {
+            return Future.succeededFuture();
+        }
+    }
+
+    private static Vertx getFromContext() {
+        Context vertxContext = Vertx.currentContext();
+        if (vertxContext != null && vertxContext.owner() != null) {
+            return vertxContext.owner();
+        } else {
+            return null;
+        }
+    }
+
+    private static Vertx getOrCreateCustom() {
+        if (customInstance == null) {
+            synchronized (VertxManager.class) {
+                if (customInstance == null) {
+                    customInstance = Vertx.vertx();
+                }
+            }
+        }
+        log.debug("Using custom Vert.x instance " + customInstance.toString());
+        return customInstance;
+    }
+
+}

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClientBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClientBuilder.java
@@ -11,8 +11,8 @@ import io.smallrye.graphql.client.impl.GraphQLClientConfiguration;
 import io.smallrye.graphql.client.impl.GraphQLClientsConfiguration;
 import io.smallrye.graphql.client.impl.SmallRyeGraphQLClientMessages;
 import io.smallrye.graphql.client.vertx.VertxClientOptionsHelper;
+import io.smallrye.graphql.client.vertx.VertxManager;
 import io.smallrye.graphql.client.websocket.WebsocketSubprotocol;
-import io.vertx.core.Context;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
@@ -128,18 +128,7 @@ public class VertxDynamicGraphQLClientBuilder implements DynamicGraphQLClientBui
                 throw ErrorMessageProvider.get().urlMissingErrorForNamedClient(configKey);
             }
         }
-        Vertx toUseVertx;
-        if (vertx != null) {
-            toUseVertx = vertx;
-        } else {
-            Context vertxContext = Vertx.currentContext();
-            if (vertxContext != null && vertxContext.owner() != null) {
-                toUseVertx = vertxContext.owner();
-            } else {
-                // create a new vertx instance if there is none
-                toUseVertx = Vertx.vertx();
-            }
-        }
+        Vertx toUseVertx = vertx != null ? vertx : VertxManager.get();
         if (subprotocols == null || subprotocols.isEmpty()) {
             subprotocols = new ArrayList<>(EnumSet.of(WebsocketSubprotocol.GRAPHQL_TRANSPORT_WS));
         }

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientBuilder.java
@@ -20,8 +20,8 @@ import io.smallrye.graphql.client.impl.typesafe.reflection.MethodInvocation;
 import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
 import io.smallrye.graphql.client.typesafe.api.TypesafeGraphQLClientBuilder;
 import io.smallrye.graphql.client.vertx.VertxClientOptionsHelper;
+import io.smallrye.graphql.client.vertx.VertxManager;
 import io.smallrye.graphql.client.websocket.WebsocketSubprotocol;
-import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
@@ -29,7 +29,6 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 public class VertxTypesafeGraphQLClientBuilder implements TypesafeGraphQLClientBuilder {
-    private static Vertx VERTX;
 
     private static final Logger log = Logger.getLogger(VertxTypesafeGraphQLClientBuilder.class);
 
@@ -178,19 +177,7 @@ public class VertxTypesafeGraphQLClientBuilder implements TypesafeGraphQLClientB
     }
 
     private Vertx vertx() {
-        if (vertx == null) {
-            Context vertxContext = Vertx.currentContext();
-            if (vertxContext != null && vertxContext.owner() != null) {
-                vertx = vertxContext.owner();
-            } else {
-                // create a new vertx instance if there is none
-                if (VERTX == null) {
-                    VERTX = Vertx.vertx();
-                }
-                vertx = VERTX;
-            }
-        }
-        return vertx;
+        return vertx != null ? vertx : VertxManager.get();
     }
 
     private Object invoke(VertxTypesafeGraphQLClientProxy graphQlClient, java.lang.reflect.Method method,


### PR DESCRIPTION
This is the smallrye-side part of the fix for https://github.com/quarkusio/quarkus/issues/28875 

The idea is that a Quarkus recorder will call `VertxManager.setFromGlobal()` providing the global Vertx instance, as can be seen in the WIP branch: https://github.com/jmartisk/quarkus/commit/50b81637ddd1d6634874a643755133fb7700be75

GraphQL clients that are built will then prefer to use that static instance instead of looking into the thread context, which might not be set if the client is built on non-HTTP-related threads (Quartz, CDI startup event handler,...)

