### PR TITLE
Deprecated annotation added to IndexInitializer

### DIFF
--- a/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/IndexInitializer.java
+++ b/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/IndexInitializer.java
@@ -88,6 +88,7 @@ public class IndexInitializer {
 
             // directives from the API module
             indexer.index(convertClassToInputStream(ComposeDirective.class));
+            indexer.index(convertClassToInputStream(Deprecated.class));
             indexer.index(convertClassToInputStream(Extends.class));
             indexer.index(convertClassToInputStream(External.class));
             indexer.index(convertClassToInputStream(Inaccessible.class));


### PR DESCRIPTION
The indexer is missing the `Deprecated.class`, and as a result, the schema returned from the `_service` query does not include it.