### PR TITLE
add the cdi extension service file also with the `jakarta` package name

### DIFF
--- a/client/implementation/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/client/implementation/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+io.smallrye.graphql.client.impl.typesafe.cdi.TypesafeGraphQLClientExtension


### PR DESCRIPTION
This is necessary for the client CDI extension to work with Jakarta 9+