### PR TITLE
graphql/client: Fix variable JSON serialization for bool/null

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
@@ -62,6 +62,10 @@ public class RequestImpl implements Request {
                 varBuilder.add(k, (Integer) v);
             } else if (v instanceof JsonValue) {
                 varBuilder.add(k, (JsonValue) v);
+            } else if (v instanceof Boolean) {
+                varBuilder.add(k, (Boolean) v);
+            } else if (v == null) {
+                varBuilder.addNull(k);
             } else {
                 try (Jsonb jsonb = JsonbBuilder.create()) {
                     JsonStructure struct = ((JsonBinding) jsonb).toJsonStructure(v);

--- a/client/implementation/src/test/java/io/smallrye/graphql/client/RequestImplTest.java
+++ b/client/implementation/src/test/java/io/smallrye/graphql/client/RequestImplTest.java
@@ -1,0 +1,47 @@
+package io.smallrye.graphql.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.graphql.client.impl.RequestImpl;
+
+/**
+ * Validates the JSON serialization of the query and variables in a RequestImpl
+ * <p>
+ * See https://github.com/smallrye/smallrye-graphql/issues/1704
+ */
+public class RequestImplTest {
+    @Test
+    public void testPrimitiveTypesToJson() {
+        RequestImpl request = new RequestImpl("example");
+
+        request.setVariable("key", 5);
+        assertEquals("{\"query\":\"example\",\"variables\":{\"key\":5}}", request.toJson());
+
+        request.setVariable("key", true);
+        assertEquals("{\"query\":\"example\",\"variables\":{\"key\":true}}", request.toJson());
+
+        request.setVariable("key", null);
+        assertEquals("{\"query\":\"example\",\"variables\":{\"key\":null}}", request.toJson());
+
+        request.setVariable("key", "foo");
+        assertEquals("{\"query\":\"example\",\"variables\":{\"key\":\"foo\"}}", request.toJson());
+    }
+
+    @Test
+    public void testComplexTypesToJson() {
+        RequestImpl request = new RequestImpl("example");
+
+        int[] arr = { 1, 2 };
+        request.setVariable("key", arr);
+        assertEquals("{\"query\":\"example\",\"variables\":{\"key\":[1,2]}}", request.toJson());
+
+        HashMap<String, int[]> map = new HashMap<String, int[]>();
+        map.put("ids", arr);
+        request.setVariable("key", map);
+        assertEquals("{\"query\":\"example\",\"variables\":{\"key\":{\"ids\":[1,2]}}}", request.toJson());
+    }
+}


### PR DESCRIPTION
As discussed in #1704, the GraphQL client currently drops boolean and null variable values due to a bug in the JSON serialization of the variables:

```kotlin
    val r = RequestImpl("foo")
    r.setVariables(mapOf("int" to 1, "str" to "bar", "bool" to true, "null" to null))
    println(r.variables)
    println(r.toJsonObject())
```

Prints:

```
{int=1, str=bar, bool=true, null=null}
{"query":"foo","variables":{"int":1,"str":"bar"}}
```

This patch should fix the issue by updating the JSON serialization routine to add boolean and null types. It also adds a unit test to verify it works as expected.

Closes smallrye/smallrye-graphql#1704

---

Note: I'm pretty new to the java landscape, so the formatting might be a bit off (default IntelliJ) and/or the test might not follow best practices--all feedback welcome!

Thanks again!