### PR TITLE
change how the type variables are handled during the creation of the reference

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
@@ -56,7 +56,7 @@ public class EnumCreator implements Creator<EnumType> {
                 annotations,
                 autoNameStrategy,
                 ReferenceType.ENUM,
-                reference.getClassParametrizedTypes());
+                reference.getAllParametrizedTypes());
 
         // Description
         Optional<String> maybeDescription = DescriptionHelper.getDescriptionForType(annotations);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/UnionCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/UnionCreator.java
@@ -38,7 +38,7 @@ public class UnionCreator implements Creator<UnionType> {
                 annotations,
                 referenceCreator.getTypeAutoNameStrategy(),
                 ReferenceType.UNION,
-                reference.getClassParametrizedTypes());
+                reference.getAllParametrizedTypes());
 
         // Description
         Optional<String> maybeDescription = DescriptionHelper.getDescriptionForType(annotations);

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/generic/parametrized/ParametrizedTypesResources.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/generic/parametrized/ParametrizedTypesResources.java
@@ -1,0 +1,181 @@
+package io.smallrye.graphql.index.generic.parametrized;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Input;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Type;
+
+@GraphQLApi
+public class ParametrizedTypesResources {
+
+    static class FirstClass extends SecondClass<Bar> {
+        int firstClassField;
+
+        public FirstClass() {
+        }
+
+        public int getFirstClassField() {
+            return firstClassField;
+        }
+
+        public void setFirstClassField(int firstClassField) {
+            this.firstClassField = firstClassField;
+        }
+    }
+
+    static class SecondClass<T> {
+        T secondClassField;
+
+        public SecondClass() {
+        }
+
+        public T getSecondClassField() {
+            return secondClassField;
+        }
+
+        public void setSecondClassField(T secondClassField) {
+            this.secondClassField = secondClassField;
+        }
+    }
+
+    // this is the only exception where it works to use both type variable in child and parent classes.
+    // first that the both `T` are the same types and that the SecondClass<T> also uses "T" in its class definition.
+    static class ThirdClass<T> extends SecondClass<T> {
+        T thirdClassField;
+
+        public ThirdClass() {
+        }
+
+        public T getThirdClassField() {
+            return thirdClassField;
+        }
+
+        public void setThirdClassField(T thirdClassField) {
+            this.thirdClassField = thirdClassField;
+        }
+    }
+
+    static class FourthClass extends FifthClass<Bar, String> {
+        String fourthClassField;
+
+        public FourthClass() {
+        }
+
+        public String getFourthClassField() {
+            return fourthClassField;
+        }
+
+        public void setFourthClassField(String fourthClassField) {
+            this.fourthClassField = fourthClassField;
+        }
+    }
+
+    static class FifthClass<M, N> {
+        M fifthClassField1;
+        N fifthClassField2;
+
+        public FifthClass() {
+        }
+
+        public M getFifthClassField1() {
+            return fifthClassField1;
+        }
+
+        public void setFifthClassField1(M fifthClassField1) {
+            this.fifthClassField1 = fifthClassField1;
+        }
+
+        public N getFifthClassField2() {
+            return fifthClassField2;
+        }
+
+        public void setFifthClassField2(N fifthClassField2) {
+            this.fifthClassField2 = fifthClassField2;
+        }
+    }
+
+    static class Bar {
+        int barField;
+
+        public Bar() {
+        }
+
+        public int getBarField() {
+            return barField;
+        }
+
+        public void setBarField(int barField) {
+            this.barField = barField;
+        }
+    }
+
+    @Type("NewFirstClass")
+    @Input("NewFirstClassInput")
+    static class RenamedFirstClass extends SecondClass<Bar> {
+        float renamedFirstClassField;
+
+        public RenamedFirstClass() {
+        }
+
+        public float getRenamedFirstClassField() {
+            return renamedFirstClassField;
+        }
+
+        public void setRenamedFirstClassField(float renamedFirstClassField) {
+            this.renamedFirstClassField = renamedFirstClassField;
+        }
+    }
+
+    @Type("NewSecondClass")
+    @Input("NewSecondClassInput")
+    static class RenamedSecondClass<T> {
+        T renamedSecondClassField;
+
+        public RenamedSecondClass() {
+        }
+
+        public T getRenamedSecondClassField() {
+            return renamedSecondClassField;
+        }
+
+        public void setRenamedSecondClassField(T renamedSecondClassField) {
+            this.renamedSecondClassField = renamedSecondClassField;
+        }
+    }
+
+    @Query
+    public FirstClass firstQuery(FirstClass firstClass) {
+        return null;
+    }
+
+    @Query
+    public SecondClass<Bar> secondQuery(SecondClass<Bar> secondClass) {
+        return null;
+    }
+
+    @Query
+    public ThirdClass<String> thirdQuery(ThirdClass<String> thirdClass) {
+        return null;
+    }
+
+    @Query
+    public FourthClass fourthQuery(FourthClass fourthClass) {
+        return null;
+    }
+
+    @Query
+    public FifthClass<Bar, String> fifthQuery(FifthClass<String, Bar> fifthClass) {
+        return null;
+    }
+
+    @Query
+    public RenamedFirstClass sixthQuery(RenamedFirstClass renamedFirstClass) {
+        return null;
+    }
+
+    @Query
+    public RenamedSecondClass<Bar> seventhQuery(RenamedSecondClass<Bar> renamedSecondClass) {
+        return null;
+    }
+
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/ReferenceCreatorTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/ReferenceCreatorTest.java
@@ -49,7 +49,7 @@ public class ReferenceCreatorTest {
                     reference.getGraphQLClassName());
             assertEquals(ReferenceType.INTERFACE, reference.getType());
             assertNull(reference.getAdaptTo());
-            assertFalse(reference.getClassParametrizedTypes().isEmpty());
+            assertFalse(reference.getAllParametrizedTypes().isEmpty());
             assertTrue(reference.isAddParametrizedTypeNameExtension());
         } finally {
             ScanningContext.remove();

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -821,7 +821,7 @@ public class Bootstrap {
     private Optional<GraphQLArgument> getAutoMapArgument(Field field) {
         // Auto Map argument
         if (field.hasWrapper() && field.getWrapper().isMap() && !field.isAdaptingWith()) { // TODO: Also pass this to the user adapter ?
-            Map<String, Reference> parametrizedTypeArguments = field.getReference().getClassParametrizedTypes();
+            Map<String, Reference> parametrizedTypeArguments = field.getReference().getAllParametrizedTypes();
             Reference keyReference = parametrizedTypeArguments.get(AUTOMAP_KEY_KEY);
 
             ReferenceType type = keyReference.getType();

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
@@ -463,8 +463,8 @@ public class ArgumentHelper extends AbstractHelper {
      */
     private Type getType(Reference reference) {
         Class<?> ownerClass = classloadingService.loadClass(reference.getClassName());
-        if (reference.getClassParametrizedTypes() == null
-                || reference.getClassParametrizedTypes().isEmpty()) {
+        if (reference.getAllParametrizedTypes() == null
+                || reference.getAllParametrizedTypes().isEmpty()) {
             return ownerClass;
         }
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/DefaultMapAdapter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/DefaultMapAdapter.java
@@ -36,7 +36,7 @@ public class DefaultMapAdapter<K, V> {
         for (Object e : entries) {
             Map<K, V> graphQLJavaMap = (Map<K, V>) e; // The entry complex type comes from graphql-java as an Map
 
-            Map<String, Reference> parametrizedTypeArguments = field.getReference().getClassParametrizedTypes();
+            Map<String, Reference> parametrizedTypeArguments = field.getReference().getAllParametrizedTypes();
 
             Reference keyReference = parametrizedTypeArguments.get("K");
             Reference valueReference = parametrizedTypeArguments.get("V");
@@ -58,7 +58,7 @@ public class DefaultMapAdapter<K, V> {
             }
         } else {
 
-            Map<String, Reference> parametrizedTypeArguments = field.getReference().getClassParametrizedTypes();
+            Map<String, Reference> parametrizedTypeArguments = field.getReference().getAllParametrizedTypes();
             Reference keyReference = parametrizedTypeArguments.get("K");
 
             for (K k : key) {


### PR DESCRIPTION
fix: #1993
/cc @jmartisk 

WIP

The problem in the ReferenceCreator class was that it did not differentiate between the `SomeClass<A>` and `SomeClass extends SomeOtherClass<A>` type variables. These type variables are stored in a map, which will be used in the schema generation process.

So, I have made a new field in the `Reference` class for storing parent's type variables.

I also added tests in the SchemaBuilderTest, which are also WIP.

Tests seems to work fine, but there seems to be a problem from the Quarkus app side:
```
Error running Quarkus: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at io.quarkus.runner.bootstrap.StartupActionImpl$1.run(StartupActionImpl.java:113)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.ExceptionInInitializerError
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:70)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
	... 6 more
Caused by: java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.<clinit>(Unknown Source)
	... 15 more
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Map.put(Object, Object)" because the return value of "io.smallrye.graphql.schema.model.Reference.getAllParametrizedTypes()" is null
	at io.quarkus.deployment.steps.SmallRyeGraphQLProcessor$buildExecutionService1691419614.deploy_2(Unknown Source)
	at io.quarkus.deployment.steps.SmallRyeGraphQLProcessor$buildExecutionService1691419614.deploy(Unknown Source)
	... 16 more
```
reproduced by:
```java
static class Bar {
    int a;
    public Bar() {}
}
static class Foo<T> extends Entity<Bar> {
        T t;
        public Foo() {
        }
    }

    static class Entity<N> {
        private N b;

        public Entity() {
        }
    }
    @Query
    public Foo<String> getFoo() {
        return null;
    }
```
