### PR TITLE
Optimise by reducing calls to ServiceLoader

### DIFF
--- a/client/api/src/main/java/io/smallrye/graphql/client/websocket/WebsocketSubprotocol.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/websocket/WebsocketSubprotocol.java
@@ -5,7 +5,9 @@ public enum WebsocketSubprotocol {
     GRAPHQL_WS("graphql-ws"),
     GRAPHQL_TRANSPORT_WS("graphql-transport-ws");
 
-    private String protocolId;
+    private static final WebsocketSubprotocol[] VALUES = values();
+
+    private final String protocolId;
 
     WebsocketSubprotocol(String protocolId) {
         this.protocolId = protocolId;
@@ -16,7 +18,7 @@ public enum WebsocketSubprotocol {
     }
 
     public static WebsocketSubprotocol fromString(String text) {
-        for (WebsocketSubprotocol b : WebsocketSubprotocol.values()) {
+        for (WebsocketSubprotocol b : VALUES) {
             if (b.protocolId.equalsIgnoreCase(text)) {
                 return b;
             }

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
@@ -315,7 +315,7 @@ class VertxTypesafeGraphQLClientProxy {
     }
 
     private JsonObjectBuilder variables(MethodInvocation method) {
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = jsonObjectFactory.createObjectBuilder();
         method.valueParameters().forEach(parameter -> builder.add(parameter.getRawName(), value(parameter.getValue())));
         return builder;
     }
@@ -398,16 +398,16 @@ class VertxTypesafeGraphQLClientProxy {
     }
 
     private JsonArray arrayValue(Object value) {
-        JsonArrayBuilder array = Json.createArrayBuilder();
+        JsonArrayBuilder array = jsonObjectFactory.createArrayBuilder();
         values(value).forEach(item -> array.add(value(item)));
         return array.build();
     }
 
     private JsonArray mapValue(Object value) {
         Map<?, ?> map = (Map<?, ?>) value;
-        JsonArrayBuilder array = Json.createArrayBuilder();
+        JsonArrayBuilder array = jsonObjectFactory.createArrayBuilder();
         map.forEach((k, v) -> {
-            JsonObjectBuilder entryBuilder = Json.createObjectBuilder();
+            JsonObjectBuilder entryBuilder = jsonObjectFactory.createObjectBuilder();
             entryBuilder.add("key", value(k));
             entryBuilder.add("value", value(v));
             array.add(entryBuilder.build());
@@ -436,7 +436,7 @@ class VertxTypesafeGraphQLClientProxy {
     }
 
     private JsonObject objectValue(Object object, Stream<FieldInfo> fields) {
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = jsonObjectFactory.createObjectBuilder();
         fields.forEach(field -> {
             if (field.isIncludeNull() || field.get(object) != null) {
                 builder.add(field.getName(), value(field.get(object)));

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/MessageType.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/MessageType.java
@@ -11,14 +11,16 @@ public enum MessageType {
     ERROR("error"),
     COMPLETE("complete");
 
-    private String str;
+    private static final MessageType[] VALUES = values();
+
+    private final String str;
 
     MessageType(String str) {
         this.str = str;
     }
 
     public static MessageType fromString(String text) {
-        for (MessageType b : MessageType.values()) {
+        for (MessageType b : VALUES) {
             if (b.str.equalsIgnoreCase(text)) {
                 return b;
             }

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/MessageType.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/MessageType.java
@@ -16,14 +16,16 @@ public enum MessageType {
     GQL_COMPLETE("complete"),
     GQL_CONNECTION_KEEP_ALIVE("ka");
 
-    private String str;
+    private static final MessageType[] VALUES = values();
+
+    private final String str;
 
     MessageType(String str) {
         this.str = str;
     }
 
     public static MessageType fromString(String text) {
-        for (MessageType b : MessageType.values()) {
+        for (MessageType b : VALUES) {
             if (b.str.equalsIgnoreCase(text)) {
                 return b;
             }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonStructure;
@@ -18,6 +19,8 @@ import io.smallrye.graphql.client.Request;
 
 public class RequestImpl implements Request {
 
+    private static final JsonBuilderFactory jsonBuilderFactory = Json.createBuilderFactory(null);
+
     private final String document;
     private Map<String, Object> variables;
     private String operationName;
@@ -29,7 +32,7 @@ public class RequestImpl implements Request {
 
     @Override
     public String toJson() {
-        JsonObjectBuilder queryBuilder = Json.createObjectBuilder().add("query", document);
+        JsonObjectBuilder queryBuilder = jsonBuilderFactory.createObjectBuilder().add("query", document);
         if (!variables.isEmpty()) {
             queryBuilder.add("variables", _formatJsonVariables());
         }
@@ -41,7 +44,7 @@ public class RequestImpl implements Request {
 
     @Override
     public JsonObject toJsonObject() {
-        JsonObjectBuilder queryBuilder = Json.createObjectBuilder().add("query", document);
+        JsonObjectBuilder queryBuilder = jsonBuilderFactory.createObjectBuilder().add("query", document);
         if (!variables.isEmpty()) {
             queryBuilder.add("variables", _formatJsonVariables());
         }
@@ -52,7 +55,7 @@ public class RequestImpl implements Request {
     }
 
     private JsonObject _formatJsonVariables() {
-        JsonObjectBuilder varBuilder = Json.createObjectBuilder();
+        JsonObjectBuilder varBuilder = jsonBuilderFactory.createObjectBuilder();
 
         variables.forEach((k, v) -> {
             // Other types to process here

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/ResponseReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/ResponseReader.java
@@ -12,6 +12,7 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
+import jakarta.json.JsonReaderFactory;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 
@@ -22,6 +23,7 @@ import io.smallrye.graphql.client.InvalidResponseException;
 
 public class ResponseReader {
     private static final Logger LOG = Logger.getLogger(ResponseReader.class.getName());
+    private static final JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
 
     /**
      * Parse a GraphQL response from the input string.
@@ -38,20 +40,21 @@ public class ResponseReader {
         if (input == null) {
             return null;
         }
-        JsonReader jsonReader = Json.createReader(new StringReader(input));
-        JsonObject jsonResponse;
-        try {
-            jsonResponse = jsonReader.readObject();
-        } catch (Exception e) {
-            return null;
-        }
+        try (JsonReader jsonReader = jsonReaderFactory.createReader(new StringReader(input))) {
+            JsonObject jsonResponse;
+            try {
+                jsonResponse = jsonReader.readObject();
+            } catch (Exception e) {
+                return null;
+            }
 
-        // validate that this is what we consider a GraphQL response - else return null
-        if (jsonResponse.size() >= 1) {
-            return checkExpectedResponseFields(jsonResponse,
-                    allowUnexpectedResponseFields);
-        } else {
-            return null;
+            // validate that this is what we consider a GraphQL response - else return null
+            if (jsonResponse.size() >= 1) {
+                return checkExpectedResponseFields(jsonResponse,
+                        allowUnexpectedResponseFields);
+            } else {
+                return null;
+            }
         }
     }
 

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/ResultBuilder.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/ResultBuilder.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonPatch;
@@ -27,6 +28,8 @@ import io.smallrye.graphql.client.typesafe.api.ErrorOr;
 import io.smallrye.graphql.client.typesafe.api.TypesafeResponse;
 
 public class ResultBuilder {
+    private static final JsonBuilderFactory jsonBuilderFactory = Json.createBuilderFactory(null);
+
     private final MethodInvocation method;
     private final JsonObject response;
     private final String responseString;
@@ -115,7 +118,7 @@ public class ResultBuilder {
         JsonPointer pointer = Json.createPointer(path.stream().map(Object::toString).collect(joining("/", "/", "")));
         if (!exists(pointer))
             return false;
-        JsonArrayBuilder errors = Json.createArrayBuilder();
+        JsonArrayBuilder errors = jsonBuilderFactory.createArrayBuilder();
         if (pointer.containsValue(data) && isListOf(pointer.getValue(data), ErrorOr.class.getSimpleName()))
             pointer.getValue(data).asJsonArray().forEach(errors::add);
         errors.add(ERROR_MARK.apply((JsonObject) error));

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/AbstractDataFetcher.java
@@ -43,8 +43,10 @@ public abstract class AbstractDataFetcher<K, T> implements PlugableBatchableData
     protected ErrorResultHelper errorResultHelper = new ErrorResultHelper();
     protected ArgumentHelper argumentHelper;
     protected EventEmitter eventEmitter = EventEmitter.getInstance();
+    @SuppressWarnings("unused")
     protected MetricsEmitter metricsEmitter = MetricsEmitter.getInstance();
     protected BatchLoaderHelper batchLoaderHelper = new BatchLoaderHelper();
+    @SuppressWarnings("unused")
     protected LinkedBlockingQueue<Long> measurementIds = new LinkedBlockingQueue<>();
 
     public AbstractDataFetcher(Operation operation, Type type) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
@@ -37,10 +37,11 @@ import io.smallrye.graphql.spi.config.Config;
  */
 public class EventEmitter {
     private static final Logger LOG = Logger.getLogger(EventEmitter.class);
+    private static final ThreadLocal<EventEmitter> eventEmitters = ThreadLocal.withInitial(EventEmitter::new);
     private final List<EventingService> enabledServices;
 
     public static EventEmitter getInstance() {
-        return new EventEmitter();
+        return eventEmitters.get();
     }
 
     private EventEmitter() {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/metrics/MetricsEmitter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/metrics/MetricsEmitter.java
@@ -16,10 +16,11 @@ import io.smallrye.graphql.spi.config.Config;
 public class MetricsEmitter {
 
     private static final Logger LOG = Logger.getLogger(MetricsEmitter.class);
+    private static final ThreadLocal<MetricsEmitter> metricsEmitters = ThreadLocal.withInitial(MetricsEmitter::new);
     private final List<MetricsService> enabledServices;
 
     public static MetricsEmitter getInstance() {
-        return new MetricsEmitter();
+        return metricsEmitters.get();
     }
 
     private MetricsEmitter() {

--- a/server/implementation/src/main/java/io/smallrye/graphql/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
+import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 
 import io.smallrye.graphql.execution.ExecutionResponse;
@@ -17,6 +18,8 @@ import io.smallrye.graphql.websocket.GraphQLWebSocketSession;
  * Websocket subprotocol handler that implements the `graphql-transport-ws` subprotocol.
  */
 public class GraphQLTransportWSSubprotocolHandler extends AbstractGraphQLWebsocketHandler {
+
+    private static final JsonBuilderFactory jsonBuilderFactory = Json.createBuilderFactory(null);
 
     private final String pingMessage;
     private final String pongMessage;
@@ -83,7 +86,7 @@ public class GraphQLTransportWSSubprotocolHandler extends AbstractGraphQLWebsock
     }
 
     private JsonObject createErrorMessage(String operationId, JsonArray errors) {
-        return Json.createObjectBuilder()
+        return jsonBuilderFactory.createObjectBuilder()
                 .add("id", operationId)
                 .add("type", "error")
                 .add("payload", errors)
@@ -100,13 +103,13 @@ public class GraphQLTransportWSSubprotocolHandler extends AbstractGraphQLWebsock
     }
 
     private JsonObject createPongMessage() {
-        return Json.createObjectBuilder()
+        return jsonBuilderFactory.createObjectBuilder()
                 .add("type", "pong")
                 .build();
     }
 
     private JsonObject createPingMessage() {
-        return Json.createObjectBuilder()
+        return jsonBuilderFactory.createObjectBuilder()
                 .add("type", "ping")
                 .build();
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/websocket/graphqltransportws/MessageType.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/websocket/graphqltransportws/MessageType.java
@@ -11,14 +11,16 @@ public enum MessageType {
     ERROR("error"),
     COMPLETE("complete");
 
-    private String str;
+    private static final MessageType[] VALUES = values();
+
+    private final String str;
 
     MessageType(String str) {
         this.str = str;
     }
 
     public static MessageType fromString(String text) {
-        for (MessageType b : MessageType.values()) {
+        for (MessageType b : VALUES) {
             if (b.str.equalsIgnoreCase(text)) {
                 return b;
             }

--- a/server/implementation/src/main/java/io/smallrye/graphql/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 
 import io.smallrye.graphql.execution.ExecutionResponse;
@@ -16,6 +17,8 @@ import io.smallrye.graphql.websocket.GraphQLWebSocketSession;
  * Websocket subprotocol handler that implements the `graphql-ws` subprotocol.
  */
 public class GraphQLWSSubprotocolHandler extends AbstractGraphQLWebsocketHandler {
+
+    private static final JsonBuilderFactory jsonBuilderFactory = Json.createBuilderFactory(null);
 
     private final String pingMessage;
 
@@ -79,7 +82,7 @@ public class GraphQLWSSubprotocolHandler extends AbstractGraphQLWebsocketHandler
     }
 
     private JsonObject createErrorMessage(String operationId, JsonObject error) {
-        return Json.createObjectBuilder()
+        return jsonBuilderFactory.createObjectBuilder()
                 .add("id", operationId)
                 .add("type", MessageType.GQL_ERROR.asString())
                 .add("payload", error)
@@ -87,7 +90,7 @@ public class GraphQLWSSubprotocolHandler extends AbstractGraphQLWebsocketHandler
     }
 
     private JsonObject createPingMessage() {
-        return Json.createObjectBuilder()
+        return jsonBuilderFactory.createObjectBuilder()
                 .add("type", MessageType.GQL_CONNECTION_KEEP_ALIVE.asString())
                 .build();
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/websocket/graphqlws/MessageType.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/websocket/graphqlws/MessageType.java
@@ -16,14 +16,16 @@ public enum MessageType {
     GQL_COMPLETE("complete"),
     GQL_CONNECTION_KEEP_ALIVE("ka");
 
-    private String str;
+    private static final MessageType[] VALUES = values();
+
+    private final String str;
 
     MessageType(String str) {
         this.str = str;
     }
 
     public static MessageType fromString(String text) {
-        for (MessageType b : MessageType.values()) {
+        for (MessageType b : VALUES) {
             if (b.str.equalsIgnoreCase(text)) {
                 return b;
             }


### PR DESCRIPTION
I decided this weekend to profile some of our programs and discovered that there seemed to be high CPU usage coming from ServiceLoaders. Below is a screenshot of the profile that I took. (One of the vert.x event loop threads)

![ServiceLoaders](https://github.com/smallrye/smallrye-graphql/assets/1919557/be55d784-82dd-4e05-9753-9a8f8129ba40)

More than half the CPU was going towards loading these services multiple times.

This change replaces most of (but not all) the unnecessary ServiceLoader calls.

### Json
Inside the Json class, it gets the provider, which makes a call to the ServiceLoader. This can be resolved using Factories instead, as they can be reused.
There are still quite a few Json.createValue()'s inside the client, which seems pretty slow. The Json library doesn't seem to have a factory for this at the moment, so I have just left it how it is for now.

### MetricsEmitter & EventEmitter

Both of these classes seemed to be used in several places, and as the getInstance() method on both of these doesn't return a single instead but instead creates a new instance each time, converting these to static values proved to be performant.
From my poking, it seems that these implementations were developed to support having a single instance accessed across multiple threads, however, I might be mistaken.

I found an instance where these classes weren't being used, so I removed them. There was also an instance inside AbstractDataFetcher where the MetricsEmitter wasn't being used, but removing it broke Quarkus as it seems to use that. I've just added a variable back so that Quarkus can continue to be happy for now.

### Closing Readers

There were a few JsonReaders that weren't being closed. I traced the code, and this doesn't fix any sort of memory leak (which aligns with my heap dumps). However, this fixes the problem of the char arrays not being recycled and being garbage collected, which will offer a minor performance improvement.

### Logger

I also replaced a non-static logger with a static logger to save it from needing to be reconstructed with every new object.

## Testing

Out of curiosity, I also deployed this to our development servers and saw some pretty decent performance improvements:

![image](https://github.com/smallrye/smallrye-graphql/assets/1919557/437822c3-e866-4b44-8529-89ed77575d8f)
_(Graph of CPU usage of our Quarkus application running GraphQL, left is the old code and the right is the new code)_
