### PR TITLE
Fix Throwable class name with wildcard

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/config/Config.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/config/Config.java
@@ -90,7 +90,7 @@ public interface Config {
             if (configuredValue.equals(throwableClass.getName())) {
                 return true;
             } else if (configuredValue.endsWith("*")) {
-                String values = configuredValue.substring(0, configuredValue.length() - 2);
+                String values = configuredValue.substring(0, configuredValue.length() - 1);
                 if (throwableClass.getName().startsWith(values)) {
                     return true;
                 }


### PR DESCRIPTION
Fixes an issue where is a configured value ends in a wildcard, the character before the wildcard is ignored.

Previously `java.lang*` would match with `java.land.SomeException`.

This also fixes a standalone wildcard (`*`) throwing an exception as it tries to do a substring of index 0 to -1.