### PR TITLE
Switching createGraphQLEnumTypes and createGraphQLDirectiveTypes to allow EnumTypes directive arguments

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -160,8 +160,9 @@ public class Bootstrap {
     private void generateGraphQLSchema() {
         GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
 
-        createGraphQLDirectiveTypes();
         createGraphQLEnumTypes();
+        createGraphQLDirectiveTypes();
+
         createGraphQLInterfaceTypes();
         createGraphQLUnionTypes();
         createGraphQLObjectTypes();

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/directiveswithenumvalues/MyEnum.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/directiveswithenumvalues/MyEnum.java
@@ -1,0 +1,9 @@
+package io.smallrye.graphql.schema.directiveswithenumvalues;
+
+import io.smallrye.graphql.schema.EnumDirective;
+
+@EnumDirective
+public enum MyEnum {
+    SOME,
+    THING
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/directiveswithenumvalues/MyEnumValueDirective.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/directiveswithenumvalues/MyEnumValueDirective.java
@@ -1,0 +1,18 @@
+package io.smallrye.graphql.schema.directiveswithenumvalues;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.eclipse.microprofile.graphql.NonNull;
+
+import io.smallrye.graphql.api.Directive;
+import io.smallrye.graphql.api.DirectiveLocation;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Directive(on = DirectiveLocation.FIELD_DEFINITION)
+public @interface MyEnumValueDirective {
+
+    @NonNull
+    MyEnum value();
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/directiveswithenumvalues/MyObject.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/directiveswithenumvalues/MyObject.java
@@ -1,0 +1,21 @@
+package io.smallrye.graphql.schema.directiveswithenumvalues;
+
+import java.util.Objects;
+
+import org.eclipse.microprofile.graphql.NonNull;
+
+public class MyObject {
+
+    @NonNull
+    @MyEnumValueDirective(MyEnum.SOME)
+    String name;
+
+    public MyObject(String name) {
+        this.name = Objects.requireNonNull(name);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/directiveswithenumvalues/SomeApi.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/directiveswithenumvalues/SomeApi.java
@@ -1,0 +1,12 @@
+package io.smallrye.graphql.schema.directiveswithenumvalues;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class SomeApi {
+    @Query
+    public MyObject getMyObject() {
+        return new MyObject("Test");
+    }
+}


### PR DESCRIPTION
/cc @jmartisk 
fixes: #1978 

Possible two edge case problems:
- if the EnumType has another directive whose arguments have a different EnumType that has yet to be added to the enumMap.
- Circular dependency: for example, EnumType has a directive whose argument is the same EnumType

For the second case, I think it's not doable even using the raw `java-graphql` API since the `GraphQLEnumType` would need a reference to itself in its definition.