### PR TITLE
Ensure that longs are passed through to the variables json object

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
@@ -64,6 +64,8 @@ public class RequestImpl implements Request {
                 varBuilder.add(k, (JsonValue) v);
             } else if (v instanceof Boolean) {
                 varBuilder.add(k, (Boolean) v);
+            } else if (v instanceof Long) {
+                varBuilder.add(k, (Long) v);
             } else if (v == null) {
                 varBuilder.addNull(k);
             } else {


### PR DESCRIPTION
This fixes longs not working as a variable type.

If you execute the following code:
```java
String command =
"""
mutation executeSomethingWithLong($timestamp: BigInteger!) {
    doSomething(timestamp: $timestamp) {
        response
    }
}
""";
getClient().executeSync(command, Map.of("timestamp", System.currentTimeMillis()));
```

At the moment, the long gets ignored, and the value is then treated as null. The GraphQL server will then fail the request. This ensures that the long is correctly passed through.