### PR TITLE
Disable asyncDns and caching when the client library initializes its …

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/VertxManager.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/VertxManager.java
@@ -5,6 +5,9 @@ import org.jboss.logging.Logger;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.file.FileSystemOptions;
+import io.vertx.core.spi.resolver.ResolverProvider;
 
 public class VertxManager {
 
@@ -64,7 +67,17 @@ public class VertxManager {
         if (customInstance == null) {
             synchronized (VertxManager.class) {
                 if (customInstance == null) {
-                    customInstance = Vertx.vertx();
+                    // when creating our own vert.x instance, we don't allow
+                    // explicitly configuring it, but it should be reasonable
+                    // to disable caching and the async DNS resolver
+                    if (!System.getProperties().contains(ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME)) {
+                        System.setProperty(ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME, "true");
+                    }
+                    FileSystemOptions fso = new FileSystemOptions();
+                    fso.setFileCachingEnabled(false);
+                    VertxOptions options = new VertxOptions();
+                    options.setFileSystemOptions(fso);
+                    customInstance = Vertx.vertx(options);
                 }
             }
         }


### PR DESCRIPTION
…own vert.x instance

Fixes https://github.com/smallrye/smallrye-graphql/issues/1607