### PR TITLE
(1.9.x backport) Fixed NPE when processing a invalid query

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -17,10 +17,8 @@ import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderFactory;
 import org.dataloader.DataLoaderRegistry;
 
-import graphql.ExecutionInput;
+import graphql.*;
 import graphql.ExecutionInput.Builder;
-import graphql.ExecutionResult;
-import graphql.GraphQL;
 import graphql.analysis.MaxQueryComplexityInstrumentation;
 import graphql.analysis.MaxQueryDepthInstrumentation;
 import graphql.execution.ExecutionId;
@@ -35,6 +33,7 @@ import io.smallrye.graphql.execution.context.SmallRyeContext;
 import io.smallrye.graphql.execution.context.SmallRyeContextManager;
 import io.smallrye.graphql.execution.datafetcher.helper.BatchLoaderHelper;
 import io.smallrye.graphql.execution.error.ExceptionHandler;
+import io.smallrye.graphql.execution.error.UnparseableDocumentException;
 import io.smallrye.graphql.execution.event.EventEmitter;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Schema;
@@ -150,9 +149,22 @@ public class ExecutionService {
                 }
 
                 ExecutionInput executionInput = executionBuilder.build();
-
                 // Context
-                smallRyeContext = SmallRyeContextManager.populateFromExecutionInput(executionInput, queryCache);
+                try {
+                    smallRyeContext = SmallRyeContextManager.populateFromExecutionInput(executionInput, queryCache);
+                } catch (UnparseableDocumentException ex) {
+                    GraphQLError error = GraphqlErrorBuilder
+                            .newError()
+                            .message("Unparseable input document")
+                            .build();
+                    ExecutionResult executionResult = ExecutionResultImpl
+                            .newExecutionResult()
+                            .addError(error)
+                            .build();
+                    ExecutionResponse executionResponse = new ExecutionResponse(executionResult);
+                    writer.write(executionResponse);
+                    return;
+                }
                 context.put(SmallRyeContextManager.CONTEXT, smallRyeContext);
                 executionInput.getGraphQLContext().putAll(context);
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContextManager.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/context/SmallRyeContextManager.java
@@ -30,6 +30,7 @@ import graphql.schema.GraphQLType;
 import graphql.schema.SelectedField;
 import io.smallrye.graphql.api.Context;
 import io.smallrye.graphql.execution.QueryCache;
+import io.smallrye.graphql.execution.error.UnparseableDocumentException;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Type;
@@ -250,6 +251,9 @@ public class SmallRyeContextManager {
 
         if (documentSupplier != null) {
             Document document = documentSupplier.get();
+            if (document == null) {
+                throw new UnparseableDocumentException();
+            }
             List<OperationDefinition> definitions = document.getDefinitionsOfType(OperationDefinition.class);
             for (OperationDefinition definition : definitions) {
                 String operationType = getOperationTypeFromDefinition(definition);

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/error/UnparseableDocumentException.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/error/UnparseableDocumentException.java
@@ -1,0 +1,5 @@
+package io.smallrye.graphql.execution.error;
+
+public class UnparseableDocumentException extends RuntimeException {
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/error/UnparseableDocumentTestCase.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/error/UnparseableDocumentTestCase.java
@@ -1,0 +1,55 @@
+package io.smallrye.graphql.tests.error;
+
+import java.net.URL;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.smallrye.graphql.tests.GraphQLAssured;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class UnparseableDocumentTestCase {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "unparseable.war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(Foo.class);
+    }
+
+    @GraphQLApi
+    static class Foo {
+        @Query
+        public String foo() {
+            return "bar";
+        }
+    }
+
+    @ArquillianResource
+    URL testingURL;
+
+    @Test
+    public void tryUnparsableDocumentRequest() {
+        GraphQLAssured graphQLAssured = new GraphQLAssured(testingURL);
+        String request = "query Foo {\n" +
+                "    foo {\n" +
+                "}";
+        String exceptionMessage = "Unparseable input document";
+
+        String response = graphQLAssured.post(request);
+        MatcherAssert.assertThat(response, Matchers.containsString(exceptionMessage));
+    }
+
+}


### PR DESCRIPTION
backport of https://github.com/smallrye/smallrye-graphql/issues/1666 to 1.9.x