### PR TITLE
Upgrade to Mutiny 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,8 @@
         <version.smallrye-config>3.1.0</version.smallrye-config>
         <version.smallrye.metrics>4.0.0</version.smallrye.metrics>
         <version.smallrye-common>2.0.0</version.smallrye-common>
-        <version.smallrye-mutiny>1.7.0</version.smallrye-mutiny>
+        <version.smallrye-mutiny>2.0.0</version.smallrye-mutiny>
+        <version.smallrye-mutiny-zero>1.0.0</version.smallrye-mutiny-zero>
         <version.smallrye-context-propagation>2.0.0</version.smallrye-context-propagation>
         <version.smallrye-stork>1.3.3</version.smallrye-stork>
         <version.opentracing>0.33.0</version.opentracing>
@@ -198,6 +199,12 @@
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>mutiny</artifactId>
                 <version>${version.smallrye-mutiny}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>mutiny-zero-flow-adapters</artifactId>
+                <version>${version.smallrye-mutiny-zero}</version>
             </dependency>
 
             <dependency>

--- a/server/implementation/pom.xml
+++ b/server/implementation/pom.xml
@@ -58,6 +58,10 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny-zero-flow-adapters</artifactId>
+        </dependency>
 
         <!-- Logging -->
         <dependency>

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/DataFetcherFactory.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/DataFetcherFactory.java
@@ -88,10 +88,10 @@ public class DataFetcherFactory {
             return (V) getCompletionStageDataFetcher(operation, type);
         } else if (isMutinyUni(operation)) {
             return (V) getUniDataFetcher(operation, type);
-        } else if (isPublisher(operation)) {
-            return (V) getPublisherDataFetcher(operation, type);
         } else if (isMutinyMulti(operation)) {
             return (V) getMultiDataFetcher(operation, type);
+        } else if (isPublisher(operation)) {
+            return (V) getPublisherDataFetcher(operation, type);
         } else if (isWrapped(operation)) {
             return (V) getOtherWrappedDataFetcher(operation, type);
         }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractStreamingDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractStreamingDataFetcher.java
@@ -15,6 +15,7 @@ import io.smallrye.graphql.schema.model.Type;
 import io.smallrye.graphql.transformation.AbstractDataFetcherException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 /**
  * Handle Stream calls with Multi, used as base for Multi and Publisher
@@ -37,9 +38,7 @@ public abstract class AbstractStreamingDataFetcher<K, T> extends AbstractDataFet
             DataFetcherResult.Builder<Object> resultBuilder,
             Object[] transformedArguments) throws Exception {
 
-        Multi<?> multi = handleUserMethodCall(dfe, transformedArguments);
-
-        return (O) multi
+        Multi<?> multi = handleUserMethodCall(dfe, transformedArguments)
                 .onItem().transform((t) -> {
                     try {
                         Object resultFromTransform = fieldHelper.transformOrAdaptResponse(t, dfe);
@@ -69,6 +68,8 @@ public abstract class AbstractStreamingDataFetcher<K, T> extends AbstractDataFet
                         return (O) resultBuilder.build();
                     }
                 });
+
+        return (O) AdaptersToReactiveStreams.publisher(multi);
 
     }
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/MultiDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/MultiDataFetcher.java
@@ -2,10 +2,13 @@ package io.smallrye.graphql.execution.datafetcher;
 
 import java.util.List;
 
+import org.reactivestreams.Publisher;
+
 import graphql.schema.DataFetchingEnvironment;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Type;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 /**
  * Handle Stream calls with Multi
@@ -23,11 +26,13 @@ public class MultiDataFetcher<K, T> extends AbstractStreamingDataFetcher<K, T> {
     @Override
     protected Multi<?> handleUserMethodCall(DataFetchingEnvironment dfe, final Object[] transformedArguments)
             throws Exception {
-        return (Multi<?>) operationInvoker.invoke(transformedArguments);
+        Publisher<?> rsPub = operationInvoker.invoke(transformedArguments);
+        return (Multi<?>) AdaptersToFlow.publisher(rsPub);
     }
 
     @Override
     protected Multi<List<T>> handleUserBatchLoad(DataFetchingEnvironment dfe, final Object[] arguments) throws Exception {
-        return (Multi<List<T>>) operationInvoker.invoke(arguments);
+        Publisher<?> rsPub = operationInvoker.invoke(arguments);
+        return (Multi<List<T>>) AdaptersToFlow.publisher(rsPub);
     }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/PublisherDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/PublisherDataFetcher.java
@@ -8,6 +8,7 @@ import graphql.schema.DataFetchingEnvironment;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Type;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 /**
  * Handle Stream calls with Publisher
@@ -26,12 +27,12 @@ public class PublisherDataFetcher<K, T> extends AbstractStreamingDataFetcher<K, 
     protected Multi<?> handleUserMethodCall(DataFetchingEnvironment dfe, final Object[] transformedArguments)
             throws Exception {
         Publisher<?> publisher = operationInvoker.invoke(transformedArguments);
-        return (Multi<?>) Multi.createFrom().publisher(publisher);
+        return (Multi<?>) Multi.createFrom().publisher(AdaptersToFlow.publisher(publisher));
     }
 
     @Override
     protected Multi<List<T>> handleUserBatchLoad(DataFetchingEnvironment dfe, final Object[] arguments) throws Exception {
         Publisher<List<T>> publisher = operationInvoker.invoke(arguments);
-        return (Multi<List<T>>) Multi.createFrom().publisher(publisher);
+        return (Multi<List<T>>) Multi.createFrom().publisher(AdaptersToFlow.publisher(publisher));
     }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ReflectionInvoker.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ReflectionInvoker.java
@@ -23,6 +23,7 @@ import io.smallrye.graphql.spi.LookupService;
 import io.smallrye.graphql.spi.ManagedInstance;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 /**
  * Invoke methods using reflection
@@ -95,9 +96,11 @@ public class ReflectionInvoker {
                     operationInstance.destroyIfNecessary();
                 });
             } else if (result instanceof Multi) {
-                return (T) ((Multi) result).onTermination().invoke(() -> {
+                Multi multi = (Multi) result;
+                multi = multi.onTermination().invoke(() -> {
                     operationInstance.destroyIfNecessary();
                 });
+                return (T) AdaptersToReactiveStreams.publisher(multi);
             } else {
                 operationInstance.destroyIfNecessary();
                 return result;

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/subscription/api/StocksApi.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/subscription/api/StocksApi.java
@@ -9,6 +9,7 @@ import org.reactivestreams.Publisher;
 
 import io.smallrye.graphql.api.Subscription;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @GraphQLApi
 public class StocksApi {
@@ -29,7 +30,7 @@ public class StocksApi {
     @Subscription
     @Description("Get stock quote changes as they happen using Mutiny")
     public Multi<Stock> getStockQuoteMulti(String stockCode) {
-        return Multi.createFrom().publisher(getStockQuotePublisher(stockCode));
+        return Multi.createFrom().publisher(AdaptersToFlow.publisher(getStockQuotePublisher(stockCode)));
     }
 
     @Subscription("listSubscription")


### PR DESCRIPTION
Adapters between legacy Reactive Streams APIs and JDK Flow are introduced as Mutiny 2 is now based on Flow, and `graphql-java` is currently stuck in Java 8 land.