### PR TITLE
Fixed a problem where during the scanning of InputTypes it included synthetic methods, added a filter + test

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
@@ -153,7 +153,7 @@ public class InputTypeCreator implements Creator<InputType> {
         // Find all methods and properties up the tree
         for (ClassInfo c = classInfo; c != null; c = ScanningContext.getIndex().getClassByName(c.superName())) {
             if (!c.toString().startsWith(JAVA_DOT)) { // Not java objects
-                allMethods.addAll(c.methods());
+                c.methods().stream().filter(methodInfo -> !methodInfo.isSynthetic()).forEach(allMethods::add);
                 for (final FieldInfo fieldInfo : c.fields()) {
                     allFields.putIfAbsent(fieldInfo.name(), fieldInfo);
                 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -199,8 +199,8 @@ public class SchemaBuilderTest {
         Set<Operation> mutations = schema.getMutations();
         Map<String, Type> outputTypes = schema.getTypes();
 
-        assertEquals(queries.size(), 2);
-        assertEquals(mutations.size(), 4);
+        assertEquals(queries.size(), 3);
+        assertEquals(mutations.size(), 5);
 
         Operation firstQuery = queries.stream()
                 .filter(q -> q.getName().equals("heroes"))
@@ -220,6 +220,12 @@ public class SchemaBuilderTest {
 
         Type greetingType = outputTypes.get("Greet");
         assertNotNull(greetingType);
+
+        Operation thirdQuery = queries.stream()
+                .filter(q -> q.getName().equals("saySome")).findFirst().orElseThrow(AssertionError::new);
+        assertEquals(thirdQuery.getArguments().size(), 1);
+        assertEquals(thirdQuery.getArguments().get(0).getReference().getName(), "SomeInput");
+        assertEquals(thirdQuery.getReference().getName(), "Some");
 
         // ------------------------------------------------------------------
         // MUTATIONS
@@ -280,6 +286,17 @@ public class SchemaBuilderTest {
         assertEquals(fourthMutation.getArguments().size(), 0);
         // return type
         assertEquals(fourthMutation.getReference().getName(), "Hero");
+
+        Operation fifthMutation = mutations.stream()
+                .filter(q -> q.getName().equals("updateSome"))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+
+        // arguments
+        assertEquals(fifthMutation.getArguments().size(), 1);
+        assertEquals(fifthMutation.getArguments().get(0).getReference().getName(), "SomeInput");
+        // return type
+        assertEquals(fifthMutation.getReference().getName(), "Some");
 
     }
 

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/generic/Attribute.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/generic/Attribute.java
@@ -1,0 +1,7 @@
+package io.smallrye.graphql.index.generic;
+
+public interface Attribute<T> {
+    T getValue();
+
+    void setValue(T value);
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/generic/HeroResource.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/generic/HeroResource.java
@@ -48,4 +48,13 @@ public class HeroResource implements CharacterResource<Hero> {
         return null;
     }
 
+    @Query
+    public Some saySome(Some value) {
+        return null;
+    }
+
+    @Mutation
+    public Some updateSome(Some some) {
+        return null;
+    }
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/generic/Some.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/generic/Some.java
@@ -1,0 +1,22 @@
+package io.smallrye.graphql.index.generic;
+
+public class Some implements Attribute<Long> {
+    Long some;
+
+    public Some() {
+    }
+
+    public Some(Long some) {
+        this.some = some;
+    }
+
+    @Override
+    public Long getValue() {
+        return some;
+    }
+
+    @Override
+    public void setValue(Long value) {
+        this.some = value;
+    }
+}


### PR DESCRIPTION
//cc @jmartisk 
fixes: #1963

The problem was caused by not filtering bridge (synthetic) methods in  `InputTypeCreator` (INPUT). The previous issue only handled the `TypeCreator` (OUTPUT). That is why if the mutation method is not present in the issue's reproducer, it does not throw the Error. Since the given query has only Output type `Greet`.(it is not a MUTATION/QUERY problem but an Input/Output problem).

I am not sure why the reproducer with Type Variable `String` worked and wrapper classes (Long, Integer, etc.) did not—probably some Jandex magic.