### PR TITLE
Define the line endings in the formatting plugin as LF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,6 +546,14 @@
                     </docletArtifact>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <version>2.23.0</version>
+                <configuration>
+                    <lineEnding>LF</lineEnding>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
I was working on another pull request, and as most of my work I do via Git Bash, I found I was constantly trying to fight the maven formatter plugin as it kept making the line endings CRLF.
This change will define that all files need to be LF without each developer needing to define it individually locally.