### PR TITLE
activate test

### DIFF
--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/NonNullHelperTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/helper/NonNullHelperTest.java
@@ -39,21 +39,20 @@ public class NonNullHelperTest {
 
         assertTrue(NonNullHelper.markAsNonNull(type, annotationsForMethod));
     }
-    //todo after jandex 3 is used this should work
-    /*
-     * @Test
-     * public void testNonNullStringKotlin() throws Exception {
-     * Index complete = IndexCreator.index(AsyncApi.class);
-     * 
-     * ClassInfo classByName = complete.getClassByName(DotName.createSimple(AsyncApi.class.getName()));
-     * MethodInfo nonNullString = classByName.method("nonNullStringKotlin");
-     * Type type = nonNullString.returnType();
-     * 
-     * Annotations annotationsForMethod = Annotations.getAnnotationsForMethod(nonNullString);
-     * 
-     * assertTrue(NonNullHelper.markAsNonNull(type, annotationsForMethod));
-     * }
-     */
+
+    @Test
+    public void testNonNullStringKotlin() throws Exception {
+        Index complete = IndexCreator.index(AsyncApi.class);
+        ScanningContext.register(complete);
+
+        ClassInfo classByName = complete.getClassByName(DotName.createSimple(AsyncApi.class.getName()));
+        MethodInfo nonNullString = classByName.method("nonNullStringKotlin");
+        Type type = nonNullString.returnType();
+
+        Annotations annotationsForMethod = Annotations.getAnnotationsForMethod(nonNullString);
+
+        assertTrue(NonNullHelper.markAsNonNull(type, annotationsForMethod));
+    }
 
     @Test
     public void testNullableString() throws Exception {


### PR DESCRIPTION
When we merged the change for kotlin notnull, jandex did not support it. Now it is supported and we can activate the test.