### PR TITLE
Add multi-module support to Maven plugin

### DIFF
--- a/tools/maven-plugin-tests/src/test/java/io/smallrye/graphql/mavenplugin/test/GenerateSchemaTest.java
+++ b/tools/maven-plugin-tests/src/test/java/io/smallrye/graphql/mavenplugin/test/GenerateSchemaTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 public class GenerateSchemaTest {
 
     private final Path SCHEMA_FILE_PATH = Paths.get("testing-project", "target", "generated", "schema.graphql");
+    private final Path SCHEMA_FILE_PATH_MULTI_MODULE = Paths.get("testing-project-multi-module", "api", "target", "generated",
+            "schema.graphql");
 
     @Before
     public void before() {
@@ -69,6 +71,26 @@ public class GenerateSchemaTest {
         String schema = execute(Collections.singletonMap("typeAutoNameStrategy", "Full"));
         assertThat("Fully qualified class names should be used for GraphQL types",
                 schema, containsString("type org_acme_Foo"));
+    }
+
+    @Test
+    public void testMultiModuleProject() throws Exception {
+        SCHEMA_FILE_PATH_MULTI_MODULE.toFile().delete();
+
+        Verifier verifier = new Verifier(new File("testing-project-multi-module").getAbsolutePath());
+        verifier.setSystemProperty("plugin.version", System.getProperty("plugin.version"));
+
+        List<String> goals = new ArrayList<>();
+        goals.add("clean");
+        goals.add("package");
+        goals.add("process-classes");
+        verifier.executeGoals(goals);
+
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog("Wrote the schema to ");
+
+        Assert.assertTrue("File " + SCHEMA_FILE_PATH_MULTI_MODULE.toAbsolutePath() + " expected but not found",
+                SCHEMA_FILE_PATH_MULTI_MODULE.toFile().exists());
     }
 
     private String execute(Map<String, String> properties) throws VerificationException, IOException {

--- a/tools/maven-plugin-tests/testing-project-multi-module/api/pom.xml
+++ b/tools/maven-plugin-tests/testing-project-multi-module/api/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>smallrye-graphql-maven-plugin-mock-project-multi-module-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <name>SmallRye: GraphQL Maven plugin tests :: Mock project Multi Module 1</name>
+    <description>Mock project for testing the Maven plugin</description>
+
+    <artifactId>smallrye-graphql-maven-plugin-mock-project-multi-module-1</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>smallrye-graphql-maven-plugin-mock-project-multi-module-2</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-graphql-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-schema</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includeDependencies>true</includeDependencies>
+                    <includeDependenciesGroupIds>org.acme</includeDependenciesGroupIds>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/maven-plugin-tests/testing-project-multi-module/api/src/main/java/org/acme/TestingApi.java
+++ b/tools/maven-plugin-tests/testing-project-multi-module/api/src/main/java/org/acme/TestingApi.java
@@ -1,0 +1,20 @@
+package org.acme;
+
+import org.acme.model.Foo;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+import java.util.Collections;
+import java.util.List;
+
+@GraphQLApi
+class TestingApi {
+
+    @Query
+    public Foo getFoo() {
+        return null;
+    }
+
+
+}

--- a/tools/maven-plugin-tests/testing-project-multi-module/model/pom.xml
+++ b/tools/maven-plugin-tests/testing-project-multi-module/model/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>smallrye-graphql-maven-plugin-mock-project-multi-module-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <name>SmallRye: GraphQL Maven plugin tests :: Mock project Multi Module 2</name>
+    <description>Mock project for testing the Maven plugin</description>
+
+    <artifactId>smallrye-graphql-maven-plugin-mock-project-multi-module-2</artifactId>
+    <packaging>jar</packaging>
+
+</project>

--- a/tools/maven-plugin-tests/testing-project-multi-module/model/src/main/java/org/acme/model/Foo.java
+++ b/tools/maven-plugin-tests/testing-project-multi-module/model/src/main/java/org/acme/model/Foo.java
@@ -1,0 +1,15 @@
+package org.acme.model;
+
+
+public class Foo {
+
+    private Integer number;
+
+    public Integer getNumber() {
+        return number;
+    }
+
+    public void setNumber(Integer number) {
+        this.number = number;
+    }
+}

--- a/tools/maven-plugin-tests/testing-project-multi-module/pom.xml
+++ b/tools/maven-plugin-tests/testing-project-multi-module/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>SmallRye: GraphQL Maven plugin tests :: Mock project Multi Module Parent</name>
+    <description>Mock project for testing the Maven plugin</description>
+
+    <groupId>org.acme</groupId>
+    <artifactId>smallrye-graphql-maven-plugin-mock-project-multi-module-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+    </properties>
+
+    <modules>
+        <module>api</module>
+        <module>model</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql</artifactId>
+            <version>${plugin.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.smallrye</groupId>
+                    <artifactId>smallrye-graphql-maven-plugin</artifactId>
+                    <version>${plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/tools/maven-plugin/README.adoc
+++ b/tools/maven-plugin/README.adoc
@@ -29,6 +29,7 @@ The schema will appear as `target/generated/schema.graphql` by default.
 - `includeDependencies` - Scan project's dependencies for GraphQL model classes too. Off (false) by default.
 - `includeDependenciesScopes` - If the above `includeDependencies` is true, you can control what scopes should be included. Default is `compile, system`
 - `includeDependenciesTypes` - If the above `includeDependencies` is true, you can control what types should be included. Default is `jar`
+- `includeDependenciesGroupIds` - If the above `includeDependencies` is true, you can control which group ids should be included. Default is empty, which means all group ids.
 - `includeScalars` - Include scalars in the schema. Default false.
 - `includeDirectives` - Include directives in the schema. Default false.
 - `includeSchemaDefinition` - Include the schema definition. Default false.


### PR DESCRIPTION
The `smallrye-graphql-maven-plugin` breaks on multi-module projects:

* Without `includeDependencies` it won't find parts of the schema in other modules
* With `includeDependencies` it crashes, because it tries to index the module artifact as a `jar` (but it is a directory)

This PR adds support for multiple modules through the followin additions:

* If a dependency Artifact is not a jar but a dir, it's indexed it as a dir
* A new config setting `includeDependenciesGroupIds` allows filtering for group ids, to allow avoiding indexing all external dependencies.
* A test case 