### PR TITLE
Update CDILookupService to leverage CDI 4 API

### DIFF
--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CDIManagedInstance.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CDIManagedInstance.java
@@ -1,19 +1,18 @@
 package io.smallrye.graphql.cdi;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Instance;
 
 import io.smallrye.graphql.spi.ManagedInstance;
 
 public class CDIManagedInstance<T> implements ManagedInstance<T> {
 
-    private final Instance<T> instance;
+    private final Instance.Handle<T> instanceHandle;
     private final T object;
-    private final boolean isDependentScoped;
 
-    CDIManagedInstance(Instance<T> instance, boolean isDependentScoped) {
-        this.instance = instance;
-        this.isDependentScoped = isDependentScoped;
-        this.object = instance.get();
+    CDIManagedInstance(Instance.Handle<T> handle) {
+        this.instanceHandle = handle;
+        this.object = handle.get();
     }
 
     @Override
@@ -23,8 +22,8 @@ public class CDIManagedInstance<T> implements ManagedInstance<T> {
 
     @Override
     public void destroyIfNecessary() {
-        if (isDependentScoped) {
-            instance.destroy(object);
+        if (instanceHandle.getBean().getScope().equals(Dependent.class)) {
+            instanceHandle.destroy();
         }
     }
 }

--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CdiLookupService.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/CdiLookupService.java
@@ -1,11 +1,5 @@
 package io.smallrye.graphql.cdi;
 
-import java.util.Set;
-
-import jakarta.enterprise.context.Dependent;
-import jakarta.enterprise.inject.AmbiguousResolutionException;
-import jakarta.enterprise.inject.UnsatisfiedResolutionException;
-import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.CDI;
 
 import io.smallrye.graphql.spi.LookupService;
@@ -31,20 +25,8 @@ public class CdiLookupService implements LookupService {
 
     @Override
     public <T> ManagedInstance<T> getInstance(Class<T> declaringClass) {
-        CDI<Object> cdi = CDI.current();
-        Bean<?> bean = getExactlyOneObject(cdi.getBeanManager().getBeans(declaringClass));
-        boolean isDependentScope = bean.getScope().equals(Dependent.class);
-        return new CDIManagedInstance<>(cdi.select(declaringClass), isDependentScope);
-    }
-
-    private <T> T getExactlyOneObject(Set<T> set) {
-        if (set.size() > 1) {
-            throw new AmbiguousResolutionException();
-        }
-        if (set.size() == 0) {
-            throw new UnsatisfiedResolutionException();
-        }
-        return set.iterator().next();
+        // getHandle() throws exception if there is unsatisfied or ambiguous dep
+        return new CDIManagedInstance<>(CDI.current().getBeanContainer().createInstance().select(declaringClass).getHandle());
     }
 
     @Override


### PR DESCRIPTION
This is in reaction to the Quarkus issue https://github.com/quarkusio/quarkus/issues/33693

It removes the need to perform resolution twice and in Quarkus it ensures it will use cached resolutions as well.

CC @mkouba