### PR TITLE
WebSocket connection failure handling

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClient.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClient.java
@@ -409,6 +409,7 @@ public class VertxDynamicGraphQLClient implements DynamicGraphQLClient {
                                         handlerEmitter.complete(handler);
                                         log.debug("Using websocket subprotocol handler: " + handler);
                                     } else {
+                                        webSocketHandler.set(null);
                                         handlerEmitter.fail(result.cause());
                                     }
                                 });
@@ -460,7 +461,7 @@ public class VertxDynamicGraphQLClient implements DynamicGraphQLClient {
             webSocketHandler().subscribe().with(handler -> {
                 handlerRef.set(handler);
                 operationId.set(handler.executeMulti(json, rawEmitter));
-            });
+            }, rawEmitter::fail);
         });
         return rawMulti
                 .onCancellation().invoke(() -> {


### PR DESCRIPTION
- Attempt to reconnect when the connection to the WebSocket fails.
- Pass down connection exceptions to created Multi.

Fixes https://github.com/smallrye/smallrye-graphql/issues/1912