### PR TITLE
Expose close status codes for WebSockets

### DIFF
--- a/client/api/src/main/java/io/smallrye/graphql/client/UnexpectedCloseException.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/UnexpectedCloseException.java
@@ -1,0 +1,26 @@
+package io.smallrye.graphql.client;
+
+/**
+ * Marks a close WebSocket message from the server that was unexpected.
+ */
+public class UnexpectedCloseException extends InvalidResponseException {
+
+    private final int closeStatusCode;
+
+    public UnexpectedCloseException(String message, int closeStatusCode) {
+        super(message);
+        this.closeStatusCode = closeStatusCode;
+    }
+
+    public UnexpectedCloseException(String message, Throwable cause, int closeStatusCode) {
+        super(message, cause);
+        this.closeStatusCode = closeStatusCode;
+    }
+
+    /**
+     * The close status code returned by the server.
+     */
+    public int getCloseStatusCode() {
+        return closeStatusCode;
+    }
+}

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
@@ -22,6 +22,7 @@ import org.jboss.logging.Logger;
 import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.InvalidResponseException;
+import io.smallrye.graphql.client.UnexpectedCloseException;
 import io.smallrye.graphql.client.impl.ResponseReader;
 import io.smallrye.graphql.client.vertx.websocket.WebSocketSubprotocolHandler;
 import io.smallrye.graphql.client.vertx.websocket.opid.IncrementingNumberOperationIDGenerator;
@@ -98,12 +99,13 @@ public class GraphQLTransportWSSubprotocolHandler implements WebSocketSubprotoco
                         // even if the status code is OK, any unfinished single-result operation
                         // should be marked as failed
                         uniOperations.forEach((id, emitter) -> emitter.fail(
-                                new InvalidResponseException("Connection closed before data was received")));
+                                new UnexpectedCloseException("Connection closed before data was received", 1000)));
                         multiOperations.forEach((id, emitter) -> emitter.complete());
                     } else {
-                        InvalidResponseException exception = new InvalidResponseException(
+                        UnexpectedCloseException exception = new UnexpectedCloseException(
                                 "Server closed the websocket connection with code: "
-                                        + webSocket.closeStatusCode() + " and reason: " + webSocket.closeReason());
+                                        + webSocket.closeStatusCode() + " and reason: " + webSocket.closeReason(),
+                                webSocket.closeStatusCode());
                         uniOperations.forEach((id, emitter) -> emitter.fail(exception));
                         multiOperations.forEach((id, emitter) -> emitter.fail(exception));
                     }

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
@@ -19,6 +19,7 @@ import org.jboss.logging.Logger;
 import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.InvalidResponseException;
+import io.smallrye.graphql.client.UnexpectedCloseException;
 import io.smallrye.graphql.client.impl.ResponseReader;
 import io.smallrye.graphql.client.vertx.websocket.WebSocketSubprotocolHandler;
 import io.smallrye.graphql.client.vertx.websocket.opid.IncrementingNumberOperationIDGenerator;
@@ -79,12 +80,13 @@ public class GraphQLWSSubprotocolHandler implements WebSocketSubprotocolHandler 
                         // even if the status code is OK, any unfinished single-result operation
                         // should be marked as failed
                         uniOperations.forEach((id, emitter) -> emitter.fail(
-                                new InvalidResponseException("Connection closed before data was received")));
+                                new UnexpectedCloseException("Connection closed before data was received", 1000)));
                         multiOperations.forEach((id, emitter) -> emitter.complete());
                     } else {
-                        InvalidResponseException exception = new InvalidResponseException(
+                        UnexpectedCloseException exception = new UnexpectedCloseException(
                                 "Server closed the websocket connection with code: "
-                                        + webSocket.closeStatusCode() + " and reason: " + webSocket.closeReason());
+                                        + webSocket.closeStatusCode() + " and reason: " + webSocket.closeReason(),
+                                webSocket.closeStatusCode());
                         uniOperations.forEach((id, emitter) -> emitter.fail(exception));
                         multiOperations.forEach((id, emitter) -> emitter.fail(exception));
                     }


### PR DESCRIPTION
Make WebSocket close exceptions expose the status code given by the server.

As it stands, there is no nice way to check the reason the WebSocket was closed. At the moment, in my code, I'm just checking if the message contains a String. This change would allow you to check the close status code for the WebSockets termination and handle it accordingly.