### PR TITLE
issue-1739: Using io.smallrye.graphql.api.Adapter is cause of memory …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: quarkusio/quarkus
-          ref: main
+          ref: 2.16
           path: quarkus
 
       - name: Cache local Maven repository

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/AbstractHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/AbstractHelper.java
@@ -399,7 +399,7 @@ public abstract class AbstractHelper {
     }
 
     private Integer getKey(String className, String methodName, List<String> parameterClasses) {
-        return Objects.hash(className, methodName, parameterClasses.toArray());
+        return Objects.hash(className, methodName, Arrays.hashCode(parameterClasses.toArray()));
     }
 
     /**


### PR DESCRIPTION
…leak

backport of https://github.com/smallrye/smallrye-graphql/pull/1740 to 1.9.x