### PR TITLE
typesafe client implementation with Jandex scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,8 +96,8 @@ jobs:
       - name: checkout Quarkus repository
         uses: actions/checkout@v2
         with:
-          repository: quarkusio/quarkus
-          ref: main
+          repository: mskacelik/quarkus
+          ref: srgql2.8.0
           path: quarkus
 
       - uses: actions/setup-java@v3.10.0

--- a/client/api/pom.xml
+++ b/client/api/pom.xml
@@ -38,6 +38,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-model</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/client/implementation-vertx/pom.xml
+++ b/client/implementation-vertx/pom.xml
@@ -17,6 +17,10 @@
             <artifactId>smallrye-graphql-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-model-builder</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config</artifactId>
         </dependency>

--- a/client/implementation-vertx/src/test/java/test/tck/TypesafeTckClientModelSuite.java
+++ b/client/implementation-vertx/src/test/java/test/tck/TypesafeTckClientModelSuite.java
@@ -1,0 +1,101 @@
+package test.tck;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.eclipse.microprofile.graphql.Input;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+
+import io.smallrye.graphql.client.GraphQLClient;
+import io.smallrye.graphql.client.model.ClientModelBuilder;
+import io.smallrye.graphql.client.model.ClientModels;
+import tck.graphql.typesafe.Animal;
+import tck.graphql.typesafe.TypesafeTCK;
+
+/**
+ * This test suite is used only for the new client-model typesafe implementation using the Jandex scanning.
+ */
+@ExcludeClassNamePatterns("^tck.graphql.typesafe.RecursionBehavior$")
+class TypesafeTckClientModelSuite extends TypesafeTCK {
+    public final static ClientModels CLIENT_MODELS;
+
+    static {
+        try {
+            CLIENT_MODELS = ClientModelBuilder.build(createIndexExcludingClasses(
+                    new File(Animal.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath()
+                            + "tck/graphql/typesafe"),
+                    "RecursionBehavior"));
+        } catch (URISyntaxException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        // These properties are for the ‘TypesafeGraphQLClientBuilder#builder’ to differentiate between the typesafe-client
+        // using the client model and the one that does not.
+
+        System.clearProperty("clientModelCase");
+        System.setProperty("clientModelCase", "true");
+    }
+
+    // This test aims to initialize system properties.
+    // With it, the *beforeAll* method will be executed (before all the suite tests).
+    @Test
+    void minimalTest() {
+    }
+
+    private static Index createIndexExcludingClasses(File directory, String classNameToExclude) throws IOException {
+        Indexer indexer = new Indexer();
+
+        // Get all files in the directory
+        File[] files = directory.listFiles();
+
+        if (files != null) {
+            for (File file : files) {
+                // Check if the file is a .class file and does not contain the excluded class name
+                if (file.isFile() && file.getName().endsWith(".class") && !file.getName().contains(classNameToExclude)) {
+                    try (FileInputStream fileInputStream = new FileInputStream(file)) {
+                        // Index the class in the new index
+                        indexer.index(fileInputStream);
+                    }
+                } else if (file.isFile() && file.getName().endsWith(".jar")) {
+                    try (JarFile jarFile = new JarFile(file)) {
+                        Enumeration<JarEntry> entries = jarFile.entries();
+                        while (entries.hasMoreElements()) {
+                            JarEntry entry = entries.nextElement();
+                            if (entry.getName().endsWith(".class")) {
+                                try (InputStream in = jarFile.getInputStream(entry)) {
+                                    indexer.index(in);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // SOME OTHER CLASSES TO BE ADDED TO INDEX
+            try {
+                indexer.indexClass(Input.class);
+                indexer.indexClass(GraphQLClient.class);
+                indexer.indexClass(Closeable.class);
+                indexer.indexClass(AutoCloseable.class);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+        }
+        // Build the new index
+        return indexer.complete();
+    }
+}

--- a/client/implementation-vertx/src/test/java/test/tck/TypesafeTckSuite.java
+++ b/client/implementation-vertx/src/test/java/test/tck/TypesafeTckSuite.java
@@ -1,6 +1,23 @@
 package test.tck;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import tck.graphql.typesafe.TypesafeTCK;
 
 class TypesafeTckSuite extends TypesafeTCK {
+    @BeforeAll
+    static void beforeAll() {
+        // These properties are for the ‘TypesafeGraphQLClientBuilder#builder’ to differentiate between the typesafe-client
+        // using the client model and the one that does not.
+
+        System.clearProperty("clientModelCase");
+        System.setProperty("clientModelCase", "false");
+    }
+
+    // This test aims to initialize system properties.
+    // With it, the *beforeAll* method will be executed (before all the suite tests).
+    @Test
+    void minimalTest() {
+    }
 }

--- a/client/implementation-vertx/src/test/java/test/tck/VertxTypesafeGraphQLClientFixture.java
+++ b/client/implementation-vertx/src/test/java/test/tck/VertxTypesafeGraphQLClientFixture.java
@@ -18,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import io.smallrye.graphql.client.typesafe.api.TypesafeGraphQLClientBuilder;
+import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.future.SucceededFuture;
@@ -63,6 +64,12 @@ public class VertxTypesafeGraphQLClientFixture implements TypesafeGraphQLClientF
 
     @Override
     public TypesafeGraphQLClientBuilder builder() {
+        boolean clientModelCase = System.getProperty("clientModelCase").equals("true");
+        if (clientModelCase) {
+            return ((VertxTypesafeGraphQLClientBuilder) builderWithoutEndpointConfig())
+                    .clientModels(TypesafeTckClientModelSuite.CLIENT_MODELS)
+                    .endpoint("urn:dummy-endpoint");
+        }
         return builderWithoutEndpointConfig().endpoint("urn:dummy-endpoint");
     }
 

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/QueryBuilder.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/QueryBuilder.java
@@ -21,18 +21,8 @@ public class QueryBuilder {
     }
 
     public String build() {
-        StringBuilder request = new StringBuilder();
-        switch (method.getOperationType()) {
-            case QUERY:
-                request.append("query ");
-                break;
-            case MUTATION:
-                request.append("mutation ");
-                break;
-            case SUBSCRIPTION:
-                request.append("subscription ");
-                break;
-        }
+        StringBuilder request = new StringBuilder(method.getOperationTypeAsString());
+        request.append(" ");
         request.append(method.getName());
         if (method.hasValueParameters())
             request.append(method.valueParameters().map(this::declare).collect(joining(", ", "(", ")")));

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/MethodInvocation.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/MethodInvocation.java
@@ -25,6 +25,7 @@ import org.eclipse.microprofile.graphql.Query;
 
 import io.smallrye.graphql.api.Subscription;
 import io.smallrye.graphql.client.core.OperationType;
+import io.smallrye.graphql.client.model.MethodKey;
 import io.smallrye.graphql.client.typesafe.api.Multiple;
 
 public class MethodInvocation implements NamedElement {
@@ -50,6 +51,10 @@ public class MethodInvocation implements NamedElement {
 
     public String getKey() {
         return method.toGenericString();
+    }
+
+    public MethodKey getMethodKey() {
+        return new MethodKey(method.getReturnType(), method.getName(), method.getParameterTypes());
     }
 
     public OperationType getOperationType() {
@@ -242,5 +247,16 @@ public class MethodInvocation implements NamedElement {
     public boolean isDeclaredInCloseable() {
         return method.getDeclaringClass().equals(Closeable.class) ||
                 method.getDeclaringClass().equals(AutoCloseable.class);
+    }
+
+    public String getOperationTypeAsString() {
+        switch (getOperationType()) {
+            case MUTATION:
+                return "mutation";
+            case SUBSCRIPTION:
+                return "subscription ";
+            default:
+                return "query";
+        }
     }
 }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/ParameterInfo.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/ParameterInfo.java
@@ -65,6 +65,10 @@ public class ParameterInfo implements NamedElement {
         }
         if (type.isAnnotated(Name.class))
             return type.getAnnotation(Name.class).value();
+        // Only because of the switch works with *java.lang.Date* which is *DateTime*
+        if (type.getTypeName().equals("java.sql.Date")) {
+            return "Date";
+        }
         switch (type.getSimpleName()) {
             case "int":
             case "Integer":
@@ -106,6 +110,7 @@ public class ParameterInfo implements NamedElement {
             case "Instant":
             case "Calendar":
             case "GregorianCalendar":
+            case "Date": // java.lang.Date
                 return "DateTime";
             default:
                 return type.getSimpleName() + (type.isScalar() || type.isEnum() ? "" : "Input");

--- a/client/model-builder/pom.xml
+++ b/client/model-builder/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-graphql-client-parent</artifactId>
+        <version>2.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-graphql-client-model-builder</artifactId>
+    <name>SmallRye: GraphQL Client :: model builder</name>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-graphql-client-model</artifactId>
+        </dependency>
+
+        <!-- Jandex indexer -->
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+        </dependency>
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.graphql</groupId>
+            <artifactId>microprofile-graphql-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client</artifactId>
+        </dependency>
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/Annotations.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/Annotations.java
@@ -1,0 +1,605 @@
+package io.smallrye.graphql.client.model;
+
+import static java.util.Collections.emptyMap;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.Type;
+
+public class Annotations {
+    // todo: maybe use some of the helper methods in this class
+    private final Map<DotName, AnnotationInstance> annotationsMap;
+
+    public final Map<DotName, AnnotationInstance> parentAnnotations;
+
+    /**
+     * Get used when creating operations.
+     * Operation only have methods (no properties)
+     *
+     * @param methodInfo the java method
+     * @return Annotations for this method and its return-type
+     */
+    public static Annotations getAnnotationsForMethod(MethodInfo methodInfo) {
+        Map<DotName, AnnotationInstance> annotationMap = new HashMap<>();
+
+        for (AnnotationInstance annotationInstance : methodInfo.annotations()) {
+            DotName name = annotationInstance.name();
+            Kind kind = annotationInstance.target().kind();
+            if (kind.equals(Kind.METHOD)) {
+                annotationMap.put(name, annotationInstance);
+            }
+        }
+
+        final Type type = methodInfo.returnType();
+        if (Classes.isParameterized(type)) {
+            Type wrappedType = type.asParameterizedType().arguments().get(0);
+            for (final AnnotationInstance annotationInstance : wrappedType.annotations()) {
+                DotName name = annotationInstance.name();
+                annotationMap.put(name, annotationInstance);
+            }
+        }
+
+        Map<DotName, AnnotationInstance> parentAnnotations = getParentAnnotations(methodInfo.declaringClass());
+
+        return new Annotations(annotationMap, parentAnnotations);
+    }
+
+    private static Map<DotName, AnnotationInstance> getParentAnnotations(FieldInfo fieldInfo, MethodInfo methodInfo) {
+        ClassInfo declaringClass = fieldInfo != null ? fieldInfo.declaringClass() : methodInfo.declaringClass();
+        return getParentAnnotations(declaringClass);
+    }
+
+    private static Map<DotName, AnnotationInstance> getParentAnnotations(ClassInfo classInfo) {
+        Map<DotName, AnnotationInstance> parentAnnotations = new HashMap<>();
+
+        for (AnnotationInstance classAnnotation : classInfo.declaredAnnotations()) {
+            parentAnnotations.putIfAbsent(classAnnotation.name(), classAnnotation);
+        }
+
+        Map<DotName, AnnotationInstance> packageAnnotations = getPackageAnnotations(classInfo);
+        for (DotName dotName : packageAnnotations.keySet()) {
+            parentAnnotations.putIfAbsent(dotName, packageAnnotations.get(dotName));
+        }
+
+        return parentAnnotations;
+    }
+
+    private static Map<DotName, AnnotationInstance> getPackageAnnotations(ClassInfo classInfo) {
+        Map<DotName, AnnotationInstance> packageAnnotations = new HashMap<>();
+
+        DotName packageName = packageInfo(classInfo);
+        if (packageName != null) {
+            ClassInfo packageInfo = ScanningContext.getIndex().getClassByName(packageName);
+            if (packageInfo != null) {
+                for (AnnotationInstance packageAnnotation : packageInfo.declaredAnnotations()) {
+                    packageAnnotations.putIfAbsent(packageAnnotation.name(), packageAnnotation);
+                }
+            }
+        }
+
+        return packageAnnotations;
+    }
+
+    private static DotName packageInfo(ClassInfo classInfo) {
+        String className = classInfo.name().toString();
+        int index = className.lastIndexOf('.');
+        if (index == -1) {
+            return null;
+        }
+        return DotName.createSimple(className.substring(0, index) + ".package-info");
+    }
+
+    /**
+     * Get used when we create types and references to them
+     * <p>
+     * Class level annotation for type creation.
+     *
+     * @param classInfo the java class
+     * @return annotation for this class
+     */
+    public static Annotations getAnnotationsForClass(ClassInfo classInfo) {
+
+        Map<DotName, AnnotationInstance> annotationMap = new HashMap<>();
+
+        for (AnnotationInstance annotationInstance : classInfo.declaredAnnotations()) {
+            DotName name = annotationInstance.name();
+            annotationMap.put(name, annotationInstance);
+        }
+
+        Map<DotName, AnnotationInstance> packageAnnotations = getPackageAnnotations(classInfo);
+        for (DotName dotName : packageAnnotations.keySet()) {
+            annotationMap.putIfAbsent(dotName, packageAnnotations.get(dotName));
+        }
+
+        return new Annotations(annotationMap, packageAnnotations);
+    }
+
+    /**
+     * Get used when creating arrays.
+     * <p>
+     * This will contains the annotation on the collection field and method
+     *
+     * @param typeInCollection the field java type
+     * @param methodTypeInCollection the method java type
+     * @return the annotation for this array
+     */
+    public static Annotations getAnnotationsForArray(Type typeInCollection,
+            Type methodTypeInCollection) {
+        Map<DotName, AnnotationInstance> annotationMap = getAnnotationsForType(typeInCollection);
+        annotationMap.putAll(getAnnotationsForType(methodTypeInCollection));
+        return new Annotations(annotationMap);
+    }
+
+    //
+
+    /**
+     * Used when we are creating operation and arguments for these operations
+     *
+     * @param methodInfo the java method
+     * @param pos the argument position
+     * @return annotation for this argument
+     */
+    public static Annotations getAnnotationsForArgument(MethodInfo methodInfo, short pos) {
+        if (pos >= methodInfo.parametersCount()) {
+            throw new IndexOutOfBoundsException(
+                    "Parameter at position " + pos + " not found on method " + methodInfo.name());
+        }
+
+        final Type parameterType = methodInfo.parameterType(pos);
+
+        Map<DotName, AnnotationInstance> annotationMap = getAnnotations(parameterType);
+
+        for (AnnotationInstance anno : methodInfo.annotations()) {
+            if (anno.target().kind().equals(Kind.METHOD_PARAMETER)) {
+                MethodParameterInfo methodParameter = anno.target().asMethodParameter();
+                short position = methodParameter.position();
+                if (position == pos) {
+                    annotationMap.put(anno.name(), anno);
+                }
+            }
+        }
+
+        final Map<DotName, AnnotationInstance> parentAnnotations = getParentAnnotations(methodInfo.declaringClass());
+
+        return new Annotations(annotationMap, parentAnnotations);
+    }
+
+    public static boolean isJsonBAnnotation(AnnotationInstance instance) {
+        return instance.name().toString().startsWith(JAKARTA_JSONB) || instance.name().toString().startsWith(JAVAX_JSONB);
+    }
+
+    // ------- All static creators done, now the actual class --------
+
+    private Annotations(Map<DotName, AnnotationInstance> annotations) {
+        this(annotations, new HashMap<>());
+    }
+
+    /**
+     * Create the annotations, mapped by name
+     *
+     * @param annotations the annotation
+     */
+    private Annotations(Map<DotName, AnnotationInstance> annotations, Map<DotName, AnnotationInstance> parentAnnotations) {
+        this.annotationsMap = annotations;
+        this.parentAnnotations = parentAnnotations;
+    }
+
+    public Set<DotName> getAnnotationNames() {
+        return annotationsMap.keySet();
+    }
+
+    public Annotations removeAnnotations(DotName... annotations) {
+        Map<DotName, AnnotationInstance> newAnnotationsMap = new HashMap<>(annotationsMap);
+        for (DotName annotation : annotations) {
+            newAnnotationsMap.remove(annotation);
+        }
+        return new Annotations(newAnnotationsMap, this.parentAnnotations);
+    }
+
+    /**
+     * Get a specific annotation
+     *
+     * @param annotation the annotation you want
+     * @return the annotation value or null
+     */
+    public AnnotationValue getAnnotationValue(DotName annotation) {
+        return this.annotationsMap.get(annotation).value();
+    }
+
+    /**
+     * Get a specific annotation
+     *
+     * @param annotation the annotation you want
+     * @param name the name of the field that you want the value of
+     * @return the annotation value or null
+     */
+    public AnnotationValue getAnnotationValue(DotName annotation, String name) {
+        return this.annotationsMap.get(annotation).value(name);
+    }
+
+    /**
+     * Check if there is an annotation and it has a valid value
+     *
+     * @param annotation the annotation we are checking
+     * @return true if valid value
+     */
+    public boolean containsKeyAndValidValue(DotName annotation) {
+        return this.annotationsMap.containsKey(annotation) && this.annotationsMap.get(annotation).value() != null;
+    }
+
+    /**
+     * Check if one of these annotations is present
+     *
+     * @param annotations the annotations to check
+     * @return true if it does
+     */
+    public boolean containsOneOfTheseAnnotations(DotName... annotations) {
+        for (DotName name : annotations) {
+            if (this.annotationsMap.containsKey(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean containsOneOfTheseInheritableAnnotations(DotName... annotations) {
+        for (DotName name : annotations) {
+            if (this.parentAnnotations.containsKey(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get on of these annotations
+     *
+     * @param annotations the annotations to check (in order)
+     * @return the annotation potentially or empty if not found
+     */
+    public Optional<AnnotationInstance> getOneOfTheseAnnotations(DotName... annotations) {
+        for (DotName name : annotations) {
+            if (this.annotationsMap.containsKey(name)) {
+                return Optional.of(this.annotationsMap.get(name));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * This go through a list of annotations and find the first one that has a valid value.
+     * If it could not find one, it return empty
+     *
+     * @param annotations the annotations in order
+     * @return the valid annotation value or default value
+     */
+    public Optional<String> getOneOfTheseAnnotationsValue(DotName... annotations) {
+        for (DotName dotName : annotations) {
+            if (dotName != null && containsKeyAndValidValue(dotName)) {
+                return getStringValue(dotName);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * This go through a list of method annotations and find the first one that has a valid value.
+     * If it could not find one, it return the default value.
+     *
+     * @param annotations the annotations in order
+     * @return the valid annotation value or empty
+     */
+    public Optional<String> getOneOfTheseMethodAnnotationsValue(DotName... annotations) {
+        for (DotName dotName : annotations) {
+            if (dotName != null && hasValidMethodAnnotation(dotName)) {
+                return getStringValue(dotName);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * This go through a list of method parameter annotations and find the first one that has a valid value.
+     * If it could not find one, it return the default value.
+     *
+     * @param annotations the annotations in order
+     * @return the valid annotation value or empty
+     */
+    public Optional<String> getOneOfTheseMethodParameterAnnotationsValue(DotName... annotations) {
+        for (DotName dotName : annotations) {
+            if (dotName != null && hasValidMethodParameterAnnotation(dotName)) {
+                return getStringValue(dotName);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Get a stream of that annotation, maybe empty if not present, maybe a stream of one, or maybe several, if it's repeatable.
+     *
+     * @param name dotname of the annotation
+     */
+    public Stream<AnnotationInstance> resolve(DotName name) {
+        var annotationInstance = annotationsMap.get(name);
+        if (annotationInstance == null) {
+            var repeatableType = ScanningContext.getIndex().getClassByName(name);
+            if (repeatableType.hasAnnotation(REPEATABLE)) {
+                DotName containerName = repeatableType.annotation(REPEATABLE).value().asClass().name();
+                AnnotationInstance containerAnnotation = annotationsMap.get(containerName);
+                if (containerAnnotation != null) {
+                    return Stream.of(containerAnnotation.value().asNestedArray());
+                }
+            }
+            return Stream.of();
+        }
+        return Stream.of(annotationInstance);
+    }
+
+    @Override
+    public String toString() {
+        return annotationsMap.toString();
+    }
+
+    private boolean hasValidMethodAnnotation(DotName annotation) {
+        return containsKeyAndValidValue(annotation) && isMethodAnnotation(getAnnotation(annotation));
+    }
+
+    private boolean hasValidMethodParameterAnnotation(DotName annotation) {
+        return containsKeyAndValidValue(annotation) && isMethodParameterAnnotation(getAnnotation(annotation));
+    }
+
+    private AnnotationInstance getAnnotation(DotName key) {
+        return this.annotationsMap.get(key);
+    }
+
+    private Optional<String> getStringValue(DotName annotation) {
+        AnnotationInstance annotationInstance = getAnnotation(annotation);
+        if (annotationInstance != null) {
+            return getStringValue(annotationInstance);
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> getStringValue(AnnotationInstance annotationInstance) {
+        AnnotationValue value = annotationInstance.value();
+        if (value != null) {
+            return getStringValue(value);
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> getStringValue(AnnotationValue annotationValue) {
+        String value;
+        if (annotationValue != null) {
+            value = annotationValue.asString();
+            if (value != null && !value.isEmpty()) {
+                return Optional.of(value);
+            }
+        }
+        return Optional.empty();
+    }
+
+    // Private static methods use by the static initializers
+
+    private static boolean isMethodAnnotation(AnnotationInstance instance) {
+        return instance.target().kind().equals(Kind.METHOD);
+    }
+
+    private static boolean isMethodParameterAnnotation(AnnotationInstance instance) {
+        return instance.target().kind().equals(Kind.METHOD_PARAMETER);
+    }
+
+    private static Annotations getAnnotationsForInputField(FieldInfo fieldInfo, MethodInfo methodInfo) {
+        Map<DotName, AnnotationInstance> annotationsForField = getAnnotationsForField(fieldInfo, methodInfo);
+
+        if (fieldInfo != null) {
+            annotationsForField.putAll(getTypeUseAnnotations(fieldInfo.type()));
+        }
+        if (methodInfo != null) {
+            List<Type> parameters = methodInfo.parameterTypes();
+            if (!parameters.isEmpty()) {
+                Type param = parameters.get(ZERO);
+                annotationsForField.putAll(getTypeUseAnnotations(param));
+            }
+        }
+
+        final Map<DotName, AnnotationInstance> parentAnnotations = getParentAnnotations(fieldInfo, methodInfo);
+
+        return new Annotations(annotationsForField, parentAnnotations);
+    }
+
+    private static Annotations getAnnotationsForOutputField(FieldInfo fieldInfo, MethodInfo methodInfo) {
+        Map<DotName, AnnotationInstance> annotationsForField = getAnnotationsForField(fieldInfo, methodInfo);
+
+        if (fieldInfo != null) {
+            annotationsForField.putAll(getTypeUseAnnotations(fieldInfo.type()));
+        }
+        if (methodInfo != null) {
+            Type returnType = methodInfo.returnType();
+            if (returnType != null) {
+                annotationsForField.putAll(getTypeUseAnnotations(methodInfo.returnType()));
+            }
+        }
+
+        Map<DotName, AnnotationInstance> parentAnnotations = getParentAnnotations(fieldInfo, methodInfo);
+
+        return new Annotations(annotationsForField, parentAnnotations);
+    }
+
+    private static Map<DotName, AnnotationInstance> getTypeUseAnnotations(Type type) {
+        if (type != null) {
+            return getAnnotationsWithFilter(type,
+                    Annotations.DATE_FORMAT,
+                    Annotations.NUMBER_FORMAT);
+        }
+        return emptyMap();
+    }
+
+    private static Map<DotName, AnnotationInstance> getAnnotations(Type type) {
+        Map<DotName, AnnotationInstance> annotationMap = new HashMap<>();
+
+        if (type.kind().equals(Type.Kind.PARAMETERIZED_TYPE)) {
+            Type typeInCollection = type.asParameterizedType().arguments().get(0);
+            annotationMap.putAll(getAnnotations(typeInCollection));
+        } else {
+            List<AnnotationInstance> annotations = type.annotations();
+            for (AnnotationInstance annotationInstance : annotations) {
+                annotationMap.put(annotationInstance.name(), annotationInstance);
+            }
+        }
+
+        return annotationMap;
+    }
+
+    private static Map<DotName, AnnotationInstance> getAnnotationsForType(Type type) {
+        Map<DotName, AnnotationInstance> annotationMap = new HashMap<>();
+        for (AnnotationInstance annotationInstance : type.annotations()) {
+            DotName name = annotationInstance.name();
+            annotationMap.put(name, annotationInstance);
+        }
+        return annotationMap;
+    }
+
+    private static Map<DotName, AnnotationInstance> getAnnotationsForField(FieldInfo fieldInfo, MethodInfo methodInfo) {
+        Map<DotName, AnnotationInstance> annotationMap = new HashMap<>();
+        if (fieldInfo != null)
+            annotationMap.putAll(listToMap(fieldInfo.annotations().stream()
+                    .filter(ai -> ai.target().kind() == Kind.FIELD)
+                    .collect(Collectors.toList())));
+        if (methodInfo != null)
+            annotationMap.putAll(listToMap(methodInfo.annotations().stream()
+                    .filter(ai -> ai.target().kind() == Kind.METHOD || ai.target().kind() == Kind.METHOD_PARAMETER)
+                    .collect(Collectors.toList())));
+        return annotationMap;
+    }
+
+    private static Map<DotName, AnnotationInstance> listToMap(List<AnnotationInstance> annotationInstances) {
+        Map<DotName, AnnotationInstance> annotationMap = new HashMap<>();
+
+        for (AnnotationInstance annotationInstance : annotationInstances) {
+            DotName name = annotationInstance.name();
+            annotationMap.put(name, annotationInstance);
+        }
+        return annotationMap;
+    }
+
+    private static Map<DotName, AnnotationInstance> getAnnotationsWithFilter(Type type, DotName... filter) {
+        Map<DotName, AnnotationInstance> annotationMap = new HashMap<>();
+
+        if (type.kind().equals(Type.Kind.PARAMETERIZED_TYPE)) {
+            Type typeInCollection = type.asParameterizedType().arguments().get(0);
+            annotationMap.putAll(getAnnotationsWithFilter(typeInCollection, filter));
+        } else {
+            List<AnnotationInstance> annotations = type.annotations();
+            for (AnnotationInstance annotationInstance : annotations) {
+                if (Arrays.asList(filter).contains(annotationInstance.name())) {
+                    annotationMap.put(annotationInstance.name(), annotationInstance);
+                }
+            }
+        }
+
+        return annotationMap;
+    }
+
+    private static final short ZERO = 0;
+
+    public static final DotName REPEATABLE = DotName.createSimple("java.lang.annotation.Repeatable");
+
+    // SmallRye Common Annotations
+    public static final DotName BLOCKING = DotName.createSimple("io.smallrye.common.annotation.Blocking");
+    public static final DotName NON_BLOCKING = DotName.createSimple("io.smallrye.common.annotation.NonBlocking");
+
+    // SmallRye GraphQL Annotations (Experimental)
+    public static final DotName TO_SCALAR = DotName.createSimple("io.smallrye.graphql.api.ToScalar"); // TODO: Remove
+    public static final DotName ADAPT_TO_SCALAR = DotName.createSimple("io.smallrye.graphql.api.AdaptToScalar");
+    public static final DotName ADAPT_WITH = DotName.createSimple("io.smallrye.graphql.api.AdaptWith");
+    public static final DotName ERROR_CODE = DotName.createSimple("io.smallrye.graphql.api.ErrorCode");
+    public static final DotName DATAFETCHER = DotName.createSimple("io.smallrye.graphql.api.DataFetcher");
+    public static final DotName SUBCRIPTION = DotName.createSimple("io.smallrye.graphql.api.Subscription");
+    public static final DotName DIRECTIVE = DotName.createSimple("io.smallrye.graphql.api.Directive");
+    public static final DotName DEFAULT_NON_NULL = DotName.createSimple("io.smallrye.graphql.api.DefaultNonNull");
+    public static final DotName NULLABLE = DotName.createSimple("io.smallrye.graphql.api.Nullable");
+    public static final DotName KOTLIN_METADATA = DotName.createSimple("kotlin.Metadata");
+
+    // MicroProfile GraphQL Annotations
+    public static final DotName GRAPHQL_CLIENT_API = DotName
+            .createSimple("io.smallrye.graphql.client.typesafe.api.GraphQLClientApi");
+    public static final DotName QUERY = DotName.createSimple("org.eclipse.microprofile.graphql.Query");
+    public static final DotName MUTATION = DotName.createSimple("org.eclipse.microprofile.graphql.Mutation");
+    public static final DotName INPUT = DotName.createSimple("org.eclipse.microprofile.graphql.Input");
+    public static final DotName TYPE = DotName.createSimple("org.eclipse.microprofile.graphql.Type");
+    public static final DotName INTERFACE = DotName.createSimple("org.eclipse.microprofile.graphql.Interface");
+    public static final DotName UNION = DotName.createSimple("io.smallrye.graphql.api.Union");
+
+    public static final DotName MULTIPLE = DotName.createSimple("io.smallrye.graphql.client.typesafe.api.Multiple");
+
+    public static final DotName NESTED_PARAMETER = DotName
+            .createSimple("io.smallrye.graphql.client.typesafe.api.NestedParameter");
+
+    public static final DotName ENUM = DotName.createSimple("org.eclipse.microprofile.graphql.Enum");
+    public static final DotName ID = DotName.createSimple("org.eclipse.microprofile.graphql.Id");
+    public static final DotName DESCRIPTION = DotName.createSimple("org.eclipse.microprofile.graphql.Description");
+    public static final DotName DATE_FORMAT = DotName.createSimple("org.eclipse.microprofile.graphql.DateFormat");
+    public static final DotName NUMBER_FORMAT = DotName.createSimple("org.eclipse.microprofile.graphql.NumberFormat");
+    public static final DotName DEFAULT_VALUE = DotName.createSimple("org.eclipse.microprofile.graphql.DefaultValue");
+    public static final DotName IGNORE = DotName.createSimple("org.eclipse.microprofile.graphql.Ignore");
+    public static final DotName NON_NULL = DotName.createSimple("org.eclipse.microprofile.graphql.NonNull");
+    public static final DotName NAME = DotName.createSimple("org.eclipse.microprofile.graphql.Name");
+    public static final DotName SOURCE = DotName.createSimple("org.eclipse.microprofile.graphql.Source");
+
+    // Json-B Annotations
+    public static final String JAVAX_JSONB = "javax.json.bind.annotation.";
+    public static final DotName JAVAX_JSONB_DATE_FORMAT = DotName.createSimple(JAVAX_JSONB + "JsonbDateFormat");
+    public static final DotName JAVAX_JSONB_NUMBER_FORMAT = DotName.createSimple(JAVAX_JSONB + "JsonbNumberFormat");
+    public static final DotName JAVAX_JSONB_PROPERTY = DotName.createSimple(JAVAX_JSONB + "JsonbProperty");
+    public static final DotName JAVAX_JSONB_TRANSIENT = DotName.createSimple(JAVAX_JSONB + "JsonbTransient");
+    public static final DotName JAVAX_JSONB_CREATOR = DotName.createSimple(JAVAX_JSONB + "JsonbCreator");
+    public static final DotName JAVAX_JSONB_TYPE_ADAPTER = DotName.createSimple(JAVAX_JSONB + "JsonbTypeAdapter");
+
+    public static final String JAKARTA_JSONB = "jakarta.json.bind.annotation.";
+    public static final DotName JAKARTA_JSONB_DATE_FORMAT = DotName.createSimple(JAKARTA_JSONB + "JsonbDateFormat");
+    public static final DotName JAKARTA_JSONB_NUMBER_FORMAT = DotName.createSimple(JAKARTA_JSONB + "JsonbNumberFormat");
+    public static final DotName JAKARTA_JSONB_PROPERTY = DotName.createSimple(JAKARTA_JSONB + "JsonbProperty");
+    public static final DotName JAKARTA_JSONB_TRANSIENT = DotName.createSimple(JAKARTA_JSONB + "JsonbTransient");
+    public static final DotName JAKARTA_JSONB_CREATOR = DotName.createSimple(JAKARTA_JSONB + "JsonbCreator");
+    public static final DotName JAKARTA_JSONB_TYPE_ADAPTER = DotName.createSimple(JAKARTA_JSONB + "JsonbTypeAdapter");
+
+    // Jackson Annotations
+    public static final DotName JACKSON_IGNORE = DotName.createSimple("com.fasterxml.jackson.annotation.JsonIgnore");
+    public static final DotName JACKSON_PROPERTY = DotName.createSimple("com.fasterxml.jackson.annotation.JsonProperty");
+    public static final DotName JACKSON_CREATOR = DotName.createSimple("com.fasterxml.jackson.annotation.JsonCreator");
+    public static final DotName JACKSON_FORMAT = DotName.createSimple("com.fasterxml.jackson.annotation.JsonFormat");
+
+    // Bean Validation Annotations (SmallRye extra, not part of the spec)
+    public static final DotName JAVAX_BEAN_VALIDATION_NOT_NULL = DotName.createSimple("javax.validation.constraints.NotNull");
+    public static final DotName JAVAX_BEAN_VALIDATION_NOT_EMPTY = DotName.createSimple("javax.validation.constraints.NotEmpty");
+    public static final DotName JAVAX_BEAN_VALIDATION_NOT_BLANK = DotName.createSimple("javax.validation.constraints.NotBlank");
+
+    public static final DotName JAKARTA_BEAN_VALIDATION_NOT_NULL = DotName
+            .createSimple("jakarta.validation.constraints.NotNull");
+    public static final DotName JAKARTA_BEAN_VALIDATION_NOT_EMPTY = DotName
+            .createSimple("jakarta.validation.constraints.NotEmpty");
+    public static final DotName JAKARTA_BEAN_VALIDATION_NOT_BLANK = DotName
+            .createSimple("jakarta.validation.constraints.NotBlank");
+
+    public static final DotName JAKARTA_NON_NULL = DotName.createSimple("jakarta.validation.constraints.NotNull");
+
+    //Kotlin NotNull
+    public static final DotName KOTLIN_NOT_NULL = DotName.createSimple("org.jetbrains.annotations.NotNull");
+
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/Classes.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/Classes.java
@@ -1,0 +1,224 @@
+package io.smallrye.graphql.client.model;
+
+import static io.smallrye.graphql.client.model.ScanningContext.getIndex;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.Queue;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.Vector;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+
+import io.smallrye.graphql.client.typesafe.api.ErrorOr;
+import io.smallrye.graphql.client.typesafe.api.TypesafeResponse;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+public class Classes {
+
+    private Classes() {
+    }
+
+    public static boolean isParameterized(Type type) {
+        return type.kind().equals(Type.Kind.PARAMETERIZED_TYPE);
+    }
+
+    public static boolean isTypeVariable(Type type) {
+        return type.kind().equals(Type.Kind.TYPE_VARIABLE);
+    }
+
+    /**
+     * Check if a certain type is Optional
+     *
+     * @param type the type
+     * @return true if it is
+     */
+    public static boolean isOptional(Type type) {
+        return isParameterized(type) && type.name().equals(OPTIONAL) // Normal Optional
+                || type.name().equals(LONG_OPTIONAL)
+                || type.name().equals(DOUBLE_OPTIONAL)
+                || type.name().equals(INTEGER_OPTIONAL);
+    }
+
+    public static boolean isEnum(Type type) {
+        if (Classes.isClass(type)) {
+            ClassInfo clazz = getIndex().getClassByName(type.asClassType().name());
+            return clazz != null && clazz.isEnum();
+        }
+        return false;
+    }
+
+    public static boolean isAsync(Type type) {
+        return isUni(type)
+                || isMulti(type);
+    }
+
+    public static boolean isUni(Type type) {
+        return type.name().equals(UNI);
+    }
+
+    public static boolean isMulti(Type type) {
+        return type.name().equals(MULTI);
+    }
+
+    public static boolean isPrimitive(Type type) {
+        return type.kind().equals(Type.Kind.PRIMITIVE);
+    }
+
+    public static boolean isClass(Type type) {
+        return type.kind().equals(Type.Kind.CLASS);
+    }
+
+    /**
+     * Return true if this is an array
+     *
+     * @param type to check
+     * @return if this is an array
+     */
+    public static boolean isArray(Type type) {
+        return type.kind().equals(Type.Kind.ARRAY);
+    }
+
+    /**
+     * Return true if type is java Collection type which is handled as GraphQL array
+     *
+     * @param type to check
+     * @return if this is a collection
+     */
+    public static boolean isCollection(Type type) {
+        if (isParameterized(type)) {
+            ClassInfo clazz = ScanningContext.getIndex().getClassByName(type.name());
+            if (clazz == null) {
+                // use classloader instead of jandex to handle basic java classes/interfaces
+                try {
+                    Class<?> clazzLoaded = Classes.class.getClassLoader().loadClass(type.name().toString());
+                    return Collection.class.isAssignableFrom(clazzLoaded);
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException("Info not found in Jandex index nor classpath for class name:" + type.name());
+                }
+            }
+            if (KNOWN_COLLECTIONS.contains(clazz.name())) {
+                return true;
+            }
+
+            // we have to go recursively over all super-interfaces as Jandex provides only direct interfaces
+            // implemented in the class itself
+            for (Type intf : clazz.interfaceTypes()) {
+                if (isCollection(intf)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return true if type is java Map or its implementations (KNOWN_MAPS)
+     *
+     * @param type to check
+     * @return if this is a map
+     */
+    public static boolean isMap(Type type) {
+        if (isParameterized(type)) {
+
+            ClassInfo clazz = ScanningContext.getIndex().getClassByName(type.name());
+            if (clazz == null) {
+                // use classloader instead of jandex to handle basic java classes/interfaces
+                try {
+                    Class<?> clazzLoaded = Classes.class.getClassLoader().loadClass(type.name().toString());
+                    return Map.class.isAssignableFrom(clazzLoaded);
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException("Info not found in Jandex index nor classpath for class name:" + type.name());
+                }
+            }
+            if (KNOWN_MAPS.contains(clazz.name())) {
+                return true;
+            }
+
+            // we have to go recursively over all super-interfaces as Jandex provides only direct interfaces
+            // implemented in the class itself
+            for (Type intf : clazz.interfaceTypes()) {
+                if (isMap(intf)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static final DotName UNI = DotName.createSimple(Uni.class.getName());
+    private static final DotName MULTI = DotName.createSimple(Multi.class.getName());
+
+    public static final DotName OBJECT = DotName.createSimple(Object.class.getName());
+
+    public static final DotName COLLECTION = DotName.createSimple(Collection.class.getName());
+    public static final DotName LIST = DotName.createSimple(List.class.getName());
+    public static final DotName LINKED_LIST = DotName.createSimple(LinkedList.class.getName());
+    public static final DotName VECTOR = DotName.createSimple(Vector.class.getName());
+    public static final DotName ARRAY_LIST = DotName.createSimple(ArrayList.class.getName());
+    public static final DotName STACK = DotName.createSimple(Stack.class.getName());
+
+    public static final DotName SET = DotName.createSimple(Set.class.getName());
+    public static final DotName HASH_SET = DotName.createSimple(HashSet.class.getName());
+    public static final DotName SORTED_SET = DotName.createSimple(SortedSet.class.getName());
+    public static final DotName TREE_SET = DotName.createSimple(TreeSet.class.getName());
+
+    public static final DotName QUEUE = DotName.createSimple(Queue.class.getName());
+    public static final DotName DEQUE = DotName.createSimple(Deque.class.getName());
+
+    public static final DotName MAP = DotName.createSimple(Map.class.getName());
+    public static final DotName HASH_MAP = DotName.createSimple(HashMap.class.getName());
+    public static final DotName TREE_MAP = DotName.createSimple(TreeMap.class.getName());
+    public static final DotName HASHTABLE = DotName.createSimple(Hashtable.class.getName());
+    public static final DotName SORTED_MAP = DotName.createSimple(SortedMap.class.getName());
+
+    public static final DotName OPTIONAL = DotName.createSimple(Optional.class.getName());
+    public static final DotName TYPESAFE_RESPONSE = DotName.createSimple(TypesafeResponse.class.getName());
+    public static final DotName ERROR_OR = DotName.createSimple(ErrorOr.class.getName());
+
+    private static final DotName INTEGER_OPTIONAL = DotName.createSimple(OptionalInt.class.getName());
+    private static final DotName DOUBLE_OPTIONAL = DotName.createSimple(OptionalDouble.class.getName());
+    private static final DotName LONG_OPTIONAL = DotName.createSimple(OptionalLong.class.getName());
+
+    private static final List<DotName> KNOWN_COLLECTIONS = new ArrayList<>();
+    private static final List<DotName> KNOWN_MAPS = new ArrayList<>();
+    static {
+        KNOWN_COLLECTIONS.add(COLLECTION);
+        KNOWN_COLLECTIONS.add(LIST);
+        KNOWN_COLLECTIONS.add(LINKED_LIST);
+        KNOWN_COLLECTIONS.add(VECTOR);
+        KNOWN_COLLECTIONS.add(ARRAY_LIST);
+        KNOWN_COLLECTIONS.add(STACK);
+        KNOWN_COLLECTIONS.add(SET);
+        KNOWN_COLLECTIONS.add(HASH_SET);
+        KNOWN_COLLECTIONS.add(SORTED_SET);
+        KNOWN_COLLECTIONS.add(TREE_SET);
+        KNOWN_COLLECTIONS.add(QUEUE);
+        KNOWN_COLLECTIONS.add(DEQUE);
+
+        KNOWN_MAPS.add(MAP);
+        KNOWN_MAPS.add(HASH_MAP);
+        KNOWN_MAPS.add(TREE_MAP);
+        KNOWN_MAPS.add(HASHTABLE);
+        KNOWN_MAPS.add(SORTED_MAP);
+    }
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/ClientModelBuilder.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/ClientModelBuilder.java
@@ -1,0 +1,93 @@
+package io.smallrye.graphql.client.model;
+
+import static io.smallrye.graphql.client.model.Annotations.GRAPHQL_CLIENT_API;
+import static io.smallrye.graphql.client.model.ScanningContext.getIndex;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.logging.Logger;
+
+import io.smallrye.graphql.client.model.helper.OperationModel;
+
+/**
+ * Builder class for generating client models from Jandex index.
+ * It scans for classes annotated with {@link Annotations#GRAPHQL_CLIENT_API} and generates client models based on the annotated
+ * methods.
+ */
+
+public class ClientModelBuilder {
+    private static final Logger LOG = Logger.getLogger(ClientModelBuilder.class.getName());
+
+    /**
+     * Builds the client models from the given Jandex index.
+     *
+     * @param index The Jandex index containing class information.
+     * @return The generated client models.
+     */
+    public static ClientModels build(IndexView index) {
+        ScanningContext.register(index);
+        return new ClientModelBuilder().generateClientModels();
+    }
+
+    private ClientModelBuilder() {
+    }
+
+    /**
+     * Generates the client models by scanning classes annotated with {@link Annotations#GRAPHQL_CLIENT_API}.
+     *
+     * @return The generated client models.
+     */
+    private ClientModels generateClientModels() {
+        ClientModels clientModels = new ClientModels();
+        Map<String, ClientModel> clientModelMap = new HashMap<>();
+
+        // Get all the @GraphQLClientApi annotations
+        Collection<AnnotationInstance> graphQLApiAnnotations = getIndex()
+                .getAnnotations(GRAPHQL_CLIENT_API);
+
+        graphQLApiAnnotations.forEach(graphQLApiAnnotation -> {
+            ClientModel operationMap = new ClientModel();
+            ClassInfo apiClass = graphQLApiAnnotation.target().asClass();
+            List<MethodInfo> methods = getAllMethodsIncludingFromSuperClasses(apiClass);
+            methods.stream().forEach(method -> {
+                String query = new QueryBuilder(method).build();
+                LOG.debugf("[%s] - Query created: %s", apiClass.name().toString(), query);
+                operationMap.getOperationMap()
+                        .put(OperationModel.of(method).getMethodKey(), query);
+            });
+            clientModelMap.put(
+                    (graphQLApiAnnotation.value("configKey") == null) ? apiClass.name().toString()
+                            : graphQLApiAnnotation.value("configKey").asString(),
+                    operationMap);
+        });
+        clientModels.setClientModelMap(clientModelMap);
+        return clientModels;
+    }
+
+    /**
+     * Retrieves all methods, including those from superclasses (interfaces).
+     *
+     * @param classInfo The ClassInfo for which methods are retrieved.
+     * @return The list of MethodInfo objects representing all methods.
+     */
+    private List<MethodInfo> getAllMethodsIncludingFromSuperClasses(ClassInfo classInfo) {
+        List<MethodInfo> methods = new ArrayList<>();
+        classInfo.methods().stream().filter(methodInfo -> !methodInfo.isSynthetic()).forEach(methods::add);
+        List<DotName> interfaceNames = classInfo.interfaceNames();
+        interfaceNames.forEach(interfaceName -> {
+            List<MethodInfo> parentMethods = getAllMethodsIncludingFromSuperClasses(getIndex().getClassByName(interfaceName));
+            methods.addAll(parentMethods);
+        });
+
+        return methods;
+    }
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/QueryBuilder.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/QueryBuilder.java
@@ -1,0 +1,61 @@
+package io.smallrye.graphql.client.model;
+
+import static io.smallrye.graphql.client.model.helper.OperationModel.of;
+import static java.util.stream.Collectors.joining;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.smallrye.graphql.client.model.helper.DirectiveInstance;
+import io.smallrye.graphql.client.model.helper.OperationModel;
+
+/**
+ * A utility class for building GraphQL queries based on a given {@link MethodInfo} which will be scanned thanks
+ * to Jandex during build-time.
+ */
+public class QueryBuilder {
+    private final OperationModel method;
+
+    /**
+     * Constructs a new {@code QueryBuilder} instance for the specified {@link MethodInfo}.
+     *
+     * @param method The {@link MethodInfo} representing the GraphQL operation.
+     */
+    public QueryBuilder(MethodInfo method) {
+        this.method = of(method);
+    }
+
+    /**
+     * Builds and returns the GraphQL query string.
+     *
+     * @return The constructed GraphQL query string.
+     */
+    public String build() {
+        StringBuilder request = new StringBuilder(method.getOperationTypeAsString());
+        request.append(" ");
+        request.append(method.getName()); // operationName
+        if (method.hasValueParameters()) {
+            request.append(method.valueParameters().stream().map(method::declare).collect(joining(", ", "(", ")")));
+        }
+
+        if (method.isSingle()) {
+            request.append(" { ");
+            request.append(method.getName());
+            if (method.hasRootParameters()) {
+                request.append(method.rootParameters().stream()
+                        .map(method::bind)
+                        .collect(joining(", ", "(", ")")));
+            }
+
+            if (method.hasDirectives()) {
+                request.append(method.getDirectives().stream().map(DirectiveInstance::buildDirective).collect(joining()));
+            }
+        }
+
+        request.append(method.fields(method.getReturnType()));
+
+        if (method.isSingle())
+            request.append(" }");
+
+        return request.toString();
+    }
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/Scalars.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/Scalars.java
@@ -1,0 +1,145 @@
+package io.smallrye.graphql.client.model;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URL;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class Scalars {
+    private static final Map<String, String> scalarMap = new HashMap<>();
+    private static final String STRING = "String";
+    private static final String BOOLEAN = "Boolean";
+    private static final String INTEGER = "Int";
+    private static final String FLOAT = "Float";
+    private static final String BIGINTEGER = "BigInteger";
+    private static final String BIGDECIMAL = "BigDecimal";
+    private static final String DATE = "Date";
+    private static final String TIME = "Time";
+    private static final String DATETIME = "DateTime";
+    private static final String ID = "ID";
+    private static final String PERIOD = "Period";
+    private static final String DURATION = "Duration";
+    private static final String VOID = "Void";
+
+    private Scalars() {
+    }
+
+    public static boolean isScalar(String className) {
+        return scalarMap.containsKey(className);
+    }
+
+    public static String getScalar(String identifier) {
+        return scalarMap.get(identifier);
+    }
+
+    public static boolean isStringScalar(String className) {
+        String potentionalString = scalarMap.get(className);
+
+        return potentionalString != null && scalarMap.get(className).equals(STRING);
+    }
+
+    static {
+        // The main java type should go first.
+
+        // Strings
+        populateScalar(String.class.getName(), STRING);
+        populateScalar(char.class.getName(), STRING);
+        populateScalar(Character.class.getName(), STRING);
+        populateScalar(UUID.class.getName(), STRING);
+        populateScalar(URL.class.getName(), STRING);
+        populateScalar(URI.class.getName(), STRING);
+        populateScalar("org.bson.types.ObjectId", STRING);
+        populateScalar("javax.json.JsonObject", STRING);
+        populateScalar("javax.json.JsonArray", STRING);
+        populateScalar("jakarta.json.JsonObject", STRING);
+        populateScalar("jakarta.json.JsonArray", STRING);
+
+        // Boolean
+        populateScalar(Boolean.class.getName(), BOOLEAN);
+        populateScalar(boolean.class.getName(), BOOLEAN);
+        populateScalar(AtomicBoolean.class.getName(), BOOLEAN);
+
+        // Integer
+        populateScalar(Integer.class.getName(), INTEGER);
+        populateScalar(int.class.getName(), INTEGER);
+        populateScalar(Short.class.getName(), INTEGER);
+        populateScalar(short.class.getName(), INTEGER);
+        populateScalar(Byte.class.getName(), INTEGER);
+        populateScalar(byte.class.getName(), INTEGER);
+        populateScalar(OptionalInt.class.getName(), INTEGER);
+        populateScalar(AtomicInteger.class.getName(), INTEGER);
+
+        // Float
+        populateScalar(Float.class.getName(), FLOAT);
+        populateScalar(float.class.getName(), FLOAT);
+        populateScalar(Double.class.getName(), FLOAT);
+        populateScalar(double.class.getName(), FLOAT);
+        populateScalar(OptionalDouble.class.getName(), FLOAT);
+
+        // BigInteger
+        populateScalar(BigInteger.class.getName(), BIGINTEGER);
+        populateScalar(Long.class.getName(), BIGINTEGER);
+        populateScalar(long.class.getName(), BIGINTEGER);
+        populateScalar(OptionalLong.class.getName(), BIGINTEGER);
+        populateScalar(AtomicLong.class.getName(), BIGINTEGER);
+
+        // BigDecimal
+        populateScalar(BigDecimal.class.getName(), BIGDECIMAL);
+
+        // Date
+        populateScalar(LocalDate.class.getName(), DATE);
+        populateScalar(Date.class.getName(), DATE);
+
+        // Time
+        populateScalar(LocalTime.class.getName(), TIME);
+        populateScalar(Time.class.getName(), TIME);
+        populateScalar(OffsetTime.class.getName(), TIME);
+
+        // DateTime
+        populateScalar(LocalDateTime.class.getName(), DATETIME);
+        populateScalar(java.util.Date.class.getName(), DATETIME);
+        populateScalar(Timestamp.class.getName(), DATETIME);
+        populateScalar(ZonedDateTime.class.getName(), DATETIME);
+        populateScalar(OffsetDateTime.class.getName(), DATETIME);
+        populateScalar(Instant.class.getName(), DATETIME);
+        populateScalar(Calendar.class.getName(), DATETIME);
+        populateScalar(GregorianCalendar.class.getName(), DATETIME);
+
+        // Duration
+        populateScalar(Duration.class.getName(), DURATION);
+        // Period
+        populateScalar(Period.class.getName(), PERIOD);
+
+        // Void
+        populateScalar(Void.class.getName(), VOID);
+        populateScalar(void.class.getName(), VOID);
+    }
+
+    private static void populateScalar(String className, String scalarName) {
+        scalarMap.put(className, scalarName);
+    }
+
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/ScanningContext.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/ScanningContext.java
@@ -1,0 +1,26 @@
+package io.smallrye.graphql.client.model;
+
+import org.jboss.jandex.IndexView;
+
+public class ScanningContext {
+    private static final ThreadLocal<ScanningContext> current = new ThreadLocal<>();
+
+    public static void register(IndexView index) {
+        ScanningContext registry = new ScanningContext(index);
+        current.set(registry);
+    }
+
+    public static IndexView getIndex() {
+        return current.get().index;
+    }
+
+    public static void remove() {
+        current.remove();
+    }
+
+    private final IndexView index;
+
+    private ScanningContext(final IndexView index) {
+        this.index = index;
+    }
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/DirectiveHelper.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/DirectiveHelper.java
@@ -1,0 +1,83 @@
+/**
+ * Helper class for resolving GraphQL directives from annotated elements using Jandex.
+ */
+package io.smallrye.graphql.client.model.helper;
+
+import static io.smallrye.graphql.client.model.Annotations.DIRECTIVE;
+import static io.smallrye.graphql.client.model.Annotations.REPEATABLE;
+import static io.smallrye.graphql.client.model.ScanningContext.getIndex;
+import static java.util.Arrays.stream;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ClassInfo;
+
+/**
+ * Utility methods for resolving GraphQL directives from annotated elements.
+ *
+ * @author mskacelik
+ */
+public class DirectiveHelper {
+
+    /**
+     * Resolves GraphQL directives from a stream of annotation instances based on the given directive location and target kind.
+     *
+     * @param annotationInstances The stream of annotation instances to filter.
+     * @param directiveLocation The GraphQL directive location.
+     * @param targetKind The target kind of the annotation.
+     * @return A stream of resolved annotation instances that match the specified criteria.
+     */
+    public static Stream<AnnotationInstance> resolveDirectives(Stream<AnnotationInstance> annotationInstances,
+            String directiveLocation,
+            AnnotationTarget.Kind targetKind) {
+        return resolveDirectives(annotationInstances
+                .filter(annotation -> annotation.target().kind() == targetKind), directiveLocation);
+    }
+
+    /**
+     * Resolves GraphQL directives from a stream of annotation instances based on the given directive location.
+     *
+     * @param annotationInstances The stream of annotation instances to filter.
+     * @param directiveLocation The GraphQL directive location.
+     * @return A stream of resolved annotation instances that match the specified criteria.
+     */
+    public static Stream<AnnotationInstance> resolveDirectives(Stream<AnnotationInstance> annotationInstances,
+            String directiveLocation) {
+        return annotationInstances
+                .flatMap(annotationInstance -> {
+                    ClassInfo scannedAnnotation = getIndex().getClassByName(annotationInstance.name());
+                    if (scannedAnnotation != null) {
+                        if (scannedAnnotation.hasAnnotation(DIRECTIVE)) {
+                            return Stream.of(annotationInstance);
+                        }
+                        Optional<AnnotationInstance> repeatableAnnotation = getIndex()
+                                .getAnnotations(REPEATABLE).stream()
+                                .filter(annotation -> annotation.target().hasAnnotation(DIRECTIVE)
+                                        && annotation.value().asClass().name().equals(annotationInstance.name()))
+                                .findFirst();
+                        if (repeatableAnnotation.isPresent()) {
+                            return Stream.of(annotationInstance.value().asNestedArray());
+                        }
+                    }
+                    return Stream.empty();
+                })
+                .filter(annotation -> directiveFilter(annotation, directiveLocation));
+
+    }
+
+    /**
+     * Checks if a given annotation instance matches the specified GraphQL directive location.
+     *
+     * @param annotation The annotation instance to check.
+     * @param directiveLocation The GraphQL directive location to match.
+     * @return {@code true} if the annotation matches the directive location, {@code false} otherwise.
+     */
+    private static boolean directiveFilter(AnnotationInstance annotation, String directiveLocation) {
+        return stream(
+                getIndex().getClassByName(annotation.name()).annotation(DIRECTIVE).value("on").asEnumArray())
+                .anyMatch(directiveLocation::equals);
+    }
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/DirectiveInstance.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/DirectiveInstance.java
@@ -1,0 +1,108 @@
+package io.smallrye.graphql.client.model.helper;
+
+import static java.util.stream.Collectors.toUnmodifiableMap;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+
+/**
+ * Represents an instance of a GraphQL directive, providing methods to build the directive string
+ * and convert the directive arguments to a string representation.
+ *
+ * @author mskacelik
+ */
+public class DirectiveInstance {
+    private final String name;
+    private final Map<String, Object> values;
+
+    /**
+     * Constructs a new {@code DirectiveInstance} based on the provided Jandex {@link AnnotationInstance}.
+     *
+     * @param annotationInstance The Jandex {@link AnnotationInstance} representing the GraphQL directive.
+     */
+    DirectiveInstance(AnnotationInstance annotationInstance) {
+        this.name = toDirectiveName(annotationInstance.name().withoutPackagePrefix());
+        this.values = annotationInstance.values().stream().collect(
+                toUnmodifiableMap(AnnotationValue::name, AnnotationValue::value));
+    }
+
+    /**
+     * Creates and returns a new {@code DirectiveInstance} based on the provided Jandex {@link AnnotationInstance}.
+     *
+     * @param annotationInstance The Jandex {@link AnnotationInstance} representing the GraphQL directive.
+     * @return A new {@code DirectiveInstance} instance.
+     */
+    public static DirectiveInstance of(AnnotationInstance annotationInstance) {
+        return new DirectiveInstance(annotationInstance);
+    }
+
+    /**
+     * Builds the GraphQL directive string, including its name and arguments.
+     *
+     * @return The GraphQL directive string.
+     */
+    public String buildDirective() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(" @") // space at the beginning for chaining multiple directives.
+                .append(name);
+
+        if (!values.isEmpty()) {
+            builder
+                    .append("(")
+                    .append(buildDirectiveArgs())
+                    .append(")");
+        }
+
+        return builder.toString();
+    }
+
+    /**
+     * Converts the directive arguments to a string representation.
+     *
+     * @return The string representation of the directive arguments.
+     */
+    private String buildDirectiveArgs() {
+        return values.entrySet().stream()
+                .map(entry -> new StringBuilder()
+                        .append(entry.getKey())
+                        .append(": ")
+                        .append(directiveArgumentValueToString(entry.getValue()))
+                        .toString())
+                .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Converts the first character of the directive name to lowercase if it is uppercase.
+     *
+     * @param name The original directive name.
+     * @return The modified directive name.
+     */
+    private String toDirectiveName(String name) {
+        if (Character.isUpperCase(name.charAt(0)))
+            name = Character.toLowerCase(name.charAt(0)) + name.substring(1);
+        return name;
+    }
+
+    /**
+     * Converts the value of a directive argument to its string representation.
+     *
+     * @param dirArgVal The value of the directive argument.
+     * @return The string representation of the directive argument value.
+     */
+    private String directiveArgumentValueToString(Object dirArgVal) {
+        if (dirArgVal.getClass().isArray()) {
+            return Arrays.stream((Object[]) dirArgVal).map(this::directiveArgumentValueToString)
+                    .collect(Collectors.joining(", ", "[", "]"));
+        }
+        return ((dirArgVal instanceof String) ? "\"" + dirArgVal + "\"" : dirArgVal).toString();
+    }
+
+    @Override
+    public String toString() {
+        return "DirectiveInstance{" + "type=" + name + ", values=" + values + '}';
+    }
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/FieldModel.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/FieldModel.java
@@ -1,0 +1,139 @@
+package io.smallrye.graphql.client.model.helper;
+
+import static io.smallrye.graphql.client.model.Annotations.NAME;
+import static java.util.stream.Collectors.toList;
+
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.microprofile.graphql.Name;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+
+/**
+ * Represents a model for a Java (jandex) class field, providing information about the field's characteristics
+ * and associated directives.
+ *
+ * @author mskacelik
+ */
+public class FieldModel implements NamedElement {
+    private FieldInfo field;
+    private List<DirectiveInstance> directives;
+
+    /**
+     * Creates a new {@code FieldModel} instance.
+     *
+     * @param field The {@link FieldInfo} object representing the field.
+     */
+    FieldModel(FieldInfo field) {
+        this.field = field;
+        this.directives = DirectiveHelper.resolveDirectives(field.annotations().stream(), getDirectiveLocation())
+                .map(DirectiveInstance::of)
+                .collect(toList());
+    }
+
+    /**
+     * Creates and returns a new {@code FieldModel} instance based on the provided field information and raw type.
+     *
+     * @param field The {@link FieldInfo} object representing the field.
+     * @return A new {@code FieldModel} instance.
+     */
+    public static FieldModel of(FieldInfo field) {
+        return new FieldModel(field);
+    }
+
+    /**
+     * If the field is renamed with a {@link Name} annotation, the real field name is used as an alias.
+     *
+     * @return An {@link Optional} containing the alias if explicitly stated, otherwise empty.
+     */
+    public Optional<String> getAlias() {
+        if (field.hasAnnotation(NAME)) {
+            return Optional.of(getRawName());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String getName() {
+        if (field.hasAnnotation(NAME)) {
+            return field.annotation(NAME).value().asString();
+        }
+        return getRawName();
+    }
+
+    @Override
+    public String getRawName() {
+        return field.name();
+    }
+
+    @Override
+    public String getDirectiveLocation() {
+        return "FIELD";
+    }
+
+    /**
+     * Checks if the field has a specific annotation.
+     *
+     * @param annotation The annotation to check.
+     * @return {@code true} if the field has the specified annotation, otherwise {@code false}.
+     */
+    public boolean hasAnnotation(DotName annotation) {
+        return field.hasAnnotation(annotation);
+    }
+
+    /**
+     * Checks if the field is static.
+     *
+     * @return {@code true} if the field is static, otherwise {@code false}.
+     */
+    public boolean isStatic() {
+        return Modifier.isStatic(field.flags());
+    }
+
+    /**
+     * Checks if the field is transient.
+     *
+     * @return {@code true} if the field is transient, otherwise {@code false}.
+     */
+    public boolean isTransient() {
+        return Modifier.isTransient(field.flags());
+    }
+
+    /**
+     * Checks if the field is synthetic.
+     *
+     * @return {@code true} if the field is synthetic, otherwise {@code false}.
+     */
+    public boolean isSynthetic() {
+        return field.asField().isSynthetic();
+    }
+
+    /**
+     * Gets the type model associated with the field.
+     *
+     * @return The {@link TypeModel} representing the type of the field.
+     */
+    public TypeModel getType() {
+        return TypeModel.of(field.type());
+    }
+
+    /**
+     * Checks if the field has any associated directives.
+     *
+     * @return {@code true} if the field has directives, otherwise {@code false}.
+     */
+    public boolean hasDirectives() {
+        return !directives.isEmpty();
+    }
+
+    /**
+     * Gets the list of directive instances associated with the field.
+     *
+     * @return The list of {@link DirectiveInstance} objects.
+     */
+    public List<DirectiveInstance> getDirectives() {
+        return directives;
+    }
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/NamedElement.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/NamedElement.java
@@ -1,0 +1,46 @@
+package io.smallrye.graphql.client.model.helper;
+
+import java.util.List;
+
+/**
+ * An interface for elements that have a name and may be associated with GraphQL directives.
+ *
+ * @author mskacelik
+ */
+public interface NamedElement {
+
+    /**
+     * Gets the name of the NamedElement, considering any {@link org.eclipse.microprofile.graphql.Name} annotation if present.
+     *
+     * @return The field name.
+     */
+    String getName();
+
+    /**
+     * Gets the raw (original) name of the NamedElement.
+     *
+     * @return The raw field name.
+     */
+    String getRawName();
+
+    /**
+     * Gets the location of directives associated with this NamedElement.
+     *
+     * @return The directive location
+     */
+    String getDirectiveLocation();
+
+    /**
+     * Checks if the NamedElement has associated directives.
+     *
+     * @return {@code true} if the NamedElement has directives, otherwise {@code false}.
+     */
+    boolean hasDirectives();
+
+    /**
+     * Gets the list of directives associated with the NamedElement.
+     *
+     * @return The list of {@link DirectiveInstance} objects.
+     */
+    List<DirectiveInstance> getDirectives();
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/OperationModel.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/OperationModel.java
@@ -1,0 +1,391 @@
+package io.smallrye.graphql.client.model.helper;
+
+import static io.smallrye.graphql.client.model.Annotations.MULTIPLE;
+import static io.smallrye.graphql.client.model.Annotations.MUTATION;
+import static io.smallrye.graphql.client.model.Annotations.NAME;
+import static io.smallrye.graphql.client.model.Annotations.QUERY;
+import static io.smallrye.graphql.client.model.Annotations.SUBCRIPTION;
+import static io.smallrye.graphql.client.model.ScanningContext.getIndex;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Stack;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.JandexReflection;
+import org.jboss.jandex.MethodInfo;
+
+import io.smallrye.graphql.client.core.OperationType;
+import io.smallrye.graphql.client.impl.SmallRyeGraphQLClientMessages;
+import io.smallrye.graphql.client.model.MethodKey;
+
+/**
+ * Represents a model for a GraphQL operation method, providing methods to generate GraphQL query fields,
+ * handle parameter bindings, and extract operation-related information.
+ */
+public class OperationModel implements NamedElement {
+    private final MethodInfo method;
+    private final List<ParameterModel> parameters;
+    private final Stack<String> typeStack = new Stack<>();
+    private final Stack<String> expressionStack = new Stack<>();
+    private Stack<TypeModel> rawParametrizedTypes = new Stack<>();
+    private final List<DirectiveInstance> directives;
+
+    /**
+     * Creates a new {@code OperationModel} instance based on the provided Jandex {@link MethodInfo}.
+     *
+     * @param method The Jandex {@link MethodInfo} representing the GraphQL operation method.
+     */
+    OperationModel(MethodInfo method) {
+        this.method = method;
+        this.parameters = method.parameters().stream().map(ParameterModel::of).collect(Collectors.toList());
+        this.directives = DirectiveHelper.resolveDirectives(method.annotations().stream(),
+                getDirectiveLocation(), AnnotationTarget.Kind.METHOD)
+                .map(DirectiveInstance::of)
+                .collect(toList());
+    }
+
+    /**
+     * Creates and returns a new {@code OperationModel} instance based on the provided Jandex {@link MethodInfo}.
+     *
+     * @param method The Jandex {@link MethodInfo} representing the GraphQL operation method.
+     * @return A new {@code OperationModel} instance.
+     */
+    public static OperationModel of(MethodInfo method) {
+        return new OperationModel(method);
+    }
+
+    /**
+     * Generates GraphQL query fields for the specified {@code TypeModel}.
+     *
+     * @param type The {@link TypeModel} for which to generate GraphQL query fields.
+     * @return The generated GraphQL query fields.
+     * @throws IllegalStateException If a field recursion is detected.
+     */
+    public String fields(TypeModel type) {
+        if (typeStack.contains(type.getName()))
+            throw SmallRyeGraphQLClientMessages.msg.fieldRecursionFound();
+        try {
+            typeStack.push(type.getName());
+            return recursionCheckedFields(type);
+        } finally {
+            typeStack.pop();
+        }
+    }
+
+    /**
+     * Generates GraphQL query fields for the specified {@code TypeModel} with recursion checking.
+     *
+     * @param type The {@link TypeModel} for which to generate GraphQL query fields.
+     * @return The generated GraphQL query fields.
+     */
+    public String recursionCheckedFields(TypeModel type) {
+        while (type.isOptional() || type.isErrorOr() || type.isTypesafeResponse()) {
+            type = type.getFirstRawType(); // unwrapping
+        }
+        if (type.isScalar())
+            return "";
+        if (type.isCollectionOrArray() || type.isAsync())
+            return fields(type.getItemTypeOrElementType());
+        if (type.isMap()) {
+            String keyFields = fields(type.getMapKeyType());
+            String valueFields = fields(type.getMapValueType());
+            return " {key" + keyFields + " value" + valueFields + "}";
+        }
+        if (isRawParametrizedType(type)) {
+            rawParametrizedTypes.push(type.getFirstRawType());
+        }
+        String fieldsResult = type.fields()
+                .map(this::field)
+                .collect(joining(" ", " {", "}"));
+        if (isRawParametrizedType(type)) {
+            rawParametrizedTypes.pop();
+        }
+        return fieldsResult;
+
+    }
+
+    /**
+     * Generates the GraphQL representation of a field based on the provided {@code FieldModel}.
+     *
+     * @param field The {@link FieldModel} representing the field.
+     * @return The GraphQL representation of the field.
+     */
+    public String field(FieldModel field) {
+        TypeModel type = field.getType();
+        if (type.isTypeVariable()) {
+            type = rawParametrizedTypes.peek();
+        }
+        StringBuilder expression = new StringBuilder();
+        field.getAlias().ifPresent(alias -> expression.append(alias).append(":"));
+        expression.append(field.getName());
+
+        if (field.hasDirectives()) {
+            expression.append(field.getDirectives().stream().map(DirectiveInstance::buildDirective).collect(joining()));
+        }
+
+        String path = nestedExpressionPrefix() + field.getRawName();
+        List<ParameterModel> nestedParameters = nestedParameters(path);
+        if (!nestedParameters.isEmpty()) {
+            expression.append(nestedParameters.stream()
+                    .map(this::bind)
+                    .collect(joining(", ", "(", ")")));
+        }
+
+        expressionStack.push(path);
+        expression.append(fields(type)); // appends the empty string, if the type is scalar, etc.
+        expressionStack.pop();
+
+        return expression.toString();
+    }
+
+    /**
+     * Declares a GraphQL parameter for the specified {@code ParameterModel}.
+     *
+     * @param parameter The {@link ParameterModel} for which to declare the GraphQL parameter.
+     * @return The GraphQL declaration of the parameter.
+     */
+    public String declare(ParameterModel parameter) {
+        return "$" + parameter.getRawName() + ": " + parameter.graphQlInputTypeName() +
+                ((parameter.hasDirectives()) ? parameter.getDirectives()
+                        .stream()
+                        .map(DirectiveInstance::buildDirective)
+                        .collect(joining())
+                        : "");
+    }
+
+    /**
+     * Binds a GraphQL parameter for the specified {@code ParameterModel}.
+     *
+     * @param parameter The {@link ParameterModel} for which to bind the GraphQL parameter.
+     * @return The GraphQL binding of the parameter.
+     */
+    public String bind(ParameterModel parameter) {
+        return parameter.getName() + ": $" + parameter.getRawName();
+    }
+
+    /**
+     * Retrieves the prefix for nested expressions in GraphQL queries.
+     *
+     * @return The prefix for nested expressions.
+     */
+    public String nestedExpressionPrefix() {
+        return expressionStack.isEmpty() ? "" : expressionStack.peek() + ".";
+    }
+
+    /**
+     * Gets the operation type of the GraphQL operation.
+     *
+     * @return The {@link OperationType} of the GraphQL operation.
+     */
+    public OperationType getOperationType() {
+        if (method.hasAnnotation(MUTATION)) {
+            return OperationType.MUTATION;
+        }
+        if (method.hasAnnotation(SUBCRIPTION)) {
+            return OperationType.SUBSCRIPTION;
+        }
+        return OperationType.QUERY;
+    }
+
+    /**
+     * Gets the name of the GraphQL operation, considering any {@link org.eclipse.microprofile.graphql.Query}
+     * or {@link org.eclipse.microprofile.graphql.Name} annotations.
+     *
+     * @return An optional containing the operation name if specified, otherwise empty.
+     */
+    public Optional<String> queryName() {
+        Optional<AnnotationInstance> queryAnnotation = getMethodAnnotation(QUERY);
+        if (queryAnnotation.isPresent() && queryAnnotation.orElseThrow().value() != null)
+            return Optional.of(queryAnnotation.orElseThrow().value().asString());
+        Optional<AnnotationInstance> nameAnnotation = getMethodAnnotation(NAME);
+        if (nameAnnotation.isPresent())
+            return Optional.of(nameAnnotation.orElseThrow().value().asString());
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the name of the GraphQL mutation, considering any {@link org.eclipse.microprofile.graphql.Mutation} annotation.
+     *
+     * @return An optional containing the mutation name if specified, otherwise empty.
+     */
+    public Optional<String> mutationName() {
+        Optional<AnnotationInstance> mutationAnnotation = getMethodAnnotation(MUTATION);
+        if (mutationAnnotation.isPresent() && mutationAnnotation.orElseThrow().value() != null)
+            return Optional.of(mutationAnnotation.orElseThrow().value().asString());
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the name of the GraphQL subscription, considering any {@link io.smallrye.graphql.api.Subscription} annotation.
+     *
+     * @return An optional containing the subscription name if specified, otherwise empty.
+     */
+
+    public Optional<String> subscriptionName() {
+        Optional<AnnotationInstance> subscriptionAnnotation = getMethodAnnotation(SUBCRIPTION);
+        if (subscriptionAnnotation.isPresent() && subscriptionAnnotation.orElseThrow().value() != null)
+            return Optional.of(subscriptionAnnotation.orElseThrow().value().asString());
+        return Optional.empty();
+    }
+
+    @Override
+    public String getName() {
+        return queryName()
+                .orElseGet(() -> mutationName()
+                        .orElseGet(() -> subscriptionName()
+                                .orElseGet(this::getRawName)));
+    }
+
+    @Override
+    public String getRawName() {
+        String name = method.name();
+        if (name.startsWith("get") && name.length() > 3 && Character.isUpperCase(name.charAt(3)))
+            return Character.toLowerCase(name.charAt(3)) + name.substring(4);
+        return name;
+    }
+
+    @Override
+    public String getDirectiveLocation() {
+        // currently the definition is that, if there is a method targeted directive, that directive
+        // will be transformed to high-level field. So the current implementation does not work with
+        // QUERY, MUTATION, SUBSCRIPTION locations...
+        return "FIELD";
+    }
+
+    @Override
+    public boolean hasDirectives() {
+        return !directives.isEmpty();
+    }
+
+    @Override
+    public List<DirectiveInstance> getDirectives() {
+        return directives;
+    }
+
+    /**
+     * Retrieves the list of parameters representing the values for the GraphQL operation.
+     *
+     * @return The list of value parameters.
+     */
+    public List<ParameterModel> valueParameters() {
+        return parameters.stream().filter(ParameterModel::isValueParameter).collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves the list of parameters representing the root-level parameters for the GraphQL operation.
+     *
+     * @return The list of root parameters.
+     */
+    public List<ParameterModel> rootParameters() {
+        return parameters.stream().filter(ParameterModel::isRootParameter).collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves the list of parameters representing nested parameters for the GraphQL operation.
+     *
+     * @param path The path for which nested parameters are retrieved.
+     * @return The list of nested parameters.
+     */
+    public List<ParameterModel> nestedParameters(String path) {
+        return parameters.stream()
+                .filter(ParameterModel::isNestedParameter)
+                .filter(parameter -> parameter
+                        .getNestedParameterNames()
+                        .anyMatch(path::equals))
+                .collect(toList());
+    }
+
+    /**
+     * Gets the return type of the GraphQL operation.
+     *
+     * @return The {@link TypeModel} representing the return type.
+     */
+    public TypeModel getReturnType() {
+        return TypeModel.of(method.returnType());
+    }
+
+    /**
+     * Checks if the GraphQL operation has value parameters.
+     *
+     * @return {@code true} if the operation has value parameters, otherwise {@code false}.
+     */
+    public boolean hasValueParameters() {
+        return !valueParameters().isEmpty();
+    }
+
+    /**
+     * Checks if the GraphQL operation has root-level parameters.
+     *
+     * @return {@code true} if the operation has root parameters, otherwise {@code false}.
+     */
+    public boolean hasRootParameters() {
+        return !rootParameters().isEmpty();
+    }
+
+    /**
+     * Checks if the GraphQL operation returns a single result (one GraphQL operation).
+     *
+     * @return {@code true} if the operation returns a single result, otherwise {@code false}.
+     */
+    public boolean isSingle() {
+        return getReturnType().isScalar()
+                || getReturnType().isParametrized()
+                || getReturnType().isArray()
+                || !getIndex().getClassByName(method.returnType().name()).hasAnnotation(MULTIPLE);
+    }
+
+    /**
+     * Gets the key for identifying the GraphQL operation method.
+     *
+     * @return The {@link MethodKey} representing the key for the operation method (return type, name, parameters types).
+     */
+    public MethodKey getMethodKey() {
+        return new MethodKey(JandexReflection.loadRawType(method.returnType()), method.name(), method.parameters().stream()
+                .map(methodParameterInfo -> JandexReflection.loadRawType(methodParameterInfo.type())).toArray(Class<?>[]::new));
+    }
+
+    /**
+     * Gets the string representation of the operation type (query, mutation, or subscription).
+     *
+     * @return The string representation of the operation type.
+     */
+    public String getOperationTypeAsString() {
+        switch (getOperationType()) {
+            case MUTATION:
+                return "mutation";
+            case SUBSCRIPTION:
+                return "subscription";
+            default:
+                return "query";
+        }
+    }
+
+    /**
+     * Retrieves a non-repeatable annotation for the GraphQL operation method.
+     *
+     * @param annotation The {@link DotName} representing the annotation to retrieve.
+     * @return An optional containing the annotation instance if present, otherwise empty.
+     */
+    private Optional<AnnotationInstance> getMethodAnnotation(DotName annotation) {
+        return method.annotations().stream()
+                .filter(annotationInstance -> annotationInstance.target().kind() == AnnotationTarget.Kind.METHOD)
+                .filter(annotationInstance -> annotationInstance.name().equals(annotation)).findFirst();
+    }
+
+    /**
+     * Checks if the given TypeModel represents a raw parametrized type, excluding type variables.
+     *
+     * @param type The TypeModel to check.
+     * @return {@code true} if the TypeModel represents a raw parametrized type (excluding type variables), otherwise
+     *         {@code false}.
+     */
+    private boolean isRawParametrizedType(TypeModel type) {
+        return type.isCustomParametrizedType() && !type.getFirstRawType().isTypeVariable();
+    }
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/ParameterModel.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/ParameterModel.java
@@ -1,0 +1,205 @@
+package io.smallrye.graphql.client.model.helper;
+
+import static io.smallrye.graphql.client.model.Annotations.ID;
+import static io.smallrye.graphql.client.model.Annotations.INPUT;
+import static io.smallrye.graphql.client.model.Annotations.NAME;
+import static io.smallrye.graphql.client.model.Annotations.NESTED_PARAMETER;
+import static io.smallrye.graphql.client.model.ScanningContext.getIndex;
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.jboss.jandex.MethodParameterInfo;
+
+import io.smallrye.graphql.client.model.Scalars;
+import io.smallrye.graphql.client.typesafe.api.Header;
+
+/**
+ * Represents a model for a method parameter in GraphQL, providing information about the parameter's name,
+ * type, and associated directives.
+ *
+ * @author mskacelik
+ */
+public class ParameterModel implements NamedElement {
+    private MethodParameterInfo parameter;
+    private TypeModel type;
+    private List<DirectiveInstance> directives;
+
+    /**
+     * Constructs a new {@code ParameterModel} instance based on the provided Jandex {@link MethodParameterInfo}.
+     *
+     * @param parameter The Jandex {@link MethodParameterInfo} representing the GraphQL method parameter.
+     */
+    ParameterModel(MethodParameterInfo parameter) {
+        this.parameter = parameter;
+        this.type = TypeModel.of(parameter.type());
+        this.directives = DirectiveHelper.resolveDirectives(parameter.annotations().stream(), getDirectiveLocation())
+                .map(DirectiveInstance::of)
+                .collect(toList());
+    }
+
+    /**
+     * Creates and returns a new {@code ParameterModel} instance based on the provided Jandex {@link MethodParameterInfo}.
+     *
+     * @param parameter The Jandex {@link MethodParameterInfo} representing the GraphQL method parameter.
+     * @return A new {@code ParameterModel} instance.
+     */
+    public static ParameterModel of(MethodParameterInfo parameter) {
+        return new ParameterModel(parameter);
+    }
+
+    /**
+     * Checks if the parameter is associated with a {@link Header} annotation, indicating it is a header parameter.
+     *
+     * @return {@code true} if the parameter is a header parameter, otherwise {@code false}.
+     */
+    private boolean isHeaderParameter() {
+        return parameter.hasAnnotation(Header.class);
+    }
+
+    /**
+     * Checks if the parameter is a value parameter, either a root or nested parameter.
+     *
+     * @return {@code true} if the parameter is a value parameter, otherwise {@code false}.
+     */
+    public boolean isValueParameter() {
+        return isRootParameter() || isNestedParameter();
+    }
+
+    /**
+     * Checks if the parameter is a root parameter (neither header nor nested parameter).
+     *
+     * @return {@code true} if the parameter is a root parameter, otherwise {@code false}.
+     */
+    public boolean isRootParameter() {
+        return !isHeaderParameter() && !isNestedParameter();
+    }
+
+    /**
+     * Checks if the parameter is a nested parameter.
+     *
+     * @return {@code true} if the parameter is a nested parameter, otherwise {@code false}.
+     */
+    public boolean isNestedParameter() {
+        return parameter.hasAnnotation(NESTED_PARAMETER);
+    }
+
+    /**
+     * Gets the names of nested parameters if the parameter is a nested parameter.
+     *
+     * @return A stream of nested parameter names.
+     */
+    public Stream<String> getNestedParameterNames() {
+        return Stream.of(parameter.annotation(NESTED_PARAMETER).value().asStringArray());
+    }
+
+    public String getName() {
+        if (parameter.hasAnnotation(NAME))
+            return parameter.annotation(NAME).value().asString();
+        if (parameter.name() == null)
+            throw new RuntimeException("Missing name information for " + this + ".\n" +
+                    "You can either annotate all parameters with @Name, " +
+                    "or compile your source code with the -parameters options, " +
+                    "so the parameter names are compiled into the class file and available at runtime.");
+        return getRawName();
+    }
+
+    public String getRawName() {
+        return parameter.name();
+    }
+
+    @Override
+    public String getDirectiveLocation() {
+        return "VARIABLE_DEFINITION";
+    }
+
+    /**
+     * Gets the GraphQL input type name for the parameter.
+     *
+     * @return The GraphQL input type name.
+     */
+    public String graphQlInputTypeName() {
+        if (parameter.hasAnnotation(ID)) {
+            if (type.isCollectionOrArray()) {
+                return "[ID" + arrayOrCollectionHelper(this::optionalExclamationMark) + "]" + optionalExclamationMark(type);
+            }
+            return "ID" + optionalExclamationMark(type);
+        } else if (type.isCollectionOrArray()) {
+            return "[" + arrayOrCollectionHelper(this::withExclamationMark) + "]" + optionalExclamationMark(type);
+        } else if (type.isMap()) {
+            var keyType = type.getMapKeyType();
+            var valueType = type.getMapValueType();
+            return "[Entry_" + withExclamationMark(keyType)
+                    + "_" + withExclamationMark(valueType) + "Input]"
+                    + optionalExclamationMark(type);
+        } else {
+            return withExclamationMark(type);
+        }
+    }
+
+    /**
+     * Adds an exclamation mark to the GraphQL input type name if the type is non-nullable.
+     *
+     * @param type The {@link TypeModel} representing the type of the parameter.
+     * @return The GraphQL input type name with an optional exclamation mark.
+     */
+    private String withExclamationMark(TypeModel type) {
+        return graphQlInputTypeName(type) + optionalExclamationMark(type);
+    }
+
+    /**
+     * Gets the GraphQL input type name for the specified {@code TypeModel}.
+     *
+     * @param type The {@link TypeModel} for which to get the GraphQL input type name.
+     * @return The GraphQL input type name.
+     */
+    private String graphQlInputTypeName(TypeModel type) {
+        if (type.isSimpleClassType() && !type.isScalar()) {
+            if (type.hasClassAnnotation(INPUT)) {
+                String value = type.getClassAnnotation(INPUT).orElseThrow().valueWithDefault(getIndex()).asString();
+                if (!value.isEmpty()) {
+                    return value;
+                }
+            }
+            if (type.hasClassAnnotation(NAME)) {
+                return type.getClassAnnotation(NAME).orElseThrow().value().asString();
+            }
+        }
+        if (Scalars.isScalar(type.getName())) {
+            return Scalars.getScalar(type.getName()); // returns simplified name
+        }
+        return type.getSimpleName() + (type.isEnum() ? "" : "Input");
+    }
+
+    /**
+     * Adds an optional exclamation mark to the GraphQL input type name based on nullability.
+     *
+     * @param type The {@link TypeModel} representing the type of the parameter.
+     * @return An optional exclamation mark.
+     */
+    private String optionalExclamationMark(TypeModel type) {
+        return type.isNonNull() ? "!" : "";
+    }
+
+    /**
+     * Helper method for handling array or collection types in GraphQL input type names.
+     *
+     * @param function The function to apply to the array or collection element type.
+     * @return The GraphQL input type name for array or collection types.
+     */
+    private String arrayOrCollectionHelper(Function<TypeModel, String> function) {
+        return function.apply((type.isArray() ? type.getArrayElementType() : type.getCollectionElementType()));
+    }
+
+    @Override
+    public boolean hasDirectives() {
+        return !directives.isEmpty();
+    }
+
+    @Override
+    public List<DirectiveInstance> getDirectives() {
+        return directives;
+    }
+}

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/TypeModel.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/TypeModel.java
@@ -1,0 +1,482 @@
+package io.smallrye.graphql.client.model.helper;
+
+import static io.smallrye.graphql.client.model.Annotations.IGNORE;
+import static io.smallrye.graphql.client.model.Annotations.JACKSON_IGNORE;
+import static io.smallrye.graphql.client.model.Annotations.JAKARTA_JSONB_TRANSIENT;
+import static io.smallrye.graphql.client.model.Classes.ERROR_OR;
+import static io.smallrye.graphql.client.model.Classes.OBJECT;
+import static io.smallrye.graphql.client.model.Classes.OPTIONAL;
+import static io.smallrye.graphql.client.model.Classes.TYPESAFE_RESPONSE;
+import static io.smallrye.graphql.client.model.Classes.isParameterized;
+import static io.smallrye.graphql.client.model.ScanningContext.getIndex;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+
+import io.smallrye.graphql.client.model.Annotations;
+import io.smallrye.graphql.client.model.Classes;
+import io.smallrye.graphql.client.model.Scalars;
+
+/**
+ * Represents a model for handling GraphQL types, including information about the underlying Jandex Type.
+ *
+ * @author mskacelik
+ */
+public class TypeModel {
+    private Type type;
+
+    /**
+     * Factory method to create a TypeModel from a Jandex Type.
+     *
+     * @param type The Jandex Type.
+     * @return A TypeModel instance.
+     */
+    public static TypeModel of(Type type) {
+        return new TypeModel(type);
+    }
+
+    /**
+     * Creates a new TypeModel for the given Jandex Type.
+     *
+     * @param type The Jandex Type.
+     */
+    TypeModel(Type type) {
+        this.type = type;
+    }
+
+    /**
+     * Retrieves whether the type represents a primitive.
+     *
+     * @return {@code true} if the type is primitive, otherwise {@code false}.
+     */
+    public boolean isPrimitive() {
+        return Classes.isPrimitive(type);
+    }
+
+    /**
+     * Retrieves whether the type represents a map.
+     *
+     * @return {@code true} if the type is a map, otherwise {@code false}.
+     */
+    public boolean isMap() {
+        return Classes.isMap(type);
+    }
+
+    /**
+     * Retrieves whether the type is a collection or array.
+     *
+     * @return {@code true} if the type is a collection or array, otherwise {@code false}.
+     */
+    public boolean isCollectionOrArray() {
+        return isArray() || isCollection();
+    }
+
+    /**
+     * Checks if the type is a class type (simple class, parametrized, or {@code Object}).
+     *
+     * @return {@code true} if the type is a class type, otherwise {@code false}.
+     */
+    public boolean isClassType() {
+        return isSimpleClassType() || isParametrized() || type.name().equals(OBJECT);
+    }
+
+    /**
+     * Checks if the type is a simple class type (not the primitive type).
+     *
+     * @return {@code true} if the type is a simple class type, otherwise {@code false}.
+     */
+    public boolean isSimpleClassType() {
+        return Classes.isClass(type) && !isPrimitive();
+    }
+
+    /**
+     * Retrieves the key type of map type.
+     *
+     * @return A {@link TypeModel} representing the key type of the map.
+     * @throws IllegalArgumentException If the type is not a map.
+     */
+    public TypeModel getMapKeyType() {
+        if (!isMap()) {
+            throw new IllegalArgumentException("Expected type to be a Map");
+        }
+        return of(type.asParameterizedType().arguments().get(0));
+    }
+
+    /**
+     * Retrieves the value type of map type.
+     *
+     * @return A {@link TypeModel} representing the value type of the map.
+     * @throws IllegalArgumentException If the type is not a map.
+     */
+    public TypeModel getMapValueType() {
+        if (!isMap()) {
+            throw new IllegalArgumentException("Expected type to be a Map");
+        }
+        return of(type.asParameterizedType().arguments().get(1));
+    }
+
+    /**
+     * Checks if the type is non-null (primitive or annotated with {@link Annotations#NON_NULL}
+     * or {@link Annotations#JAKARTA_NON_NULL}).
+     *
+     * @return {@code true} if the type is non-null, otherwise {@code false}.
+     */
+    public boolean isNonNull() {
+        return isPrimitive() ||
+                type.hasAnnotation(Annotations.NON_NULL) ||
+                type.hasAnnotation(Annotations.JAKARTA_NON_NULL);
+    }
+
+    /**
+     * Checks if the type is an array.
+     *
+     * @return {@code true} if the type is an array, otherwise {@code false}.
+     */
+    public boolean isArray() {
+        return Classes.isArray(type);
+    }
+
+    /**
+     * Checks if the type is a collection.
+     *
+     * @return {@code true} if the type is a collection, otherwise {@code false}.
+     */
+    public boolean isCollection() {
+        return Classes.isCollection(type);
+    }
+
+    /**
+     * Retrieves the simple name of the type.
+     *
+     * @return The simple name of the type.
+     */
+    public String getSimpleName() {
+        return type.name().local();
+    }
+
+    /**
+     * Retrieves the full name of the type, considering parameters for generics.
+     *
+     * @return The full name of the type.
+     */
+    public String getName() {
+        StringBuilder name = new StringBuilder((isArray()) ? getArrayElementType().getName() : type.name().toString());
+        if (isParametrized()) {
+            name.append(getItemTypes().map(TypeModel::getName).collect(Collectors.joining(", ", "<", ">")));
+        }
+        if (isArray()) {
+            name.append("[]");
+        }
+        return name.toString();
+    }
+
+    /**
+     * Retrieves a stream of {@link TypeModel} instances representing the parameters of parametrized type. (if parametrized).
+     *
+     * @return A stream of {@link TypeModel} parameter instances.
+     * @throws IllegalArgumentException If the type is not parametrized.
+     */
+    public Stream<TypeModel> getItemTypes() {
+        if (!Classes.isParameterized(type)) {
+            throw new IllegalArgumentException("Type " + getName() + " is not parametrized, cannot get its Item Types");
+        }
+        return type.asParameterizedType().arguments().stream().map(TypeModel::of);
+    }
+
+    /**
+     * Retrieves the element type for an array type.
+     *
+     * @return A {@link TypeModel} representing the element type of the array.
+     * @throws IllegalArgumentException If the type is not an array.
+     */
+    public TypeModel getArrayElementType() {
+        if (!isArray()) {
+            throw new IllegalArgumentException("Type " + getName() + " is not an array type, cannot get its Element Type");
+        }
+        return of(type.asArrayType().elementType());
+    }
+
+    /**
+     * Retrieves the item type for collections or arrays.
+     *
+     * @return A {@link TypeModel} representing the item type.
+     */
+    public TypeModel getItemTypeOrElementType() {
+        if (isArray()) {
+            return getArrayElementType();
+        }
+        return getFirstRawType();
+    }
+
+    /**
+     * Retrieves the element type for collections.
+     *
+     * @return A {@link TypeModel} representing the element type of the collection.
+     */
+    public TypeModel getCollectionElementType() {
+        return getFirstRawType();
+    }
+
+    /**
+     * Retrieves the first raw type.
+     *
+     * @return A {@link TypeModel} representing the first raw type.
+     */
+    public TypeModel getFirstRawType() {
+        return getItemTypes().collect(toList()).get(0);
+
+    }
+
+    /**
+     * Checks if the type is an enum.
+     *
+     * @return {@code true} if the type is an enum, otherwise {@code false}.
+     */
+    public boolean isEnum() {
+        return Classes.isEnum(type);
+    }
+
+    /**
+     * Checks if the type is a scalar (string, number, etc.).
+     *
+     * @return {@code true} if the type is a scalar, otherwise {@code false}.
+     */
+    public boolean isScalar() {
+        return Scalars.isScalar(getName()) || hasScalarConstructor() || isEnum();
+    }
+
+    /**
+     * Checks if the type has a scalar constructor.
+     *
+     * @return {@code true} if the type has a scalar constructor, otherwise {@code false}.
+     */
+    private boolean hasScalarConstructor() {
+        return isSimpleClassType()
+                && getIndex().getClassByName(type.name()).methods().stream().anyMatch(this::isStaticStringConstructor);
+    }
+
+    /**
+     * Checks if a method is a static string constructor method.
+     *
+     * @param method The method to check.
+     * @return {@code true} if the method is a static string constructor method, otherwise {@code false}.
+     */
+    private boolean isStaticStringConstructor(MethodInfo method) {
+        return isStaticConstructorMethodNamed(method, "of")
+                || isStaticConstructorMethodNamed(method, "valueOf")
+                || isStaticConstructorMethodNamed(method, "parse");
+    }
+
+    /**
+     * Checks if a method is a static constructor method with a specific name.
+     *
+     * @param method The method to check.
+     * @param name The name of the constructor method.
+     * @return {@code true} if the method is a static constructor method with the specified name, otherwise {@code false}.
+     */
+    private boolean isStaticConstructorMethodNamed(MethodInfo method, String name) {
+        return method.name().equals(name)
+                && Modifier.isStatic(method.flags())
+                && method.returnType().equals(type)
+                // TODO: for other custom scalar types (float, int)
+                && hasOneStringParameter(method);
+    }
+
+    /**
+     * Checks if a method has exactly one string parameter.
+     *
+     * @param methodInfo The method information.
+     * @return {@code true} if the method has exactly one string parameter, otherwise {@code false}.
+     */
+    private boolean hasOneStringParameter(MethodInfo methodInfo) {
+        return methodInfo.parametersCount() == 1 &&
+                Scalars.isStringScalar(TypeModel.of(methodInfo.parameterType(0)).getName());
+    }
+
+    /**
+     * Checks if the type is a parametrized TypesafeResponse.
+     *
+     * @return {@code true} if the type is a parametrized TypesafeResponse, otherwise {@code false}.
+     */
+    public boolean isTypesafeResponse() {
+        return isParametrized() && type.name().equals(TYPESAFE_RESPONSE);
+    }
+
+    /**
+     * Checks if the type is a parametrized ErrorOr.
+     *
+     * @return {@code true} if the type is a parametrized ErrorOr, otherwise {@code false}.
+     */
+    public boolean isErrorOr() {
+        return isParametrized() && type.name().equals(ERROR_OR);
+    }
+
+    /**
+     * Checks if the type is a parametrized Optional.
+     * Optional* classes are considered as Scalars; this method checks if the type is an {@code Optional<T>}.
+     *
+     * @return {@code true} if the type is a parametrized Optional, otherwise {@code false}.
+     */
+    public boolean isOptional() { // Optional* classes are considered as Scalars, we check here if type is a `Optional<T>`
+        return isParametrized() && type.name().equals(OPTIONAL);
+    }
+
+    /**
+     * Checks if the type is an asynchronous type.
+     *
+     * @return {@code true} if the type is asynchronous, otherwise {@code false}.
+     */
+    public boolean isAsync() {
+        return Classes.isAsync(type);
+    }
+
+    /**
+     * Checks if the type is parametrized.
+     *
+     * @return {@code true} if the type is parametrized, otherwise {@code false}.
+     */
+    public boolean isParametrized() {
+        return Classes.isParameterized(type);
+    }
+
+    /**
+     * Checks if the type is a type variable.
+     *
+     * @return {@code true} if the type is a type variable, otherwise {@code false}.
+     */
+    public boolean isTypeVariable() {
+        return Classes.isTypeVariable(type);
+    }
+
+    /**
+     * Retrieves a stream of FieldModel instances representing the fields of the type.
+     *
+     * @return A stream of FieldModel instances.
+     * @throws IllegalArgumentException If the type is not a class type.
+     */
+    public Stream<FieldModel> fields() {
+        if (!isClassType()) {
+            throw new IllegalArgumentException(
+                    "Expected type " + type.name().toString() + " to be Class type, cannot get fields from non-class type");
+        }
+        return fields(getIndex().getClassByName(type.name()));
+    }
+
+    /**
+     * Retrieves a stream of {@link FieldModel} instances representing the fields of a class.
+     *
+     * @param clazz The class information.
+     * @return A stream of {@link FieldModel} instances.
+     */
+    private Stream<FieldModel> fields(ClassInfo clazz) {
+        return (clazz == null) ? Stream.of()
+                : Stream.concat(
+                        fields(getIndex().getClassByName(clazz.superClassType().name())), // to superClass
+                        fieldsHelper(clazz)
+                                .map(FieldModel::of)
+                                .filter(this::isGraphQlField));
+
+    }
+
+    /**
+     * Retrieves a stream of {@link FieldInfo} instances representing the fields of a class.
+     *
+     * @param clazz The class information.
+     * @return A stream of {@link FieldInfo} instances.
+     */
+    private Stream<FieldInfo> fieldsHelper(ClassInfo clazz) {
+        if (System.getSecurityManager() == null) {
+            return clazz.unsortedFields().stream();
+        }
+        return AccessController.doPrivileged((PrivilegedAction<Stream<FieldInfo>>) () -> clazz.unsortedFields().stream());
+
+    }
+
+    /**
+     * Checks if a field is a GraphQL field.
+     *
+     * @param field The field to check.
+     * @return {@code true} if the field is a GraphQL field, otherwise {@code false}.
+     */
+    private boolean isGraphQlField(FieldModel field) {
+        return !field.isStatic() &&
+                !field.isSynthetic() &&
+                !field.isTransient() &&
+                !isAnnotatedBy(field, IGNORE, JAKARTA_JSONB_TRANSIENT, JACKSON_IGNORE);
+    }
+
+    /**
+     * Checks if a field is annotated by any of the specified annotations.
+     *
+     * @param field The field to check.
+     * @param annotationClasses The annotations to check for.
+     * @return {@code true} if the field is annotated by any of the specified annotations, otherwise {@code false}.
+     */
+    private boolean isAnnotatedBy(FieldModel field, DotName... annotationClasses) {
+        return Arrays.stream(annotationClasses).anyMatch(field::hasAnnotation);
+    }
+
+    /**
+     * Checks if the class represented by this TypeModel has a specific annotation.
+     *
+     * @param annotationName The name of the annotation to check.
+     * @return {@code true} if the class has the specified annotation, otherwise {@code false}.
+     */
+    public boolean hasClassAnnotation(DotName annotationName) {
+        ClassInfo clazz = getIndex().getClassByName(type.name());
+        return clazz.annotations().stream()
+                .anyMatch(annotation -> isClassAnnotation(annotation) && annotation.name().equals(annotationName));
+    }
+
+    /**
+     * Retrieves the annotation instance for a specific annotation on the class.
+     *
+     * @param annotationName The name of the annotation.
+     * @return An Optional containing the AnnotationInstance, or an empty Optional if the annotation is not present.
+     */
+    public Optional<AnnotationInstance> getClassAnnotation(DotName annotationName) {
+        ClassInfo clazz = getIndex().getClassByName(type.name());
+        return clazz.annotations().stream()
+                .filter(annotation -> isClassAnnotation(annotation) && annotation.name().equals(annotationName)).findFirst();
+    }
+
+    /**
+     * Checks if the annotation is associated with a class.
+     *
+     * @param annotationInstance The AnnotationInstance to check.
+     * @return {@code true} if the annotation is a class-level annotation, otherwise {@code false}.
+     */
+    private boolean isClassAnnotation(AnnotationInstance annotationInstance) {
+        return annotationInstance.target().kind().equals(AnnotationTarget.Kind.CLASS);
+    }
+
+    /**
+     * Checks if the type is a custom user-made parametrized type, excluding certain standard types.
+     *
+     * @return {@code true} if the type is a custom user-made parametrized type, otherwise {@code false}.
+     */
+    public boolean isCustomParametrizedType() {
+        return isParametrized()
+                && !isAsync()
+                && !isOptional()
+                && !isTypesafeResponse()
+                && !isErrorOr()
+                && !isMap()
+                && !isCollection();
+    }
+}

--- a/client/model-builder/src/test/java/io/smallrye/graphql/client/model/ClientModelBuilderTest.java
+++ b/client/model-builder/src/test/java/io/smallrye/graphql/client/model/ClientModelBuilderTest.java
@@ -1,0 +1,182 @@
+package io.smallrye.graphql.client.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.graphql.api.Subscription;
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+
+/**
+ * @author mskacelik
+ */
+public class ClientModelBuilderTest {
+
+    @GraphQLClientApi(configKey = "scalar")
+    interface ScalarClientApi {
+        @Query
+        Integer returnInteger(Integer someNumber);
+
+        @Mutation
+        String returnString(String someString);
+
+        @Subscription
+        float returnNonNullFloat(float someFloat);
+    }
+
+    @Test
+    void sclarClientModelTest() throws IOException {
+        String configKey = "scalar";
+        ClientModels clientModels = ClientModelBuilder.build(Index.of(ScalarClientApi.class));
+        assertNotNull(clientModels.getClientModelByConfigKey(configKey));
+        ClientModel clientModel = clientModels.getClientModelByConfigKey(configKey);
+        assertEquals(3, clientModel.getOperationMap().size());
+        assertOperation(clientModel,
+                new MethodKey(Integer.class, "returnInteger", new Class<?>[] { Integer.class }),
+                "query returnInteger($someNumber: Int) { returnInteger(someNumber: $someNumber) }");
+
+        assertOperation(clientModel,
+                new MethodKey(String.class, "returnString", new Class<?>[] { String.class }),
+                "mutation returnString($someString: String) { returnString(someString: $someString) }");
+
+        assertOperation(clientModel,
+                new MethodKey(float.class, "returnNonNullFloat", new Class<?>[] { float.class }),
+                "subscription returnNonNullFloat($someFloat: Float!) { returnNonNullFloat(someFloat: $someFloat) }");
+    }
+
+    @GraphQLClientApi(configKey = "collection")
+    interface CollectionClientApi {
+        @Query
+        Collection<Integer> returnIntegerCollection(Integer[] someNumbers);
+
+        @Mutation
+        List<String> returnStringList(Set<String> someStrings);
+
+        @Subscription
+        ArrayList<Float> returnFloatArrayList(HashSet<Float> someFloats);
+    }
+
+    @Test
+    void collectionClientModelTest() throws IOException {
+        String configKey = "collection";
+        ClientModels clientModels = ClientModelBuilder.build(Index.of(CollectionClientApi.class));
+        assertNotNull(clientModels.getClientModelByConfigKey(configKey));
+        ClientModel clientModel = clientModels.getClientModelByConfigKey(configKey);
+        assertEquals(3, clientModel.getOperationMap().size());
+        assertOperation(clientModel,
+                new MethodKey(Collection.class, "returnIntegerCollection", new Class<?>[] { Integer[].class }),
+                "query returnIntegerCollection($someNumbers: [Int]) { returnIntegerCollection(someNumbers: $someNumbers) }");
+
+        assertOperation(clientModel,
+                new MethodKey(List.class, "returnStringList", new Class<?>[] { Set.class }),
+                "mutation returnStringList($someStrings: [String]) { returnStringList(someStrings: $someStrings) }");
+
+        assertOperation(clientModel,
+                new MethodKey(ArrayList.class, "returnFloatArrayList", new Class<?>[] { HashSet.class }),
+                "subscription returnFloatArrayList($someFloats: [Float]) { returnFloatArrayList(someFloats: $someFloats) }");
+    }
+
+    @Test
+    void simpleObjectClientModelTest() throws IOException {
+        String configKey = "simple-object";
+        ClientModels clientModels = ClientModelBuilder.build(Index.of(SimpleObjectClientApi.class,
+                SimpleObjectClientApi.SomeObject.class, SimpleObjectClientApi.SomeObject.InnerClass.class));
+        assertNotNull(clientModels.getClientModelByConfigKey(configKey));
+        ClientModel clientModel = clientModels.getClientModelByConfigKey(configKey);
+        assertEquals(1, clientModel.getOperationMap().size());
+        assertOperation(clientModel,
+                new MethodKey(SimpleObjectClientApi.SomeObject.class, "returnSomeObject",
+                        new Class<?>[] { SimpleObjectClientApi.SomeObject.class }),
+                "query returnSomeObject($someObject: SomeObjectInput) { returnSomeObject(someObject: $someObject) {name innerObject {someInt}} }");
+    }
+
+    @GraphQLClientApi(configKey = "simple-object")
+    interface SimpleObjectClientApi {
+        @Query
+        SomeObject returnSomeObject(SomeObject someObject);
+
+        class SomeObject {
+            String name;
+            InnerClass innerObject;
+
+            static class InnerClass {
+                int someInt;
+            }
+        }
+    }
+
+    @Test
+    void complexObjectClientModelTest() throws IOException {
+        String configKey = "complex-object";
+        ClientModels clientModels = ClientModelBuilder
+                .build(Index.of(ComplexObjectClientApi.class, ComplexObjectClientApi.SomeGenericClass.class,
+                        ComplexObjectClientApi.SomeGenericClass.InnerClass.class, ComplexObjectClientApi.SomeObjectOne.class,
+                        ComplexObjectClientApi.SomeObjectTwo.class,
+                        ComplexObjectClientApi.SomeObjectThree.class,
+                        ComplexObjectClientApi.SomeObjectFour.class,
+                        ComplexObjectClientApi.SomeObjectFive.class));
+        assertNotNull(clientModels.getClientModelByConfigKey(configKey));
+        ClientModel clientModel = clientModels.getClientModelByConfigKey(configKey);
+        assertEquals(1, clientModel.getOperationMap().size());
+        assertOperation(clientModel,
+                new MethodKey(List.class, "returnSomeGenericObject", new Class<?>[] { List.class }),
+                "query returnSomeGenericObject($someObject: [SomeGenericClassInput])" +
+                        " { returnSomeGenericObject(someObject: $someObject) {somethingParent {number}" +
+                        " field1 {number} field2 {innerField {number} something {someObject {someThingElse" +
+                        " {string}}}}} }");
+    }
+
+    @GraphQLClientApi(configKey = "complex-object")
+    interface ComplexObjectClientApi {
+        @Query
+        List<SomeGenericClass<SomeObjectOne>> returnSomeGenericObject(List<SomeGenericClass<SomeObjectOne>> someObject);
+
+        class SomeGenericClass<T> extends SomeObjectFour<T> {
+            T field1;
+            InnerClass<T> field2;
+
+            static class InnerClass<N> {
+                N innerField;
+
+                SomeObjectTwo<List<SomeObjectFive<SomeObjectThree>>> something;
+            }
+        }
+
+        class SomeObjectOne {
+            int number;
+        }
+
+        class SomeObjectTwo<T> {
+            T someObject;
+        }
+
+        class SomeObjectThree {
+            String string;
+        }
+
+        class SomeObjectFour<T> {
+            T somethingParent;
+        }
+
+        class SomeObjectFive<S> {
+            S someThingElse;
+        }
+    }
+
+    private void assertOperation(ClientModel clientModel, MethodKey methodKey, String expectedQuery) {
+        String actualQuery = clientModel.getOperationMap().get(methodKey);
+        assertEquals(expectedQuery, actualQuery);
+    }
+
+}

--- a/client/model/pom.xml
+++ b/client/model/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-graphql-client-parent</artifactId>
+        <version>2.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-graphql-client-model</artifactId>
+    <name>SmallRye: GraphQL Client :: model</name>
+</project>

--- a/client/model/src/main/java/io/smallrye/graphql/client/model/ClientModel.java
+++ b/client/model/src/main/java/io/smallrye/graphql/client/model/ClientModel.java
@@ -1,0 +1,28 @@
+package io.smallrye.graphql.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClientModel {
+
+    private Map<MethodKey, String> operationQueryMap;
+
+    public ClientModel() {
+        operationQueryMap = new HashMap<>();
+    };
+
+    public Map<MethodKey, String> getOperationMap() {
+        return operationQueryMap;
+    }
+
+    public void setOperationMap(Map<MethodKey, String> operationQueryMap) {
+        this.operationQueryMap = operationQueryMap;
+    }
+
+    @Override
+    public String toString() {
+        return "ClientModel{" +
+                "operationQueryMap=" + operationQueryMap +
+                '}';
+    }
+}

--- a/client/model/src/main/java/io/smallrye/graphql/client/model/ClientModels.java
+++ b/client/model/src/main/java/io/smallrye/graphql/client/model/ClientModels.java
@@ -1,0 +1,33 @@
+package io.smallrye.graphql.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClientModels {
+    private Map<String, ClientModel> clientModelMap;
+
+    public ClientModel getClientModelByConfigKey(String configKey) {
+        return clientModelMap.get(configKey);
+    }
+
+    // bytecode recording
+    public ClientModels() {
+        clientModelMap = new HashMap<>();
+    }
+
+    public void setClientModelMap(Map<String, ClientModel> clientModelMap) {
+        this.clientModelMap = clientModelMap;
+    }
+
+    public Map<String, ClientModel> getClientModelMap() {
+        return clientModelMap;
+    }
+
+    // for testing purposes...
+    @Override
+    public String toString() {
+        return "ClientModels{" +
+                "operationMap=" + clientModelMap.toString() +
+                '}';
+    }
+}

--- a/client/model/src/main/java/io/smallrye/graphql/client/model/MethodKey.java
+++ b/client/model/src/main/java/io/smallrye/graphql/client/model/MethodKey.java
@@ -1,0 +1,70 @@
+package io.smallrye.graphql.client.model;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class MethodKey {
+    private Class<?> declaringClass;
+    private String methodName;
+    private Class<?>[] parameterTypes;
+
+    public MethodKey(Class<?> declaringClass, String methodName, Class<?>[] parameterTypes) {
+        this.declaringClass = declaringClass;
+        this.methodName = methodName;
+        this.parameterTypes = parameterTypes;
+    }
+
+    public MethodKey() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MethodKey methodKey = (MethodKey) o;
+        return Objects.equals(declaringClass, methodKey.declaringClass) && Objects.equals(methodName, methodKey.methodName)
+                && Arrays.equals(parameterTypes, methodKey.parameterTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(declaringClass, methodName);
+        result = 31 * result + Arrays.hashCode(parameterTypes);
+        return result;
+    }
+
+    public Class<?> getDeclaringClass() {
+        return declaringClass;
+    }
+
+    public void setDeclaringClass(Class<?> declaringClass) {
+        this.declaringClass = declaringClass;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public void setMethodName(String methodName) {
+        this.methodName = methodName;
+    }
+
+    public Class<?>[] getParameterTypes() {
+        return parameterTypes;
+    }
+
+    public void setParameterTypes(Class<?>[] parameterTypes) {
+        this.parameterTypes = parameterTypes;
+    }
+
+    @Override
+    public String toString() {
+        return "MethodKey{" +
+                "declaringClass=" + declaringClass +
+                ", methodName='" + methodName + '\'' +
+                ", parameterTypes=" + Arrays.toString(parameterTypes) +
+                '}';
+    }
+}

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -21,6 +21,8 @@
         <module>generator</module>
         <module>generator-test</module>
         <module>tck</module>
+        <module>model</module>
+        <module>model-builder</module>
     </modules>
 
     <build>

--- a/client/tck/src/main/java/tck/graphql/typesafe/ArrayBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/ArrayBehavior.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
 
-class ArrayBehavior {
+public class ArrayBehavior {
     private final TypesafeGraphQLClientFixture fixture = TypesafeGraphQLClientFixture.load();
 
     @GraphQLClientApi

--- a/client/tck/src/main/java/tck/graphql/typesafe/NestedBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/NestedBehavior.java
@@ -783,31 +783,4 @@ class NestedBehavior {
 
         then(thrown).hasMessage("missing boolean value for " + MissingPrimitiveFieldApi.class.getName() + "#call.bar");
     }
-
-    @SuppressWarnings("unused")
-    private static class Hero {
-        String name;
-        List<Team> teams;
-    }
-
-    @SuppressWarnings("unused")
-    private static class Team {
-        String name;
-        List<Hero> heroes;
-    }
-
-    @GraphQLClientApi
-    private interface RecursiveApi {
-        @SuppressWarnings({ "UnusedReturnValue", "unused" })
-        Hero member();
-    }
-
-    @Test
-    void shouldFailToCallApiWithRecursiveFields() {
-        RecursiveApi api = fixture.build(RecursiveApi.class);
-
-        IllegalStateException thrown = catchThrowableOfType(api::member, IllegalStateException.class);
-
-        then(thrown).hasMessageContaining("Field recursion found");
-    }
 }

--- a/client/tck/src/main/java/tck/graphql/typesafe/RecursionBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/RecursionBehavior.java
@@ -1,0 +1,39 @@
+package tck.graphql.typesafe;
+
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+
+public class RecursionBehavior {
+
+    private final TypesafeGraphQLClientFixture fixture = TypesafeGraphQLClientFixture.load();
+
+    private static class Hero {
+        String name;
+        List<Team> teams;
+    }
+
+    private static class Team {
+        String name;
+        List<Hero> heroes;
+    }
+
+    @GraphQLClientApi
+    private interface RecursiveApi {
+        Hero member();
+    }
+
+    @Test
+    void shouldFailToCallApiWithRecursiveFields() {
+        RecursiveApi api = fixture.build(RecursiveApi.class);
+
+        IllegalStateException thrown = catchThrowableOfType(api::member, IllegalStateException.class);
+
+        then(thrown).hasMessageContaining("Field recursion found");
+    }
+}

--- a/docs/typesafe-client-directives.md
+++ b/docs/typesafe-client-directives.md
@@ -1,0 +1,44 @@
+# Typesafe Client Static Directives
+
+## Custom Static Directives
+
+The declaration of custom static directives for the typesafe client follows the same principles as the server-side [directives](directives.md). With only exception of using the [Executable Directive Locations](https://spec.graphql.org/draft/#ExecutableDirectiveLocation) instead of Type System Directive Locations.
+```java
+@Directive(on = { FIELD, VARIABLE_DEFINITION })
+@Retention(RUNTIME)
+public @interface MyDirective {
+    String value() default "";
+}
+```
+
+Applying this to your API should look like this:
+```java
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+
+@GraphQLClientApi
+public @interface MyClientApi {
+    
+    @Query
+    @MyDirective("top-level field")
+    MySuperHero getMySuperHero(@MyDirective("variable definition") String nameOfMySuperHero);
+    
+    class MySuperHero {
+        @MyDirective("field")
+        String name;
+    }
+}
+```
+Your API is going to generate a query something like this:
+```
+query mySuperHero(
+  $nameOfMySuperHero: String @myDirective(value: "variable definition")
+) {
+  mySuperHero(nameOfMySuperHero: $nameOfMySuperHero)
+    @myDirective(value: "top-level field") {
+    name @myDirective(value: "field")
+  }
+}
+```
+
+> [NOTE]
+> The current implementation supports only FIELD and VARIABLE_DEFINITION locations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - Running multiple queries at once: 'typesafe-client-multiple-queries.md'
       - Error handling: 'typesafe-client-error-handling.md'
       - Accessing metadata of responses: 'typesafe-client-accessing-metadata-of-responses.md'
+      - Static Directives: 'typesafe-client-directives.md'
   - Dynamic client:
       - Basic usage: 'dynamic-client-usage.md'
       - Error handling: 'dynamic-client-error-handling.md'

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,16 @@
                 <artifactId>smallrye-graphql-client-implementation-vertx</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>smallrye-graphql-client-model</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>smallrye-graphql-client-model-builder</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.graphql-java</groupId>

--- a/server/integration-tests-jdk16/src/test/java/io/smallrye/graphql/tests/client/RecordAsInputToDynamicClientTest.java
+++ b/server/integration-tests-jdk16/src/test/java/io/smallrye/graphql/tests/client/RecordAsInputToDynamicClientTest.java
@@ -10,7 +10,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +44,6 @@ public class RecordAsInputToDynamicClientTest {
             assertEquals("a", result.a());
             assertEquals("b", result.b());
         }
-
     }
 
     /**

--- a/server/integration-tests-jdk16/src/test/java/io/smallrye/graphql/tests/client/RecordAsInputToTypesafeClientTest.java
+++ b/server/integration-tests-jdk16/src/test/java/io/smallrye/graphql/tests/client/RecordAsInputToTypesafeClientTest.java
@@ -9,9 +9,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/server/integration-tests/pom.xml
+++ b/server/integration-tests/pom.xml
@@ -202,6 +202,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-client-model-builder</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api-maven</artifactId>
             <scope>compile</scope>

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/parsing/TypesafeClientFormatAnnotationsTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/parsing/TypesafeClientFormatAnnotationsTest.java
@@ -31,7 +31,7 @@ public class TypesafeClientFormatAnnotationsTest {
     @ArquillianResource
     URL testingURL;
 
-    private static FormatAnnotationsClientApi client;
+    protected FormatAnnotationsClientApi client;
 
     @Before
     public void prepare() {

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/parsing/TypesafeClientFormatAnnotationsWithClientModelTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/parsing/TypesafeClientFormatAnnotationsWithClientModelTest.java
@@ -1,0 +1,36 @@
+package io.smallrye.graphql.tests.client.parsing;
+
+import static io.smallrye.graphql.client.model.ClientModelBuilder.build;
+
+import java.io.IOException;
+
+import org.jboss.jandex.Index;
+import org.junit.Before;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
+
+public class TypesafeClientFormatAnnotationsWithClientModelTest extends TypesafeClientFormatAnnotationsTest {
+
+    boolean onlyOnce = false;
+
+    @Override
+    @Before
+    public void prepare() {
+        if (!onlyOnce) {
+            Index index = null;
+            try {
+                index = Index.of(FormatAnnotationsClientApi.class,
+                        ObjectWithFormattedFields.class,
+                        GraphQLClientApi.class);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            client = new VertxTypesafeGraphQLClientBuilder()
+                    .clientModels(build(index))
+                    .endpoint(testingURL.toString() + "graphql")
+                    .build(FormatAnnotationsClientApi.class);
+            onlyOnce = true;
+        }
+    }
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/parsing/TypesafeClientMapTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/parsing/TypesafeClientMapTest.java
@@ -29,13 +29,13 @@ public class TypesafeClientMapTest {
     @Deployment
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(MapClientApi.class, MapApi.class);
+                .addClasses(MapApi.class, ComplexToComplexMapWrapper.class, Foo.class);
     }
 
     @ArquillianResource
     URL testingURL;
 
-    private static MapClientApi client;
+    protected MapClientApi client;
 
     @Before
     public void prepare() {

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/parsing/TypesafeClientMapWithClientModelTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/parsing/TypesafeClientMapWithClientModelTest.java
@@ -1,0 +1,36 @@
+package io.smallrye.graphql.tests.client.parsing;
+
+import static io.smallrye.graphql.client.model.ClientModelBuilder.build;
+
+import java.io.IOException;
+
+import org.jboss.jandex.Index;
+import org.junit.Before;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
+
+public class TypesafeClientMapWithClientModelTest extends TypesafeClientMapTest {
+
+    boolean onlyOnce = false;
+
+    @Override
+    @Before
+    public void prepare() {
+        if (!onlyOnce) {
+            Index index = null;
+            try {
+                index = Index.of(GraphQLClientApi.class);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            client = new VertxTypesafeGraphQLClientBuilder()
+                    .clientModels(build(index))
+                    .endpoint(testingURL.toString() + "graphql")
+                    .build(MapClientApi.class);
+
+            onlyOnce = true;
+        }
+    }
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/calendar/TypesafeCalendarTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/calendar/TypesafeCalendarTest.java
@@ -31,7 +31,7 @@ public class TypesafeCalendarTest {
     @ArquillianResource
     URL testingURL;
 
-    private ClientSomeApi client;
+    protected ClientSomeApi client;
 
     @Before
     public void prepare() {

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/calendar/TypesafeCalendarWithClientModelTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/calendar/TypesafeCalendarWithClientModelTest.java
@@ -1,0 +1,33 @@
+package io.smallrye.graphql.tests.client.typesafe.calendar;
+
+import static io.smallrye.graphql.client.model.ClientModelBuilder.build;
+
+import java.io.IOException;
+
+import org.jboss.jandex.Index;
+import org.junit.Before;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
+
+public class TypesafeCalendarWithClientModelTest extends TypesafeCalendarTest {
+    private boolean onlyOnce = false;
+
+    @Override
+    @Before
+    public void prepare() {
+        if (!onlyOnce) {
+            Index index = null;
+            try {
+                index = Index.of(ClientSomeApi.class, GraphQLClientApi.class);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            client = new VertxTypesafeGraphQLClientBuilder()
+                    .clientModels(build(index))
+                    .endpoint(testingURL.toString() + "graphql")
+                    .build(ClientSomeApi.class);
+            onlyOnce = true;
+        }
+    }
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/ClientApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/ClientApi.java
@@ -1,0 +1,18 @@
+package io.smallrye.graphql.tests.client.typesafe.directives;
+
+import org.eclipse.microprofile.graphql.Query;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.graphql.tests.client.typesafe.directives.model.SomeClass;
+
+@GraphQLClientApi
+public interface ClientApi {
+
+    @Query
+    @FieldDirective(fields = 1)
+    @FieldDirective(fields = { 2, 3 })
+    @VariableDefinitionDirective(fields = "should ignore")
+    SomeClass getQuerySomeClass(@FieldDirective(fields = 999) /* will ignore */ SomeClass someObject,
+            @VariableDefinitionDirective @VariableDefinitionDirective(fields = "a") boolean simpleType);
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/FieldDirective.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/FieldDirective.java
@@ -1,0 +1,24 @@
+package io.smallrye.graphql.tests.client.typesafe.directives;
+
+import static io.smallrye.graphql.api.DirectiveLocation.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+
+import org.eclipse.microprofile.graphql.NonNull;
+
+import io.smallrye.graphql.api.Directive;
+
+@Retention(RUNTIME)
+@Directive(on = { FIELD })
+@Repeatable(FieldDirective.FieldDirectives.class)
+public @interface FieldDirective {
+    @NonNull
+    int[] fields();
+
+    @Retention(RUNTIME)
+    @interface FieldDirectives {
+        FieldDirective[] value();
+    }
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/ServerApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/ServerApi.java
@@ -1,0 +1,25 @@
+package io.smallrye.graphql.tests.client.typesafe.directives;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+import io.smallrye.graphql.execution.context.SmallRyeContext;
+import io.smallrye.graphql.tests.client.typesafe.directives.model.SomeClass;
+
+@GraphQLApi
+public class ServerApi {
+
+    private static String EXPECTED_QUERY = "query querySomeClass($someObject: SomeClassInput, $simpleType: Boolean! @variableDefinitionDirective @variableDefinitionDirective(fields: \"a\")) { querySomeClass(someObject: $someObject, simpleType: $simpleType) @fieldDirective(fields: [1]) @fieldDirective(fields: [2, 3]) {id @fieldDirective(fields: [4]) number} }";
+    @Inject
+    SmallRyeContext context;
+
+    @Query
+    public SomeClass getQuerySomeClass(SomeClass someObject, boolean simpleType) {
+        if (!context.getQuery().equals(EXPECTED_QUERY)) {
+            throw new RuntimeException("Queries do not match");
+        }
+        return someObject;
+    }
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/TypesafeStaticDirectivesClientModelTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/TypesafeStaticDirectivesClientModelTest.java
@@ -1,0 +1,72 @@
+package io.smallrye.graphql.tests.client.typesafe.directives;
+
+import static io.smallrye.graphql.client.model.ClientModelBuilder.build;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.jandex.Index;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
+import io.smallrye.graphql.tests.client.typesafe.directives.model.SomeClass;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TypesafeStaticDirectivesClientModelTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "typesafe-directive-client-model.war")
+                .addClasses(SomeClass.class, ServerApi.class,
+                        // needed for the server-side (java-graphql) validation
+                        FieldDirective.class,
+                        VariableDefinitionDirective.class);
+    }
+
+    @ArquillianResource
+    URL testingURL;
+
+    protected ClientApi client;
+    private boolean onlyOnce = false;
+
+    @Before
+    public void prepare() {
+        if (!onlyOnce) {
+            Index index = null;
+            try {
+                index = Index.of(SomeClass.class, ClientApi.class, ServerApi.class,
+                        FieldDirective.class,
+                        FieldDirective.FieldDirectives.class,
+                        VariableDefinitionDirective.class,
+                        VariableDefinitionDirective.VariableDefinitionDirectives.class,
+                        GraphQLClientApi.class);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            client = new VertxTypesafeGraphQLClientBuilder()
+                    .clientModels(build(index))
+                    .endpoint(testingURL.toString() + "graphql")
+                    .build(ClientApi.class);
+        }
+    }
+
+    @Test
+    public void singleQueryDirectiveTest() {
+        SomeClass queryInput = new SomeClass("a", 1);
+        // query checking is on the server side API
+        assertEquals(queryInput, client.getQuerySomeClass(queryInput, false));
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/VariableDefinitionDirective.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/VariableDefinitionDirective.java
@@ -1,0 +1,21 @@
+package io.smallrye.graphql.tests.client.typesafe.directives;
+
+import static io.smallrye.graphql.api.DirectiveLocation.VARIABLE_DEFINITION;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+
+import io.smallrye.graphql.api.Directive;
+
+@Retention(RUNTIME)
+@Directive(on = { VARIABLE_DEFINITION })
+@Repeatable(VariableDefinitionDirective.VariableDefinitionDirectives.class)
+public @interface VariableDefinitionDirective {
+    String fields() default "";
+
+    @Retention(RUNTIME)
+    @interface VariableDefinitionDirectives {
+        VariableDefinitionDirective[] value();
+    }
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/model/SomeClass.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/directives/model/SomeClass.java
@@ -1,0 +1,50 @@
+package io.smallrye.graphql.tests.client.typesafe.directives.model;
+
+import java.util.Objects;
+
+import io.smallrye.graphql.tests.client.typesafe.directives.FieldDirective;
+
+public class SomeClass {
+    @FieldDirective(fields = 4)
+    private String id;
+    private int number;
+
+    public SomeClass() {
+    }
+
+    public SomeClass(String id, int number) {
+        this.id = id;
+        this.number = number;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    public void setNumber(int number) {
+        this.number = number;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        SomeClass someClass = (SomeClass) o;
+        return number == someClass.number && Objects.equals(id, someClass.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, number);
+    }
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/ignoreannotation/TypesafeIgnoreAnnotationTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/ignoreannotation/TypesafeIgnoreAnnotationTest.java
@@ -32,7 +32,7 @@ public class TypesafeIgnoreAnnotationTest {
     @ArquillianResource
     URL testingURL;
 
-    private IgnoreClientApi client;
+    protected IgnoreClientApi client;
 
     @Before
     public void prepare() {

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/ignoreannotation/TypesafeIgnoreAnnotationWithClientModelTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/ignoreannotation/TypesafeIgnoreAnnotationWithClientModelTest.java
@@ -1,0 +1,31 @@
+package io.smallrye.graphql.tests.client.typesafe.ignoreannotation;
+
+import static io.smallrye.graphql.client.model.ClientModelBuilder.build;
+
+import java.io.IOException;
+
+import org.jboss.jandex.Index;
+import org.junit.Before;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
+import io.smallrye.graphql.tests.client.typesafe.ignoreannotation.clientmodels.Person;
+
+public class TypesafeIgnoreAnnotationWithClientModelTest extends TypesafeIgnoreAnnotationTest {
+
+    @Override
+    @Before
+    public void prepare() {
+        Index index = null;
+        try {
+            index = Index.of(IgnoreClientApi.class, Person.class, GraphQLClientApi.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        client = new VertxTypesafeGraphQLClientBuilder()
+                .clientModels(build(index))
+                .endpoint(testingURL.toString() + "graphql")
+                .build(IgnoreClientApi.class);
+    }
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientGraphQLTransportWSSubscriptionTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientGraphQLTransportWSSubscriptionTest.java
@@ -15,12 +15,17 @@ import io.smallrye.graphql.client.websocket.WebsocketSubprotocol;
 @RunAsClient
 public class TypesafeClientGraphQLTransportWSSubscriptionTest extends AbstractTypesafeClientSubscriptionTest {
 
+    private boolean onlyOnce = false;
+
     @Before
     public void prepare() {
-        client = new VertxTypesafeGraphQLClientBuilder()
-                .endpoint(testingURL + "graphql")
-                .subprotocols(WebsocketSubprotocol.GRAPHQL_TRANSPORT_WS)
-                .build(SubscriptionClientApi.class);
+        if (!onlyOnce) {
+            client = new VertxTypesafeGraphQLClientBuilder()
+                    .endpoint(testingURL + "graphql")
+                    .subprotocols(WebsocketSubprotocol.GRAPHQL_TRANSPORT_WS)
+                    .build(SubscriptionClientApi.class);
+            onlyOnce = true;
+        }
     }
 
 }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientGraphQLTransportWSSubscriptionWithClientModelTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientGraphQLTransportWSSubscriptionWithClientModelTest.java
@@ -1,0 +1,47 @@
+package io.smallrye.graphql.tests.client.typesafe.subscription;
+
+import static io.smallrye.graphql.client.model.ClientModelBuilder.build;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.jandex.Index;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
+import io.smallrye.graphql.client.websocket.WebsocketSubprotocol;
+
+/**
+ * Test subscriptions with a typesafe client and graphql-ws subprotocol
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TypesafeClientGraphQLTransportWSSubscriptionWithClientModelTest extends AbstractTypesafeClientSubscriptionTest {
+    private boolean onlyOnce = false;
+
+    @Before
+    public void prepare() {
+        if (!onlyOnce) {
+            Index index = null;
+            try {
+                index = Index.of(SubscriptionClientApi.class,
+                        Dummy.class, DummyWithSourceField.class,
+                        DummyWithErrorOrOnFailingSourceField.class,
+                        GraphQLClientApi.class, Closeable.class, AutoCloseable.class);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            client = new VertxTypesafeGraphQLClientBuilder()
+                    .clientModels(build(index))
+                    .endpoint(testingURL + "graphql")
+                    .subprotocols(WebsocketSubprotocol.GRAPHQL_TRANSPORT_WS)
+                    .build(SubscriptionClientApi.class);
+            onlyOnce = true;
+        }
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientGraphQLWSSubscriptionTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientGraphQLWSSubscriptionTest.java
@@ -14,13 +14,17 @@ import io.smallrye.graphql.client.websocket.WebsocketSubprotocol;
 @RunWith(Arquillian.class)
 @RunAsClient
 public class TypesafeClientGraphQLWSSubscriptionTest extends AbstractTypesafeClientSubscriptionTest {
+    private boolean onlyOnce = false;
 
     @Before
     public void prepare() {
-        client = new VertxTypesafeGraphQLClientBuilder()
-                .endpoint(testingURL + "graphql")
-                .subprotocols(WebsocketSubprotocol.GRAPHQL_WS)
-                .build(SubscriptionClientApi.class);
+        if (!onlyOnce) {
+            client = new VertxTypesafeGraphQLClientBuilder()
+                    .endpoint(testingURL + "graphql")
+                    .subprotocols(WebsocketSubprotocol.GRAPHQL_WS)
+                    .build(SubscriptionClientApi.class);
+            onlyOnce = true;
+        }
     }
 
 }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientGraphQLWSSubscriptionWithClientModelTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/subscription/TypesafeClientGraphQLWSSubscriptionWithClientModelTest.java
@@ -1,0 +1,50 @@
+package io.smallrye.graphql.tests.client.typesafe.subscription;
+
+import static io.smallrye.graphql.client.model.ClientModelBuilder.build;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.jandex.Index;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
+import io.smallrye.graphql.client.websocket.WebsocketSubprotocol;
+
+/**
+ * Test subscriptions with a typesafe client and graphql-ws subprotocol
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TypesafeClientGraphQLWSSubscriptionWithClientModelTest extends AbstractTypesafeClientSubscriptionTest {
+    private boolean onlyOnce = false;
+
+    @Before
+    public void prepare() {
+        if (!onlyOnce) {
+            Index index = null;
+            try {
+                index = Index.of(SubscriptionClientApi.class,
+                        Dummy.class, DummyWithSourceField.class,
+                        DummyWithErrorOrOnFailingSourceField.class,
+                        GraphQLClientApi.class, Closeable.class, AutoCloseable.class);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            client = new VertxTypesafeGraphQLClientBuilder()
+                    .clientModels(build(index))
+                    .endpoint(testingURL + "graphql")
+                    .subprotocols(WebsocketSubprotocol.GRAPHQL_WS)
+                    .build(SubscriptionClientApi.class);
+
+            onlyOnce = true;
+        }
+
+    }
+
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/voidmutation/TypesafeVoidMutationTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/voidmutation/TypesafeVoidMutationTest.java
@@ -40,7 +40,7 @@ public class TypesafeVoidMutationTest {
     @ArquillianResource
     URL testingURL;
 
-    private RectangleClientApi client;
+    protected RectangleClientApi client;
 
     @Before
     public void prepare() {

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/voidmutation/TypesafeVoidMutationWithClientModelTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/typesafe/voidmutation/TypesafeVoidMutationWithClientModelTest.java
@@ -1,0 +1,35 @@
+package io.smallrye.graphql.tests.client.typesafe.voidmutation;
+
+import static io.smallrye.graphql.client.model.ClientModelBuilder.build;
+
+import java.io.IOException;
+
+import org.jboss.jandex.Index;
+import org.junit.Before;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
+import io.smallrye.graphql.tests.client.typesafe.voidmutation.client.RectangleClientApi;
+
+public class TypesafeVoidMutationWithClientModelTest extends TypesafeVoidMutationTest {
+
+    private boolean onlyOnce = false;
+
+    @Before
+    @Override
+    public void prepare() {
+        if (!onlyOnce) {
+            Index index = null;
+            try {
+                index = Index.of(RectangleClientApi.class, Rectangle.class, GraphQLClientApi.class);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            client = new VertxTypesafeGraphQLClientBuilder()
+                    .clientModels(build(index))
+                    .endpoint(testingURL.toString() + "graphql")
+                    .build(RectangleClientApi.class);
+            client.resetRectangles();
+        }
+    }
+}


### PR DESCRIPTION
/cc @t1 @jmartisk

WIP version of type-safe scanning and query building for Quarkus.
I also added a static directive handling

Would benefit by having tests...

This is a very early version, so stuff like proper names, packages, and overall refactoring will be done later.

I used help classes from the schema-builder, and left some of its methods just in case they will be needed later (later in my development).

Quarkus-side: https://github.com/mskacelik/quarkus/tree/typesafe-client-rework

A relevant piece of code on Quarkus-side: https://github.com/mskacelik/quarkus/blob/ecdbf30475b00277aa7ecf75790f8b6ded6f9bc2/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java#L96 

