### PR TITLE
Schema Description feature

### DIFF
--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Schema.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Schema.java
@@ -17,6 +17,7 @@ import java.util.Set;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public final class Schema implements Serializable {
+    private String description;
     private Set<Operation> queries = new HashSet<>();
     private Set<Operation> mutations = new HashSet<>();
     private Set<Operation> subscriptions = new HashSet<>();
@@ -337,13 +338,38 @@ public final class Schema implements Serializable {
 
     @Override
     public String toString() {
-        return "Schema{" + "queries=" + queries + ", mutations=" + mutations + ", subscriptions=" + subscriptions
-                + ", groupedQueries=" + groupedQueries + ", groupedMutations=" + groupedMutations + ", groupedSubscriptions="
-                + groupedSubscriptions + ", directiveTypes=" + directiveTypes + ", inputs=" + inputs + ", types=" + types
-                + ", interfaces=" + interfaces + ", enums=" + enums + ", errors=" + errors + '}';
+        return "Schema{" +
+                "description='" + description + '\'' +
+                ", queries=" + queries +
+                ", mutations=" + mutations +
+                ", subscriptions=" + subscriptions +
+                ", groupedQueries=" + groupedQueries +
+                ", groupedMutations=" + groupedMutations +
+                ", groupedSubscriptions=" + groupedSubscriptions +
+                ", directiveTypes=" + directiveTypes +
+                ", inputs=" + inputs +
+                ", types=" + types +
+                ", interfaces=" + interfaces +
+                ", unions=" + unions +
+                ", enums=" + enums +
+                ", errors=" + errors +
+                ", directiveInstances=" + directiveInstances +
+                '}';
     }
 
     public List<DirectiveInstance> getDirectiveInstances() {
         return directiveInstances;
+    }
+
+    public void setDirectiveInstances(List<DirectiveInstance> directiveInstances) {
+        this.directiveInstances = directiveInstances;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -174,6 +174,7 @@ public class Bootstrap {
                 createGraphQLDirectives(schema.getDirectiveInstances()))
                 .map(graphQLDirective -> graphQLDirective.toAppliedDirective())
                 .collect(Collectors.toList()));
+        schemaBuilder.description(schema.getDescription());
         schemaBuilder.additionalDirectives(directiveTypes);
         schemaBuilder.additionalTypes(new HashSet<>(enumMap.values()));
         schemaBuilder.additionalTypes(new HashSet<>(interfaceMap.values()));

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/EnumTestApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/EnumTestApi.java
@@ -1,5 +1,6 @@
 package io.smallrye.graphql.schema;
 
+import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
 
@@ -12,8 +13,10 @@ public class EnumTestApi {
     }
 
     @EnumDirective
+    @Description("EnumWithDirectives description")
     public enum EnumWithDirectives {
         @EnumDirective
+        @Description("A description")
         A,
         B
     }

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/InputTestApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/InputTestApi.java
@@ -1,5 +1,6 @@
 package io.smallrye.graphql.schema;
 
+import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
 
@@ -19,8 +20,10 @@ public class InputTestApi {
     }
 
     @InputDirective
+    @Description("InputType description")
     public static class InputWithDirectives {
         @InputDirective
+        @Description("InputTypeField description")
         public int foo;
 
         @InputDirective

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
@@ -120,10 +120,13 @@ class SchemaTest {
         GraphQLEnumType enumWithDirectives = graphQLSchema.getTypeAs("EnumWithDirectives");
         assertNotNull(enumWithDirectives.getDirective("enumDirective"),
                 "Enum EnumWithDirectives should have directive @enumDirective");
+        assertEquals("EnumWithDirectives description", enumWithDirectives.getDescription());
         assertNotNull(enumWithDirectives.getValue("A").getDirective("enumDirective"),
                 "Enum value EnumWithDirectives.A should have directive @enumDirective");
+        assertEquals("A description", enumWithDirectives.getValue("A").getDescription());
         assertNull(enumWithDirectives.getValue("B").getDirective("enumDirective"),
                 "Enum value EnumWithDirectives.B should not have directive @enumDirective");
+        assertNull(enumWithDirectives.getValue("B").getDescription());
     }
 
     @Test
@@ -142,6 +145,7 @@ class SchemaTest {
                         "Unexpected directive argument value")));
         assertTrue(unionWithDirectives.getDirectives("InputDirective").isEmpty(),
                 "Union SomeUnion should not have a directive @inputDirective");
+        assertEquals("Union description", unionWithDirectives.getDescription());
     }
 
     @Test
@@ -152,8 +156,10 @@ class SchemaTest {
         GraphQLInputObjectType inputWithDirectives = graphQLSchema.getTypeAs("InputWithDirectivesInput");
         assertNotNull(inputWithDirectives.getDirective("inputDirective"),
                 "Input type InputWithDirectivesInput should have directive @inputDirective");
+        assertEquals("InputType description", inputWithDirectives.getDescription());
         assertNotNull(inputWithDirectives.getField("foo").getDirective("inputDirective"),
                 "Input type field InputWithDirectivesInput.foo should have directive @inputDirective");
+        assertEquals("InputTypeField description", inputWithDirectives.getField("foo").getDescription());
         assertNotNull(inputWithDirectives.getField("bar").getDirective("inputDirective"),
                 "Input type field InputWithDirectivesInput.bar should have directive @inputDirective");
 
@@ -275,6 +281,7 @@ class SchemaTest {
                 .collect(Collectors.toList()).forEach(composeDirective -> composeDirective.getArguments()
                         .forEach(argument -> assertTrue(!expectedArgValues.add(argument.getValue()),
                                 "Unexpected directive argument value")));
+        assertEquals("Schema description", graphQLSchema.getDescription());
     }
 
     @Test
@@ -357,14 +364,14 @@ class SchemaTest {
         assertRolesAllowedDirective(adminPasswordField, "admin");
     }
 
-    private static void assertKeyDirective(GraphQLDirective graphQLDirective, String value) {
+    private void assertKeyDirective(GraphQLDirective graphQLDirective, String value) {
         assertEquals("key", graphQLDirective.getName());
         assertEquals(1, graphQLDirective.getArguments().size());
         assertEquals("fields", graphQLDirective.getArguments().get(0).getName());
         assertEquals(value, graphQLDirective.getArguments().get(0).toAppliedArgument().getArgumentValue().getValue());
     }
 
-    public static void assertRolesAllowedDirective(GraphQLFieldDefinition field, String roleValue) {
+    private void assertRolesAllowedDirective(GraphQLFieldDefinition field, String roleValue) {
         assertNotNull(field);
 
         if (Objects.isNull(roleValue)) {

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/UnionTestApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/UnionTestApi.java
@@ -1,5 +1,6 @@
 package io.smallrye.graphql.schema;
 
+import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
 
@@ -27,6 +28,7 @@ public class UnionTestApi {
     @UnionDirective(value = "A")
     @InputDirective // should be ignored
     @UnionDirective(value = "B")
+    @Description("Union description")
     interface SomeUnion {
     }
 

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/schemadirectives/Schema1.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/schemadirectives/Schema1.java
@@ -1,10 +1,12 @@
 package io.smallrye.graphql.schema.schemadirectives;
 
+import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
 
 @GraphQLApi
 @RepeatableSchemaDirective(name = "name1")
+@Description("Schema description")
 public class Schema1 {
     @Query
     public String foo() {


### PR DESCRIPTION
/cc @jmartisk 

Implemented a new feature that enables users to include a description for the entire schema using the `@Description` annotation. Also, introduced additional checks within the tests.

In scenarios where multiple `@Description` annotations are applied to the schema, only the first annotation will be considered, with any subsequent descriptions triggering a LOG warning.
