### PR TITLE
Issue deprecated index

### DIFF
--- a/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/IndexInitializer.java
+++ b/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/IndexInitializer.java
@@ -88,6 +88,7 @@ public class IndexInitializer {
 
             // directives from the API module
             indexer.index(convertClassToInputStream(ComposeDirective.class));
+            indexer.index(convertClassToInputStream(Deprecated.class));
             indexer.index(convertClassToInputStream(Extends.class));
             indexer.index(convertClassToInputStream(External.class));
             indexer.index(convertClassToInputStream(Inaccessible.class));

--- a/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/IndexInitializer.java
+++ b/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/IndexInitializer.java
@@ -28,6 +28,7 @@ import org.jboss.jandex.IndexReader;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 
+import io.smallrye.graphql.api.Deprecated;
 import io.smallrye.graphql.api.Entry;
 import io.smallrye.graphql.api.federation.ComposeDirective;
 import io.smallrye.graphql.api.federation.Extends;
@@ -35,6 +36,7 @@ import io.smallrye.graphql.api.federation.External;
 import io.smallrye.graphql.api.federation.Inaccessible;
 import io.smallrye.graphql.api.federation.InterfaceObject;
 import io.smallrye.graphql.api.federation.Key;
+import io.smallrye.graphql.api.federation.Override;
 import io.smallrye.graphql.api.federation.Provides;
 import io.smallrye.graphql.api.federation.Requires;
 import io.smallrye.graphql.api.federation.Shareable;


### PR DESCRIPTION
Added imports for `Deprecated` and `Override` to make sure that Java native interfaces won't be used.