### PR TITLE
Added new federation directives

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/DirectiveTypeCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/DirectiveTypeCreator.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.logging.Logger;
 
@@ -24,6 +25,8 @@ public class DirectiveTypeCreator extends ModelCreator {
     public DirectiveTypeCreator(ReferenceCreator referenceCreator) {
         super(referenceCreator);
     }
+
+    private static DotName NON_NULL = DotName.createSimple("org.eclipse.microprofile.graphql.NonNull");
 
     public DirectiveType create(ClassInfo classInfo) {
         LOG.debug("Creating directive from " + classInfo.name().toString());
@@ -43,6 +46,9 @@ public class DirectiveTypeCreator extends ModelCreator {
             argument.setName(method.name());
             Annotations annotationsForMethod = Annotations.getAnnotationsForInterfaceField(method);
             populateField(Direction.IN, argument, method.returnType(), annotationsForMethod);
+            if (annotationsForMethod.containsOneOfTheseAnnotations(NON_NULL)) {
+                argument.setNotNull(true);
+            }
             directiveType.addArgumentType(argument);
         }
 

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/ComposeDirective.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/ComposeDirective.java
@@ -1,0 +1,38 @@
+package io.smallrye.graphql.api.federation;
+
+import static io.smallrye.graphql.api.DirectiveLocation.SCHEMA;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.NonNull;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.graphql.api.Directive;
+import io.smallrye.graphql.api.federation.ComposeDirective.ComposeDirectives;
+
+/**
+ * <b><code>directive @composeDirective(name: String!) repeatable on SCHEMA</code></b>
+ *
+ * @see <a href="https://www.apollographql.com/docs/federation/federated-types/federated-directives/#composedirective">
+ *      federation spec</a>
+ */
+@Directive(on = { SCHEMA })
+@Description("Indicates to composition that all uses of a particular custom type system directive in the subgraph schema" +
+        " should be preserved in the supergraph schema (by default, composition omits most directives from the supergraph" +
+        " schema).")
+@Retention(RUNTIME)
+@Repeatable(ComposeDirectives.class)
+@Experimental("SmallRye GraphQL Federation is still subject to change.")
+public @interface ComposeDirective {
+    @NonNull
+    @Description("The name (including the leading @) of the directive to preserve during composition.")
+    String name();
+
+    @Retention(RUNTIME)
+    @interface ComposeDirectives {
+        ComposeDirective[] value();
+    }
+}

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/Inaccessible.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/Inaccessible.java
@@ -1,0 +1,36 @@
+package io.smallrye.graphql.api.federation;
+
+import static io.smallrye.graphql.api.DirectiveLocation.ARGUMENT_DEFINITION;
+import static io.smallrye.graphql.api.DirectiveLocation.ENUM;
+import static io.smallrye.graphql.api.DirectiveLocation.ENUM_VALUE;
+import static io.smallrye.graphql.api.DirectiveLocation.FIELD_DEFINITION;
+import static io.smallrye.graphql.api.DirectiveLocation.INPUT_FIELD_DEFINITION;
+import static io.smallrye.graphql.api.DirectiveLocation.INPUT_OBJECT;
+import static io.smallrye.graphql.api.DirectiveLocation.INTERFACE;
+import static io.smallrye.graphql.api.DirectiveLocation.OBJECT;
+import static io.smallrye.graphql.api.DirectiveLocation.SCALAR;
+import static io.smallrye.graphql.api.DirectiveLocation.UNION;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import org.eclipse.microprofile.graphql.Description;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.graphql.api.Directive;
+
+/**
+ * <b><code>directive @inaccessible on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION</code></b>
+ *
+ * @see <a href="https://www.apollographql.com/docs/federation/federated-types/federated-directives/#inaccessible">federation
+ *      spec</a>
+ */
+@Directive(on = { FIELD_DEFINITION, INTERFACE, OBJECT, UNION, ARGUMENT_DEFINITION, SCALAR, ENUM, ENUM_VALUE, INPUT_OBJECT,
+        INPUT_FIELD_DEFINITION })
+@Retention(RUNTIME)
+@Description("Indicates that a definition in the subgraph schema should be omitted from the router's API schema," +
+        " even if that definition is also present in other subgraphs." +
+        " This means that the field is not exposed to clients at all.")
+@Experimental("SmallRye GraphQL Federation is still subject to change.")
+public @interface Inaccessible {
+}

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/InterfaceObject.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/InterfaceObject.java
@@ -1,0 +1,28 @@
+package io.smallrye.graphql.api.federation;
+
+import static io.smallrye.graphql.api.DirectiveLocation.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import org.eclipse.microprofile.graphql.Description;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.graphql.api.Directive;
+
+/**
+ * <b><code>directive @interfaceObject on OBJECT</code></b>
+ *
+ * @see <a href="https://www.apollographql.com/docs/federation/federated-types/federated-directives/#interfaceobject">federation
+ *      spec</a>
+ */
+@Directive(on = { OBJECT })
+@Retention(RUNTIME)
+@Description("Indicates that an object definition serves as an abstraction of another subgraph's" +
+        " entity interface. This abstraction enables a subgraph to automatically contribute fields" +
+        " to all entities that implement a particular entity interface.\n" +
+        "During composition, the fields of every @interfaceObject are added both to their" +
+        " corresponding interface definition and to all entity types that implement that interface.")
+@Experimental("SmallRye GraphQL Federation is still subject to change.")
+public @interface InterfaceObject {
+}

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/Override.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/Override.java
@@ -1,0 +1,33 @@
+package io.smallrye.graphql.api.federation;
+
+import static io.smallrye.graphql.api.DirectiveLocation.FIELD_DEFINITION;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.NonNull;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.graphql.api.Directive;
+
+/**
+ * <b><code>directive @override(from: String!) on FIELD_DEFINITION</code></b>
+ *
+ * @see <a href="https://www.apollographql.com/docs/federation/federated-types/federated-directives/#override">federation
+ *      spec</a>
+ */
+@Directive(on = { FIELD_DEFINITION })
+@Retention(RUNTIME)
+@Description("Indicates that an object field is now resolved by this subgraph instead of another subgraph where" +
+        " it's also defined. This enables you to migrate a field from one subgraph to another.\n" +
+        "You can apply @override to entity fields and fields of the root operation types (such as Query and Mutation).")
+@Experimental("SmallRye GraphQL Federation is still subject to change.")
+public @interface Override {
+    @NonNull
+    @Description("The name of the other subgraph that no longer resolves the field.\n" +
+            "If you're performing composition with managed federation, this must match the name of the subgraph in Apollo Studio.\n"
+            +
+            "If you're performing composition with the Rover CLI, this must match the name of the subgraph in the YAML config file you provide to rover supergraph compose.")
+    String from();
+}

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/Shareable.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/Shareable.java
@@ -1,0 +1,26 @@
+package io.smallrye.graphql.api.federation;
+
+import static io.smallrye.graphql.api.DirectiveLocation.FIELD_DEFINITION;
+import static io.smallrye.graphql.api.DirectiveLocation.OBJECT;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import org.eclipse.microprofile.graphql.Description;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.graphql.api.Directive;
+
+/**
+ * <b><code>directive @shareable on FIELD_DEFINITION | OBJECT</code></b>
+ *
+ * @see <a href="https://www.apollographql.com/docs/federation/federated-types/federated-directives/#shareable">federation
+ *      spec</a>
+ */
+@Directive(on = { FIELD_DEFINITION, OBJECT })
+@Description("Indicates that an object type's field is allowed to be resolved by multiple subgraphs" +
+        " (by default in Federation 2, object fields can be resolved by only one subgraph).")
+@Retention(RUNTIME)
+@Experimental("SmallRye GraphQL Federation is still subject to change.")
+public @interface Shareable {
+}

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/Tag.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/Tag.java
@@ -1,0 +1,49 @@
+package io.smallrye.graphql.api.federation;
+
+import static io.smallrye.graphql.api.DirectiveLocation.ARGUMENT_DEFINITION;
+import static io.smallrye.graphql.api.DirectiveLocation.ENUM;
+import static io.smallrye.graphql.api.DirectiveLocation.ENUM_VALUE;
+import static io.smallrye.graphql.api.DirectiveLocation.FIELD_DEFINITION;
+import static io.smallrye.graphql.api.DirectiveLocation.INPUT_FIELD_DEFINITION;
+import static io.smallrye.graphql.api.DirectiveLocation.INPUT_OBJECT;
+import static io.smallrye.graphql.api.DirectiveLocation.INTERFACE;
+import static io.smallrye.graphql.api.DirectiveLocation.OBJECT;
+import static io.smallrye.graphql.api.DirectiveLocation.SCALAR;
+import static io.smallrye.graphql.api.DirectiveLocation.UNION;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.NonNull;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.graphql.api.Directive;
+import io.smallrye.graphql.api.federation.Tag.Tags;
+
+/**
+ * <b><code>directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION |
+ * ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION</code></b>
+ *
+ * @see <a href="https://www.apollographql.com/docs/federation/federated-types/federated-directives/#tag">federation spec</a>
+ */
+@Directive(on = { FIELD_DEFINITION, INTERFACE, OBJECT, UNION, ARGUMENT_DEFINITION, SCALAR, ENUM, ENUM_VALUE,
+        INPUT_OBJECT, INPUT_FIELD_DEFINITION })
+@Retention(RUNTIME)
+@Description("Applies arbitrary string metadata to a schema location. Custom tooling can use this metadata" +
+        " during any step of the schema delivery flow, including composition, static analysis, and" +
+        " documentation. Apollo Studio's enterprise contracts feature uses @tag with its inclusion and" +
+        " exclusion filters.")
+@Experimental("SmallRye GraphQL Federation is still subject to change.")
+@Repeatable(Tags.class)
+public @interface Tag {
+    @NonNull
+    @Description("The tag name to apply.")
+    String name();
+
+    @Retention(RUNTIME)
+    @interface Tags {
+        Tag[] value();
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -234,6 +234,9 @@ public class Bootstrap {
         }
         for (String argumentName : directiveType.argumentNames()) {
             GraphQLInputType argumentType = argumentType(directiveType.argumentType(argumentName));
+            if (directiveType.argumentType(argumentName).isNotNull()) {
+                argumentType = GraphQLNonNull.nonNull(argumentType);
+            }
             directiveBuilder = directiveBuilder
                     .argument(GraphQLArgument.newArgument().type(argumentType).name(argumentName).build());
         }

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
@@ -30,6 +30,7 @@ import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
@@ -173,7 +174,9 @@ class SchemaTest {
                     keyDirective.getDescription());
             assertEquals(EnumSet.of(OBJECT, INTERFACE), keyDirective.validLocations());
             assertEquals(1, keyDirective.getArguments().size());
-            assertEquals("String", ((GraphQLScalarType) keyDirective.getArgument("fields").getType()).getName());
+            assertEquals("String",
+                    ((GraphQLScalarType) ((GraphQLNonNull) keyDirective.getArgument("fields").getType()).getWrappedType())
+                            .getName());
 
             GraphQLUnionType entityType = (GraphQLUnionType) graphQLSchema.getType("_Entity");
             assertNotNull(entityType);


### PR DESCRIPTION
/cc @jmartisk @t1 
fixes: #1542 
Note that `@ComposeDirective` is not applicable, since currently there is no feature for adding directives into a GraphQL schema.
Issue: https://github.com/smallrye/smallrye-graphql/issues/1831
directives: https://www.apollographql.com/docs/federation/federated-types/federated-directives
quarkus branch: https://github.com/mskacelik/quarkus/tree/SmallRye-GraphQL-2.2.0


