### PR TITLE
Remove antlr dependency, it is shaded inside graphql-java

### DIFF
--- a/client/generator/pom.xml
+++ b/client/generator/pom.xml
@@ -66,11 +66,6 @@
             <artifactId>graphql-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-            <version>4.9.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
backport of https://github.com/smallrye/smallrye-graphql/pull/1626/ to 1.9