### PR TITLE
#1616: make ErrorExtensionProvider a singleton

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ErrorExtensionProviders.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ErrorExtensionProviders.java
@@ -1,0 +1,28 @@
+package io.smallrye.graphql.execution.error;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.smallrye.graphql.api.ErrorExtensionProvider;
+
+/**
+ * All ErrorExtensionProvider holder
+ *
+ * @author Pipinet (pipinet@vip.qq.com)
+ */
+public class ErrorExtensionProviders {
+    private final List<ErrorExtensionProvider> providers;
+
+    protected ErrorExtensionProviders() {
+        this.providers = ServiceLoader.load(ErrorExtensionProvider.class)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .collect(Collectors.toList());
+    }
+
+    protected Stream<ErrorExtensionProvider> get() {
+        return providers.stream();
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExecutionErrorsService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExecutionErrorsService.java
@@ -4,7 +4,6 @@ import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.ServiceLoader;
 
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -22,7 +21,6 @@ import javax.json.bind.JsonbConfig;
 import graphql.ExceptionWhileDataFetching;
 import graphql.GraphQLError;
 import graphql.validation.ValidationError;
-import io.smallrye.graphql.api.ErrorExtensionProvider;
 import io.smallrye.graphql.spi.config.Config;
 
 /**
@@ -37,6 +35,7 @@ public class ExecutionErrorsService {
     private static final Jsonb JSONB = JsonbBuilder.create(new JsonbConfig()
             .withNullValues(Boolean.TRUE)
             .withFormatting(Boolean.TRUE));
+    private static final ErrorExtensionProviders ERROR_EXTENSION_PROVIDERS = new ErrorExtensionProviders();
 
     private final Config config = Config.get();
 
@@ -100,7 +99,7 @@ public class ExecutionErrorsService {
     }
 
     private void addErrorExtensions(JsonObjectBuilder objectBuilder, Throwable exception) {
-        ServiceLoader.load(ErrorExtensionProvider.class)
+        ERROR_EXTENSION_PROVIDERS.get()
                 .forEach(provider -> addKeyValue(objectBuilder, provider.getKey(), provider.mapValueFrom(exception)));
     }
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExecutionErrorsService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExecutionErrorsService.java
@@ -35,7 +35,8 @@ public class ExecutionErrorsService {
     private static final Jsonb JSONB = JsonbBuilder.create(new JsonbConfig()
             .withNullValues(Boolean.TRUE)
             .withFormatting(Boolean.TRUE));
-    private static final ErrorExtensionProviders ERROR_EXTENSION_PROVIDERS = new ErrorExtensionProviders();
+
+    private final ErrorExtensionProviders errorExtensionProviders = new ErrorExtensionProviders();
 
     private final Config config = Config.get();
 
@@ -99,7 +100,7 @@ public class ExecutionErrorsService {
     }
 
     private void addErrorExtensions(JsonObjectBuilder objectBuilder, Throwable exception) {
-        ERROR_EXTENSION_PROVIDERS.get()
+        errorExtensionProviders.get()
                 .forEach(provider -> addKeyValue(objectBuilder, provider.getKey(), provider.mapValueFrom(exception)));
     }
 

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/error/ErrorExtensionProvidersTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/error/ErrorExtensionProvidersTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.graphql.execution.error;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,8 +21,8 @@ public class ErrorExtensionProvidersTest {
 
         Assertions.assertThat(result1.size()).isEqualTo(3);
         assertEquals(result1.size(), result2.size());
-        assertTrue(result1.get(0) == result2.get(0));
-        assertTrue(result1.get(1) == result2.get(1));
-        assertTrue(result1.get(2) == result2.get(2));
+        assertSame(result1.get(0), result2.get(0));
+        assertSame(result1.get(1), result2.get(1));
+        assertSame(result1.get(2), result2.get(2));
     }
 }

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/error/ErrorExtensionProvidersTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/error/ErrorExtensionProvidersTest.java
@@ -1,0 +1,28 @@
+package io.smallrye.graphql.execution.error;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.graphql.api.ErrorExtensionProvider;
+
+public class ErrorExtensionProvidersTest {
+    private final ErrorExtensionProviders providers = new ErrorExtensionProviders();
+
+    @Test
+    void should_get_same_instance() {
+        List<ErrorExtensionProvider> result1 = providers.get().collect(Collectors.toList());
+        List<ErrorExtensionProvider> result2 = providers.get().collect(Collectors.toList());
+
+        Assertions.assertThat(result1.size()).isEqualTo(3);
+        assertEquals(result1.size(), result2.size());
+        assertTrue(result1.get(0) == result2.get(0));
+        assertTrue(result1.get(1) == result2.get(1));
+        assertTrue(result1.get(2) == result2.get(2));
+    }
+}


### PR DESCRIPTION
backport of https://github.com/smallrye/smallrye-graphql/pull/1617 to 1.8.x