### PR TITLE
Change bean discovery mode to annotated in all beans.xml

### DIFF
--- a/client/implementation/src/main/resources/META-INF/beans.xml
+++ b/client/implementation/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/server/implementation-cdi/src/main/resources/META-INF/beans.xml
+++ b/server/implementation-cdi/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/server/implementation/src/main/resources/META-INF/beans.xml
+++ b/server/implementation/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/server/runner/src/main/resources/META-INF/beans.xml
+++ b/server/runner/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/server/runner/src/main/webapp/WEB-INF/beans.xml
+++ b/server/runner/src/main/webapp/WEB-INF/beans.xml
@@ -1,5 +1,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>


### PR DESCRIPTION
Follow up on the discussion in Quarkus issue https://github.com/quarkusio/quarkus/issues/31378#issuecomment-1446381954

In short, a Quarkus app using graphql now logs warnings because graphql artifacts contains `beans.xml` with discovery mode `all` which is unsupported in CDI Lite and in Quarkus/Arc.

I quick scanned the sub modules containing `beans.xml` and it seems that all classes meant to be beans already have bean defining annotations (although keep in mind I am very much unfamiliar with this project).
The change seems to pass all tests in this repo and shouldn't affect Quarkus (since even up until now, Arc treated these JARs as `annotated` anyway).
It would be nice to test this with some other container such as WFLY to see if we're good. @jmartisk what's the easiest way to verify that? Are there some WFLY tests we could run? If so, where can I find them?