### PR TITLE
Fixing some bugs regarding transformation of annotation 'java.lang.Deprecated' to graphQL's 'Deprecated'. directive.

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ArgumentCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ArgumentCreator.java
@@ -103,14 +103,16 @@ public class ArgumentCreator extends ModelCreator {
             }
         }
         if (deprecatedHelper != null && directives != null) {
-            List<DirectiveInstance> deprecatedDirectives = deprecatedHelper
-                    .transformDeprecatedToDirectives(annotationsForThisArgument,
-                            directives.getDirectiveTypes().get(DotName.createSimple("io.smallrye.graphql.api.Deprecated")));
-            if (!deprecatedDirectives.isEmpty()) {
-                logger.debug("Adding deprecated directives " + deprecatedDirectives + " to field '" + argument.getName()
-                        + "' of  of method '" + argument.getMethodName() + "'");
-                argument.addDirectiveInstances(deprecatedDirectives);
-            }
+            deprecatedHelper
+                    .transformDeprecatedToDirective(annotationsForThisArgument,
+                            directives.getDirectiveTypes().get(DotName.createSimple("io.smallrye.graphql.api.Deprecated")))
+                    .ifPresent(deprecatedDirective -> {
+                        logger.debug(
+                                "Adding deprecated directive " + deprecatedDirective + " to argument '"
+                                        + argument.getName()
+                                        + "' of method '" + argument.getMethodName() + "'");
+                        argument.addDirectiveInstance(deprecatedDirective);
+                    });
         }
 
         populateField(Direction.IN, argument, argumentType, annotationsForThisArgument);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
@@ -106,9 +106,8 @@ public class FieldCreator extends ModelCreator {
                     reference);
             if (direction == Direction.IN) {
                 addDirectivesForBeanValidationConstraints(annotationsForPojo, field, parentObjectReference);
-                addDirectivesForDeprecated(annotationsForPojo, field, parentObjectReference);
             }
-
+            addDirectivesForDeprecated(annotationsForPojo, field, parentObjectReference);
             populateField(direction, field, fieldType, methodType, annotationsForPojo);
 
             return Optional.of(field);
@@ -166,8 +165,8 @@ public class FieldCreator extends ModelCreator {
                     reference);
             if (direction == Direction.IN) {
                 addDirectivesForBeanValidationConstraints(annotationsForPojo, field, parentObjectReference);
-                addDirectivesForDeprecated(annotationsForPojo, field, parentObjectReference);
             }
+            addDirectivesForDeprecated(annotationsForPojo, field, parentObjectReference);
             populateField(direction, field, fieldType, annotationsForPojo);
 
             return Optional.of(field);
@@ -191,14 +190,14 @@ public class FieldCreator extends ModelCreator {
     private void addDirectivesForDeprecated(Annotations annotationsForPojo, Field field,
             Reference parentObjectReference) {
         if (deprecatedHelper != null && directives != null) {
-            List<DirectiveInstance> deprecatedDirectives = deprecatedHelper
-                    .transformDeprecatedToDirectives(annotationsForPojo,
-                            directives.getDirectiveTypes().get(DotName.createSimple("io.smallrye.graphql.api.Deprecated")));
-            if (!deprecatedDirectives.isEmpty()) {
-                logger.debug("Adding deprecated directives " + deprecatedDirectives + " to field '" + field.getName()
-                        + "' of parent type '" + parentObjectReference.getName() + "'");
-                field.addDirectiveInstances(deprecatedDirectives);
-            }
+            deprecatedHelper
+                    .transformDeprecatedToDirective(annotationsForPojo,
+                            directives.getDirectiveTypes().get(DotName.createSimple("io.smallrye.graphql.api.Deprecated")))
+                    .ifPresent(deprecatedDirectives -> {
+                        logger.debug("Adding deprecated directives " + deprecatedDirectives + " to field '" + field.getName()
+                                + "' of parent type '" + parentObjectReference.getName() + "'");
+                        field.addDirectiveInstance(deprecatedDirectives);
+                    });
         }
     }
 

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
@@ -70,7 +70,6 @@ public class InputTypeCreator implements Creator<InputType> {
 
         // Directives
         inputType.setDirectiveInstances(getDirectiveInstances(annotations));
-
         // Fields
         addFields(inputType, classInfo, reference);
 

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/DeprecatedDirectivesHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/DeprecatedDirectivesHelper.java
@@ -1,11 +1,9 @@
 package io.smallrye.graphql.schema.helper;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.jboss.jandex.DotName;
-import org.jboss.logging.Logger;
 
 import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.model.DirectiveInstance;
@@ -13,18 +11,15 @@ import io.smallrye.graphql.schema.model.DirectiveType;
 
 public class DeprecatedDirectivesHelper {
 
-    private static Logger LOGGER = Logger.getLogger(DeprecatedDirectivesHelper.class);
-
-    public List<DirectiveInstance> transformDeprecatedToDirectives(Annotations annotations, DirectiveType directiveType) {
-        List<DirectiveInstance> result = new ArrayList<>();
+    public Optional<DirectiveInstance> transformDeprecatedToDirective(Annotations annotations, DirectiveType directiveType) {
         Set<DotName> annotationNames = annotations.getAnnotationNames();
         for (DotName annotationName : annotationNames) {
             if (annotationName.equals(DotName.createSimple("java.lang.Deprecated"))) {
                 DirectiveInstance directive = new DirectiveInstance();
                 directive.setType(directiveType);
-                result.add(directive);
+                return Optional.of(directive);
             }
         }
-        return result;
+        return Optional.empty();
     }
 }

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/RolesAllowedDirectivesHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/RolesAllowedDirectivesHelper.java
@@ -1,6 +1,7 @@
 package io.smallrye.graphql.schema.helper;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import org.jboss.jandex.AnnotationValue;
@@ -34,7 +35,7 @@ public class RolesAllowedDirectivesHelper {
         return arg;
     }
 
-    public DirectiveInstance transformRolesAllowedToDirectives(Annotations methodAnnotations,
+    public Optional<DirectiveInstance> transformRolesAllowedToDirectives(Annotations methodAnnotations,
             Annotations classAnnotations) {
 
         Set<DotName> annotationNames = new HashSet<>(methodAnnotations.getAnnotationNames());
@@ -52,10 +53,10 @@ public class RolesAllowedDirectivesHelper {
                     value = getStringValue(classAnnotations, annotationName, "value");
                 }
                 directive.setValue("value", value);
-                return directive;
+                return Optional.of(directive);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     private String getStringValue(Annotations annotations, DotName annotationName, String parameterName) {

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/EnumValue.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/EnumValue.java
@@ -59,4 +59,7 @@ public final class EnumValue {
         this.directiveInstances = directiveInstances;
     }
 
+    public void addDirectiveInstance(DirectiveInstance directiveInstance) {
+        this.directiveInstances.add(directiveInstance);
+    }
 }

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Field.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Field.java
@@ -206,9 +206,7 @@ public class Field implements Serializable {
     }
 
     public void addDirectiveInstance(DirectiveInstance directiveInstance) {
-        if (directiveInstances != null) {
-            this.directiveInstances.add(directiveInstance);
-        }
+        this.directiveInstances.add(directiveInstance);
     }
 
     @Override

--- a/tools/maven-plugin/src/main/java/io/smallrye/graphql/mavenplugin/GenerateSchemaMojo.java
+++ b/tools/maven-plugin/src/main/java/io/smallrye/graphql/mavenplugin/GenerateSchemaMojo.java
@@ -147,11 +147,12 @@ public class GenerateSchemaMojo extends AbstractMojo {
         // even if includeDependencies=false
         Predicate<Artifact> isMutiny = a -> a.getGroupId().equals("io.smallrye.reactive") &&
                 a.getArtifactId().equals("mutiny");
+        Predicate<Artifact> isSmallRyeGraphQLApi = a -> a.getGroupId().equals("io.smallrye") &&
+                a.getArtifactId().equals("smallrye-graphql-api");
         mavenProject.getArtifacts()
                 .stream()
-                .filter(isMutiny)
-                .findAny()
-                .ifPresent(a -> {
+                .filter(a -> isMutiny.test((Artifact) a) || isSmallRyeGraphQLApi.test((Artifact) a))
+                .forEach(a -> {
                     Result r = indexJar(((Artifact) a).getFile());
                     if (r != null) {
                         indexes.add(r.getIndex());
@@ -165,7 +166,7 @@ public class GenerateSchemaMojo extends AbstractMojo {
                         && includeDependenciesTypes.contains(artifact.getType())
                         && (includeDependenciesGroupIds.isEmpty() ||
                                 includeDependenciesGroupIds.contains(artifact.getGroupId()))
-                        && !isMutiny.test(artifact)) {
+                        && !isMutiny.test(artifact) && !isSmallRyeGraphQLApi.test(artifact)) {
 
                     Index index = indexArtifact(artifact);
                     if (index != null) {


### PR DESCRIPTION
fixes:#1896
/cc @jmartisk 
## Changes:
Changes:
- [x] Refactored the code to ensure that the transformation methods return the `Optional<DirectiveInstance>` type instead of the raw type. This change eliminates situations where the method could return `null` or a list, as was the case with `DeprecatedDirectivesHelper`. Since the `java.lang.Deprecated` is non repeatable annotation.
- [x] Resolved a bug causing a NullPointerException when using `java.lang.Deprecated` during schema generation via the `smallrye-graphql-maven-plugin` goal: `generating-schema`. The issue stemmed from the fact that `GenerateSchemaMojo` did not scan the `smallrye-graphql-api`, where the GraphQL Deprecated annotation was defined.
- [x] Implemented a feature enabling the transformation of `java.lang.Deprecated` from operations (high-level fields), enum values, and field definitions of an output type. This addition complements the existing implementation for attribute definitions and input type field definitions. 

tests: https://github.com/quarkusio/quarkus/commit/204c115d9f23c22df54bdc9bd92284a87ddd99d8