### PR TITLE
fix #1714: use header name param also when not compiled with `-parameters`

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/MethodInvocation.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/MethodInvocation.java
@@ -62,6 +62,7 @@ public class MethodInvocation implements NamedElement {
         return OperationType.QUERY;
     }
 
+    @Override
     public String getName() {
         return queryName()
                 .orElseGet(() -> mutationName()
@@ -93,15 +94,12 @@ public class MethodInvocation implements NamedElement {
         return Optional.empty();
     }
 
+    @Override
     public String getRawName() {
         String name = method.getName();
         if (name.startsWith("get") && name.length() > 3 && Character.isUpperCase(name.charAt(3)))
             return Character.toLowerCase(name.charAt(3)) + name.substring(4);
         return name;
-    }
-
-    public boolean isRenamed() {
-        return !getName().equals(getRawName());
     }
 
     public TypeInfo getReturnType() {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/MethodInvocation.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/MethodInvocation.java
@@ -27,7 +27,7 @@ import io.smallrye.graphql.api.Subscription;
 import io.smallrye.graphql.client.core.OperationType;
 import io.smallrye.graphql.client.typesafe.api.Multiple;
 
-public class MethodInvocation {
+public class MethodInvocation implements NamedElement {
     public static MethodInvocation of(Method method, Object... args) {
         return new MethodInvocation(new TypeInfo(null, method.getDeclaringClass()), method, args);
     }
@@ -93,7 +93,7 @@ public class MethodInvocation {
         return Optional.empty();
     }
 
-    private String getRawName() {
+    public String getRawName() {
         String name = method.getName();
         if (name.startsWith("get") && name.length() > 3 && Character.isUpperCase(name.charAt(3)))
             return Character.toLowerCase(name.charAt(3)) + name.substring(4);

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/NamedElement.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/NamedElement.java
@@ -5,5 +5,7 @@ public interface NamedElement {
 
     String getRawName();
 
-    boolean isRenamed();
+    default boolean isRenamed() {
+        return !getName().equals(getRawName());
+    }
 }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/NamedElement.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/NamedElement.java
@@ -1,0 +1,9 @@
+package io.smallrye.graphql.client.impl.typesafe.reflection;
+
+public interface NamedElement {
+    String getName();
+
+    String getRawName();
+
+    boolean isRenamed();
+}

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/ParameterInfo.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/ParameterInfo.java
@@ -141,11 +141,6 @@ public class ParameterInfo implements NamedElement {
         return parameter.getName();
     }
 
-    @Override
-    public boolean isRenamed() {
-        return !getName().equals(getRawName());
-    }
-
     public <A extends Annotation> A[] getAnnotations(Class<A> type) {
         return parameter.getAnnotationsByType(type);
     }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/ParameterInfo.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/ParameterInfo.java
@@ -13,7 +13,7 @@ import org.eclipse.microprofile.graphql.NonNull;
 import io.smallrye.graphql.client.typesafe.api.Header;
 import io.smallrye.graphql.client.typesafe.api.NestedParameter;
 
-public class ParameterInfo {
+public class ParameterInfo implements NamedElement {
     private final MethodInvocation method;
     private final Parameter parameter;
     private final TypeInfo type;
@@ -124,6 +124,7 @@ public class ParameterInfo {
         return this.value;
     }
 
+    @Override
     public String getName() {
         if (parameter.isAnnotationPresent(Name.class))
             return parameter.getAnnotation(Name.class).value();
@@ -135,10 +136,12 @@ public class ParameterInfo {
         return getRawName();
     }
 
+    @Override
     public String getRawName() {
         return parameter.getName();
     }
 
+    @Override
     public boolean isRenamed() {
         return !getName().equals(getRawName());
     }


### PR DESCRIPTION
The logic for determining the header name was split between the `toHeaderName` method and the `HeaderDescriptor` class... I unified that.