### PR TITLE
Issue 1753 and Issue 1950

### DIFF
--- a/docs/custom-json-serializers-deserializers.md
+++ b/docs/custom-json-serializers-deserializers.md
@@ -1,6 +1,6 @@
-# Customizing JSON-B deserializers
+# Customizing JSON-B serializers/deserializers
 
-If your application needs finer-grained control over JSON deserialization than you can achieve via
+If your application needs finer-grained control over JSON serialization/deserialization than you can achieve via
 formatting annotations like `@JsonbDateFormat`, you may plug in your own custom instances of the `Jsonb` class
 for each input type that your GraphQL application exposes.
 
@@ -9,6 +9,8 @@ and implement its `overrideJsonbConfig` method.
 An example that plugs in a custom date format for a particular class that is used as input:
 
 ```
+package org.acme.custom.json.config;
+
 public class CustomJsonbService implements EventingService {
 
     @Override
@@ -19,7 +21,7 @@ public class CustomJsonbService implements EventingService {
     @Override
     public Map<String, Jsonb> overrideJsonbConfig() {
         JsonbConfig config = new JsonbConfig().withDateFormat("MM dd yyyy HH:mm Z", null);
-        return Collections.singletonMap("org.example.model.MyModelClass", JsonbBuilder.create(config));
+        return Collections.singletonMap("MyModelClass.class.getName()", JsonbBuilder.create(config));
     }
 }
 ```
@@ -27,3 +29,4 @@ public class CustomJsonbService implements EventingService {
 As the discovery of eventing services uses the ServiceLoader mechanism, don't forget to add a 
 `META-INF/services/io.smallrye.graphql.spi.EventingService` file that contains the fully qualified 
 name of your implementation.
+Example `org.acme.custom.json.config.CustomJsonbService`

--- a/docs/custom-json-serializers-deserializers.md
+++ b/docs/custom-json-serializers-deserializers.md
@@ -20,11 +20,14 @@ public class CustomJsonbService implements EventingService {
 
     @Override
     public Map<String, Jsonb> overrideJsonbConfig() {
-        JsonbConfig config = new JsonbConfig().withDateFormat("MM dd yyyy HH:mm Z", null);
+        JsonbConfig config = new JsonbConfig().withDateFormat("MM dd yyyy HH:mm Z", null).withDeserializers(OBJECTID_DESERIALIZER).withSerializers(
+            OBJECTID_SERIALIZER);
         return Collections.singletonMap("MyModelClass.class.getName()", JsonbBuilder.create(config));
     }
 }
 ```
+
+We can customize the JsonbConfig as per our need in above example we have registered additional serializer and date formatting for the class MyModelClass.
 
 As the discovery of eventing services uses the ServiceLoader mechanism, don't forget to add a 
 `META-INF/services/io.smallrye.graphql.spi.EventingService` file that contains the fully qualified 

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
@@ -386,7 +386,7 @@ public class ArgumentHelper extends AbstractHelper {
         m = includeNullCreatorParameters(m, field);
 
         // Create a valid jsonString from a map
-        String jsonString = JsonBCreator.getJsonB().toJson(m);
+        String jsonString = JsonBCreator.getJsonB(className).toJson(m);
         return correctComplexObjectFromJsonString(jsonString, field);
     }
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
@@ -174,7 +174,9 @@ public class EventEmitter {
 
     public Map<String, Jsonb> fireOverrideJsonbConfig() {
         Map<String, Jsonb> overrides = new HashMap<>();
+        int counter = 1;
         for (EventingService extensionService : enabledServices) {
+            LOG.debug(counter++ + ". Registering custom config for EventingService class - " + extensionService.getClass().getName());
             overrides.putAll(extensionService.overrideJsonbConfig());
         }
         return overrides;

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
@@ -174,10 +174,15 @@ public class EventEmitter {
 
     public Map<String, Jsonb> fireOverrideJsonbConfig() {
         Map<String, Jsonb> overrides = new HashMap<>();
-        int counter = 1;
         for (EventingService extensionService : enabledServices) {
-            LOG.debug(counter++ + ". Registering custom config for EventingService class - " + extensionService.getClass().getName());
-            overrides.putAll(extensionService.overrideJsonbConfig());
+            Map<String, Jsonb> map = extensionService.overrideJsonbConfig();
+            map.forEach((clazz, jsonb) -> {
+                LOG.debug("Registering custom JsonB config for class " + clazz + " (it was returned by "
+                        + extensionService.getClass()
+                                .getName()
+                        + ")");
+                overrides.put(clazz, jsonb);
+            });
         }
         return overrides;
     }


### PR DESCRIPTION
Fix to provide custom serializer and deserialzer for Smallrye-graphql jsonb config.

Issues #1753  and Issues #1950 

@jmartisk @phillip-kruger 

This is my first contribution, so need your advise on the change. I have added few changes to make the JSONB Config exposed out. 

Can you have a look at it and share your feedback. Moreover need some help in testcases if those have to be added.

```
# Usage for custom changes will be exclusive to smallrye-graphql viz. no ObjectID dependency.
JsonBCreator.setJsonB(Collections.singletonList(OBJECTID_SERIALIZER),
        Collections.singletonList(OBJECTID_DESERIALIZER));
```