### PR TITLE
issue-1739: Using io.smallrye.graphql.api.Adapter is cause of memory …

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/AbstractHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/AbstractHelper.java
@@ -399,7 +399,7 @@ public abstract class AbstractHelper {
     }
 
     private Integer getKey(String className, String methodName, List<String> parameterClasses) {
-        return Objects.hash(className, methodName, parameterClasses.toArray());
+        return Objects.hash(className, methodName, Arrays.hashCode(parameterClasses.toArray()));
     }
 
     /**


### PR DESCRIPTION
…leak

backport of https://github.com/smallrye/smallrye-graphql/pull/1740 to 2.0.x