### PR TITLE
Mapping directive arguments to custom scalar types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: wildfly-extras/wildfly-graphql-feature-pack
-          ref: main
+          ref: srgql-2.8.0
           path: wildfly-graphql-feature-pack
 
       - uses: actions/setup-java@v3.0.0

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/DirectiveTypeCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/DirectiveTypeCreator.java
@@ -18,7 +18,9 @@ import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
 import io.smallrye.graphql.api.federation.policy.Policy;
+import io.smallrye.graphql.api.federation.policy.PolicyItem;
 import io.smallrye.graphql.api.federation.requiresscopes.RequiresScopes;
+import io.smallrye.graphql.api.federation.requiresscopes.ScopeItem;
 import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.helper.DescriptionHelper;
 import io.smallrye.graphql.schema.helper.Direction;
@@ -28,8 +30,9 @@ import io.smallrye.graphql.schema.model.DirectiveType;
 
 public class DirectiveTypeCreator extends ModelCreator {
     private static final DotName POLICY = DotName.createSimple(Policy.class.getName());
+    private static final DotName POLICY_ITEM = DotName.createSimple(PolicyItem.class.getName());
     private static final DotName REQUIRES_SCOPES = DotName.createSimple(RequiresScopes.class.getName());
-    private static final DotName STRING = DotName.createSimple(String.class.getName());
+    private static final DotName SCOPE = DotName.createSimple(ScopeItem.class.getName());
 
     private static final Logger LOG = Logger.getLogger(DirectiveTypeCreator.class.getName());
 
@@ -59,13 +62,19 @@ public class DirectiveTypeCreator extends ModelCreator {
             DirectiveArgument argument = new DirectiveArgument();
             Type argumentType;
             if (classInfo.name().equals(POLICY) || classInfo.name().equals(REQUIRES_SCOPES)) {
-                // For both of these directives, we need to override the argument type to be an array of nested arrays
-                // of strings, where none of the nested elements can be null
+                // For both of these directives, we need to override the argument type to be an array of nested arrays,
+                // where none of the nested elements can be null
+                DotName typeName;
+                if (classInfo.name().equals(POLICY)) {
+                    typeName = POLICY_ITEM;
+                } else {
+                    typeName = SCOPE;
+                }
                 AnnotationInstance nonNullAnnotation = AnnotationInstance.create(NON_NULL, null,
                         Collections.emptyList());
-                Type stringType = ClassType.createWithAnnotations(STRING, Type.Kind.CLASS,
+                Type type = ClassType.createWithAnnotations(typeName, Type.Kind.CLASS,
                         new AnnotationInstance[] { nonNullAnnotation });
-                argumentType = buildArrayType(stringType, 2, nonNullAnnotation);
+                argumentType = buildArrayType(type, 2, nonNullAnnotation);
             } else {
                 argumentType = method.returnType();
             }

--- a/common/schema-model/pom.xml
+++ b/common/schema-model/pom.xml
@@ -10,4 +10,12 @@
     <artifactId>smallrye-graphql-schema-model</artifactId>
     <name>SmallRye: GraphQL Common :: Schema Model</name>
     <description>A model that represents the schema</description>
+
+     <dependencies>
+        <!-- The API -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-graphql-api</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
@@ -28,6 +28,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.smallrye.graphql.api.federation.FieldSet;
+import io.smallrye.graphql.api.federation.policy.PolicyItem;
+import io.smallrye.graphql.api.federation.requiresscopes.ScopeItem;
+
 /**
  * Here we keep all the scalars we know about
  *
@@ -50,6 +54,9 @@ public class Scalars {
     private static final String PERIOD = "Period";
     private static final String DURATION = "Duration";
     private static final String VOID = "Void";
+    private static final String FIELD_SET = "FieldSet";
+    private static final String POLICY = "Policy";
+    private static final String SCOPE = "Scope";
 
     private Scalars() {
     }
@@ -181,6 +188,13 @@ public class Scalars {
         // Void
         populateScalar(Void.class.getName(), VOID, Void.class.getName());
         populateScalar(void.class.getName(), VOID, Void.class.getName());
+
+        // Federation
+        if (Boolean.getBoolean("smallrye.graphql.federation.enabled")) {
+            populateScalar(FieldSet.class.getName(), FIELD_SET, FieldSet.class.getName());
+            populateScalar(PolicyItem.class.getName(), POLICY, PolicyItem.class.getName());
+            populateScalar(ScopeItem.class.getName(), SCOPE, ScopeItem.class.getName());
+        }
     }
 
     private static void populateScalar(String className, String scalarName) {

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -12,7 +12,7 @@ import org.eclipse.microprofile.graphql.Id;
 import io.smallrye.graphql.api.federation.Extends;
 import io.smallrye.graphql.api.federation.Key;
 
-@Extends @Key(fields = "id")
+@Extends @Key(fields = @FieldSet("id"))
 public class Product {
     @Id
     private String id;

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/FieldSet.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/FieldSet.java
@@ -1,0 +1,16 @@
+package io.smallrye.graphql.api.federation;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import org.eclipse.microprofile.graphql.NonNull;
+
+/**
+ * String-serialized scalar represents a set of fields that's passed to a federated directive.
+ */
+@Retention(RUNTIME)
+public @interface FieldSet {
+    @NonNull
+    String value();
+}

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/Key.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/Key.java
@@ -35,7 +35,7 @@ public @interface Key {
             "\"id\"\n" +
             "\"username region\"\n" +
             "\"name organization { id }\"")
-    String fields();
+    FieldSet fields();
 
     @DefaultValue("true")
     @Description("If false, indicates to the router that this subgraph doesn't define a reference resolver for this " +

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/Provides.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/Provides.java
@@ -33,5 +33,5 @@ public @interface Provides {
             "\"name\"\n" +
             "\"name address\"\n" +
             "\"... on Person { name address }\" (valid for fields that return a union or interface)")
-    String fields();
+    FieldSet fields();
 }

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/Requires.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/Requires.java
@@ -31,5 +31,5 @@ public @interface Requires {
             "\"name\"\n" +
             "\"name address\"\n" +
             "\"name organization { id }\"")
-    String fields();
+    FieldSet fields();
 }

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/policy/PolicyItem.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/policy/PolicyItem.java
@@ -7,10 +7,10 @@ import java.lang.annotation.Retention;
 import org.eclipse.microprofile.graphql.NonNull;
 
 /**
- * Defines a group of authorization policies, each representing a set used by the {@link Policy} directive.
+ * String-serialized scalar represents an authorization policy.
  */
 @Retention(RUNTIME)
-public @interface PolicyGroup {
+public @interface PolicyItem {
     @NonNull
-    PolicyItem[] value();
+    String value();
 }

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/requiresscopes/ScopeItem.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/requiresscopes/ScopeItem.java
@@ -7,10 +7,10 @@ import java.lang.annotation.Retention;
 import org.eclipse.microprofile.graphql.NonNull;
 
 /**
- * Defines a group of JWT scopes, each representing a set used by the {@link RequiresScopes} directive.
+ * String-serialized scalar represents a JWT scope.
  */
 @Retention(RUNTIME)
-public @interface ScopeGroup {
+public @interface ScopeItem {
     @NonNull
-    ScopeItem[] value();
+    String value();
 }

--- a/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/ExecutionServlet.java
+++ b/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/ExecutionServlet.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -90,25 +91,25 @@ public class ExecutionServlet extends HttpServlet {
         // Query
         String query = request.getParameter(QUERY);
         if (query != null && !query.isEmpty()) {
-            input.add(QUERY, URLDecoder.decode(query, "UTF8"));
+            input.add(QUERY, URLDecoder.decode(query, StandardCharsets.UTF_8));
         }
         // OperationName
         String operationName = request.getParameter(OPERATION_NAME);
         if (operationName != null && !operationName.isEmpty()) {
-            input.add(OPERATION_NAME, URLDecoder.decode(query, "UTF8"));
+            input.add(OPERATION_NAME, URLDecoder.decode(query, StandardCharsets.UTF_8));
         }
 
         // Variables
         String variables = request.getParameter(VARIABLES);
         if (variables != null && !variables.isEmpty()) {
-            JsonObject jsonObject = toJsonObject(URLDecoder.decode(variables, "UTF8"));
+            JsonObject jsonObject = toJsonObject(URLDecoder.decode(variables, StandardCharsets.UTF_8));
             input.add(VARIABLES, jsonObject);
         }
 
         // Extensions
         String extensions = request.getParameter(EXTENSIONS);
         if (extensions != null && !extensions.isEmpty()) {
-            JsonObject jsonObject = toJsonObject(URLDecoder.decode(extensions, "UTF8"));
+            JsonObject jsonObject = toJsonObject(URLDecoder.decode(extensions, StandardCharsets.UTF_8));
             input.add(EXTENSIONS, jsonObject);
         }
 

--- a/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/IndexInitializer.java
+++ b/server/implementation-servlet/src/main/java/io/smallrye/graphql/entry/http/IndexInitializer.java
@@ -35,6 +35,7 @@ import io.smallrye.graphql.api.federation.Authenticated;
 import io.smallrye.graphql.api.federation.ComposeDirective;
 import io.smallrye.graphql.api.federation.Extends;
 import io.smallrye.graphql.api.federation.External;
+import io.smallrye.graphql.api.federation.FieldSet;
 import io.smallrye.graphql.api.federation.Inaccessible;
 import io.smallrye.graphql.api.federation.InterfaceObject;
 import io.smallrye.graphql.api.federation.Key;
@@ -45,8 +46,10 @@ import io.smallrye.graphql.api.federation.Shareable;
 import io.smallrye.graphql.api.federation.Tag;
 import io.smallrye.graphql.api.federation.policy.Policy;
 import io.smallrye.graphql.api.federation.policy.PolicyGroup;
+import io.smallrye.graphql.api.federation.policy.PolicyItem;
 import io.smallrye.graphql.api.federation.requiresscopes.RequiresScopes;
 import io.smallrye.graphql.api.federation.requiresscopes.ScopeGroup;
+import io.smallrye.graphql.api.federation.requiresscopes.ScopeItem;
 
 /**
  * This creates an index from the classpath.
@@ -100,16 +103,19 @@ public class IndexInitializer {
             indexer.index(convertClassToInputStream(Deprecated.class));
             indexer.index(convertClassToInputStream(Extends.class));
             indexer.index(convertClassToInputStream(External.class));
+            indexer.index(convertClassToInputStream(FieldSet.class));
             indexer.index(convertClassToInputStream(Inaccessible.class));
             indexer.index(convertClassToInputStream(InterfaceObject.class));
             indexer.index(convertClassToInputStream(Key.class));
             indexer.index(convertClassToInputStream(Override.class));
             indexer.index(convertClassToInputStream(Policy.class));
             indexer.index(convertClassToInputStream(PolicyGroup.class));
+            indexer.index(convertClassToInputStream(PolicyItem.class));
             indexer.index(convertClassToInputStream(Provides.class));
             indexer.index(convertClassToInputStream(Requires.class));
             indexer.index(convertClassToInputStream(RequiresScopes.class));
             indexer.index(convertClassToInputStream(ScopeGroup.class));
+            indexer.index(convertClassToInputStream(ScopeItem.class));
             indexer.index(convertClassToInputStream(Shareable.class));
             indexer.index(convertClassToInputStream(Tag.class));
             indexer.index(convertClassToInputStream(OneOf.class));

--- a/server/implementation/pom.xml
+++ b/server/implementation/pom.xml
@@ -140,6 +140,7 @@
                 <configuration>
                     <useFile>false</useFile>
                     <trimStackTrace>false</trimStackTrace>
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
         </plugins>

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -180,7 +180,7 @@ public class Bootstrap {
         addSubscriptions(schemaBuilder);
         schemaBuilder.withSchemaAppliedDirectives(Arrays.stream(
                 createGraphQLDirectives(schema.getDirectiveInstances()))
-                .map(graphQLDirective -> graphQLDirective.toAppliedDirective())
+                .map(GraphQLDirective::toAppliedDirective)
                 .collect(Collectors.toList()));
         schemaBuilder.description(schema.getDescription());
         schemaBuilder.additionalDirectives(directiveTypes);
@@ -675,10 +675,14 @@ public class Bootstrap {
             }
             GraphQLInputType inputType = createGraphQLInputType(argumentType);
 
+            // We have to call .valueProgrammatic(...) in order for graphql.schema.InputValueWithState to be set to
+            // EXTERNAL_VALUE, meaning that .valueToLiteral(...) from our own Coercing implementation will be called
+            // when converting. If we use .value(...), INTERNAL_VALUE (which is deprecated) will be used, along with
+            // ValuesResolverLegacy.valueToLiteralLegacy
             GraphQLArgument.Builder argumentBuilder = GraphQLArgument.newArgument()
                     .name(argumentName)
                     .type(inputType)
-                    .value(entry.getValue());
+                    .valueProgrammatic(entry.getValue());
 
             if (argumentType.hasDefaultValue()) {
                 argumentBuilder = argumentBuilder.defaultValueProgrammatic(sanitizeDefaultValue(argumentType));

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/GraphQLScalarTypes.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/GraphQLScalarTypes.java
@@ -9,6 +9,9 @@ import java.util.UUID;
 import graphql.Scalars;
 import graphql.scalars.ExtendedScalars;
 import graphql.schema.GraphQLScalarType;
+import io.smallrye.graphql.scalar.federation.FieldSetScalar;
+import io.smallrye.graphql.scalar.federation.PolicyScalar;
+import io.smallrye.graphql.scalar.federation.ScopeScalar;
 import io.smallrye.graphql.scalar.number.BigDecimalScalar;
 import io.smallrye.graphql.scalar.number.BigIntegerScalar;
 import io.smallrye.graphql.scalar.number.FloatScalar;
@@ -96,6 +99,12 @@ public class GraphQLScalarTypes {
         mapType(new DurationScalar());
 
         mapType(new VoidScalar()); // Void
+
+        if (Boolean.getBoolean("smallrye.graphql.federation.enabled")) {
+            mapType(new FieldSetScalar());
+            mapType(new PolicyScalar());
+            mapType(new ScopeScalar());
+        }
 
         for (final GraphQLScalarType value : SCALAR_MAP.values()) {
             SCALARS_BY_NAME.put(value.getName(), value);

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/FieldSetCoercing.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/FieldSetCoercing.java
@@ -1,0 +1,72 @@
+package io.smallrye.graphql.scalar.federation;
+
+import static io.smallrye.graphql.SmallRyeGraphQLServerMessages.msg;
+
+import java.util.Map;
+
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.schema.Coercing;
+import io.smallrye.graphql.api.federation.FieldSet;
+
+public class FieldSetCoercing implements Coercing<Object, String> {
+
+    private static String typeName(Object input) {
+        if (input == null) {
+            return "null";
+        }
+        return input.getClass().getSimpleName();
+    }
+
+    private String convertImpl(Object input) {
+        if (input instanceof Map) {
+            Object value = ((Map<?, ?>) input).get("value");
+            if (value instanceof String) {
+                return (String) value;
+            } else {
+                throw new RuntimeException("Can not parse a String from [" + typeName(value) + "]");
+            }
+        } else {
+            throw new RuntimeException("Can not parse a FieldSet from [" + typeName(input) + "]");
+        }
+    }
+
+    @Override
+    public String serialize(Object input) {
+        if (input == null)
+            return null;
+        try {
+            return convertImpl(input);
+        } catch (RuntimeException e) {
+            throw msg.coercingSerializeException(FieldSet.class.getSimpleName(), typeName(input), e);
+        }
+    }
+
+    @Override
+    public Object parseValue(Object input) {
+        try {
+            return convertImpl(input);
+        } catch (RuntimeException e) {
+            throw msg.coercingParseValueException(FieldSet.class.getSimpleName(), typeName(input), e);
+        }
+    }
+
+    @Override
+    public Object parseLiteral(Object input) {
+        if (input == null)
+            return null;
+
+        if (input instanceof StringValue) {
+            return ((StringValue) input).getValue();
+        } else {
+            throw msg.coercingParseLiteralException(typeName(input));
+        }
+    }
+
+    @Override
+    public Value<?> valueToLiteral(Object input) {
+        String s = serialize(input);
+        return StringValue.newStringValue(s).build();
+    }
+
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/FieldSetScalar.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/FieldSetScalar.java
@@ -1,0 +1,15 @@
+package io.smallrye.graphql.scalar.federation;
+
+import io.smallrye.graphql.api.federation.FieldSet;
+import io.smallrye.graphql.scalar.AbstractScalar;
+
+/**
+ * Scalar for {@link FieldSet}.
+ */
+public class FieldSetScalar extends AbstractScalar {
+
+    public FieldSetScalar() {
+
+        super("FieldSet", new FieldSetCoercing(), FieldSet.class);
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/PolicyCoercing.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/PolicyCoercing.java
@@ -1,0 +1,72 @@
+package io.smallrye.graphql.scalar.federation;
+
+import static io.smallrye.graphql.SmallRyeGraphQLServerMessages.msg;
+
+import java.util.Map;
+
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.schema.Coercing;
+import io.smallrye.graphql.api.federation.policy.PolicyItem;
+
+public class PolicyCoercing implements Coercing<Object, String> {
+
+    private static String typeName(Object input) {
+        if (input == null) {
+            return "null";
+        }
+        return input.getClass().getSimpleName();
+    }
+
+    private String convertImpl(Object input) {
+        if (input instanceof Map) {
+            Object value = ((Map<?, ?>) input).get("value");
+            if (value instanceof String) {
+                return (String) value;
+            } else {
+                throw new RuntimeException("Can not parse a String from [" + typeName(value) + "]");
+            }
+        } else {
+            throw new RuntimeException("Can not parse a Policy from [" + typeName(input) + "]");
+        }
+    }
+
+    @Override
+    public String serialize(Object input) {
+        if (input == null)
+            return null;
+        try {
+            return convertImpl(input);
+        } catch (RuntimeException e) {
+            throw msg.coercingSerializeException(PolicyItem.class.getSimpleName(), typeName(input), e);
+        }
+    }
+
+    @Override
+    public Object parseValue(Object input) {
+        try {
+            return convertImpl(input);
+        } catch (RuntimeException e) {
+            throw msg.coercingParseValueException(PolicyItem.class.getSimpleName(), typeName(input), e);
+        }
+    }
+
+    @Override
+    public Object parseLiteral(Object input) {
+        if (input == null)
+            return null;
+
+        if (input instanceof StringValue) {
+            return ((StringValue) input).getValue();
+        } else {
+            throw msg.coercingParseLiteralException(typeName(input));
+        }
+    }
+
+    @Override
+    public Value<?> valueToLiteral(Object input) {
+        String s = serialize(input);
+        return StringValue.newStringValue(s).build();
+    }
+
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/PolicyScalar.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/PolicyScalar.java
@@ -1,0 +1,15 @@
+package io.smallrye.graphql.scalar.federation;
+
+import io.smallrye.graphql.api.federation.policy.PolicyItem;
+import io.smallrye.graphql.scalar.AbstractScalar;
+
+/**
+ * Scalar for {@link PolicyItem}.
+ */
+public class PolicyScalar extends AbstractScalar {
+
+    public PolicyScalar() {
+
+        super("Policy", new PolicyCoercing(), PolicyItem.class);
+    }
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/ScopeCoercing.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/ScopeCoercing.java
@@ -1,0 +1,72 @@
+package io.smallrye.graphql.scalar.federation;
+
+import static io.smallrye.graphql.SmallRyeGraphQLServerMessages.msg;
+
+import java.util.Map;
+
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.schema.Coercing;
+import io.smallrye.graphql.api.federation.requiresscopes.ScopeItem;
+
+public class ScopeCoercing implements Coercing<Object, String> {
+
+    private static String typeName(Object input) {
+        if (input == null) {
+            return "null";
+        }
+        return input.getClass().getSimpleName();
+    }
+
+    private String convertImpl(Object input) {
+        if (input instanceof Map) {
+            Object value = ((Map<?, ?>) input).get("value");
+            if (value instanceof String) {
+                return (String) value;
+            } else {
+                throw new RuntimeException("Can not parse a String from [" + typeName(value) + "]");
+            }
+        } else {
+            throw new RuntimeException("Can not parse a Scope from [" + typeName(input) + "]");
+        }
+    }
+
+    @Override
+    public String serialize(Object input) {
+        if (input == null)
+            return null;
+        try {
+            return convertImpl(input);
+        } catch (RuntimeException e) {
+            throw msg.coercingSerializeException(ScopeItem.class.getSimpleName(), typeName(input), e);
+        }
+    }
+
+    @Override
+    public Object parseValue(Object input) {
+        try {
+            return convertImpl(input);
+        } catch (RuntimeException e) {
+            throw msg.coercingParseValueException(ScopeItem.class.getSimpleName(), typeName(input), e);
+        }
+    }
+
+    @Override
+    public Object parseLiteral(Object input) {
+        if (input == null)
+            return null;
+
+        if (input instanceof StringValue) {
+            return ((StringValue) input).getValue();
+        } else {
+            throw msg.coercingParseLiteralException(typeName(input));
+        }
+    }
+
+    @Override
+    public Value<?> valueToLiteral(Object input) {
+        String s = serialize(input);
+        return StringValue.newStringValue(s).build();
+    }
+
+}

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/ScopeScalar.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/federation/ScopeScalar.java
@@ -1,0 +1,15 @@
+package io.smallrye.graphql.scalar.federation;
+
+import io.smallrye.graphql.api.federation.requiresscopes.ScopeItem;
+import io.smallrye.graphql.scalar.AbstractScalar;
+
+/**
+ * Scalar for {@link ScopeItem}.
+ */
+public class ScopeScalar extends AbstractScalar {
+
+    public ScopeScalar() {
+
+        super("Scope", new ScopeCoercing(), ScopeItem.class);
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaFederationEnabledTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaFederationEnabledTest.java
@@ -1,0 +1,97 @@
+package io.smallrye.graphql.schema;
+
+import static graphql.Scalars.GraphQLString;
+import static graphql.introspection.Introspection.DirectiveLocation.INTERFACE;
+import static graphql.introspection.Introspection.DirectiveLocation.OBJECT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Repeatable;
+import java.util.EnumSet;
+
+import org.junit.jupiter.api.Test;
+
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLScalarType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLUnionType;
+import io.smallrye.graphql.api.Directive;
+import io.smallrye.graphql.api.federation.FieldSet;
+import io.smallrye.graphql.api.federation.Key;
+import io.smallrye.graphql.api.federation.Key.Keys;
+
+class SchemaFederationEnabledTest extends SchemaTestBase {
+
+    @Test
+    void testSchemaWithFederationEnabled() {
+        config.federationEnabled = true;
+        // need to set it as system property because the SchemaBuilder doesn't have access to the Config object
+        System.setProperty("smallrye.graphql.federation.enabled", "true");
+        try {
+            GraphQLSchema graphQLSchema = createGraphQLSchema(Repeatable.class, Directive.class, Key.class, Keys.class,
+                    FieldSet.class, TestTypeWithFederation.class, FederationTestApi.class);
+
+            GraphQLDirective keyDirective = graphQLSchema.getDirective("key");
+            assertEquals("key", keyDirective.getName());
+            assertTrue(keyDirective.isRepeatable());
+            assertEquals(
+                    "Designates an object type as an entity and specifies its key fields " +
+                            "(a set of fields that the subgraph can use to uniquely identify any instance " +
+                            "of the entity). You can apply multiple @key directives to a single entity " +
+                            "(to specify multiple valid sets of key fields).",
+                    keyDirective.getDescription());
+            assertEquals(EnumSet.of(OBJECT, INTERFACE), keyDirective.validLocations());
+            assertEquals(2, keyDirective.getArguments().size());
+            assertEquals("FieldSet",
+                    ((GraphQLScalarType) ((GraphQLNonNull) keyDirective.getArgument("fields").getType()).getWrappedType())
+                            .getName());
+            assertEquals("Boolean",
+                    ((GraphQLScalarType) keyDirective.getArgument("resolvable").getType()).getName());
+
+            GraphQLUnionType entityType = (GraphQLUnionType) graphQLSchema.getType("_Entity");
+            assertNotNull(entityType);
+            assertEquals(1, entityType.getTypes().size());
+            assertEquals(TestTypeWithFederation.class.getSimpleName(), entityType.getTypes().get(0).getName());
+
+            GraphQLObjectType queryRoot = graphQLSchema.getQueryType();
+            assertEquals(3, queryRoot.getFields().size());
+
+            GraphQLFieldDefinition entities = queryRoot.getField("_entities");
+            assertEquals(1, entities.getArguments().size());
+            assertEquals("[_Any!]!", entities.getArgument("representations").getType().toString());
+            assertEquals("[_Entity]!", entities.getType().toString());
+
+            GraphQLFieldDefinition service = queryRoot.getField("_service");
+            assertEquals(0, service.getArguments().size());
+            assertEquals("_Service!", service.getType().toString());
+
+            GraphQLFieldDefinition query = queryRoot.getField("testTypeWithFederation");
+            assertEquals(1, query.getArguments().size());
+            assertEquals(GraphQLString, query.getArgument("arg").getType());
+            assertEquals("TestTypeWithFederation", ((GraphQLObjectType) query.getType()).getName());
+
+            GraphQLObjectType type = graphQLSchema.getObjectType("TestTypeWithFederation");
+            assertEquals(2, type.getDirectives().size());
+            assertKeyDirective(type.getDirectives().get(0), "id", null);
+            assertKeyDirective(type.getDirectives().get(1), "type id", true);
+            assertEquals(3, type.getFields().size());
+            assertEquals("id", type.getFields().get(0).getName());
+            assertEquals(GraphQLString, type.getFields().get(0).getType());
+            assertEquals("type", type.getFields().get(1).getName());
+            assertEquals(GraphQLString, type.getFields().get(1).getType());
+            assertEquals("value", type.getFields().get(2).getName());
+            assertEquals(GraphQLString, type.getFields().get(2).getType());
+
+            GraphQLObjectType serviceType = graphQLSchema.getObjectType("_Service");
+            assertEquals(1, serviceType.getFields().size());
+            assertEquals("sdl", serviceType.getFields().get(0).getName());
+            assertEquals("String!", serviceType.getFields().get(0).getType().toString());
+        } finally {
+            System.clearProperty("smallrye.graphql.federation.enabled");
+        }
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTest.java
@@ -1,10 +1,7 @@
 package io.smallrye.graphql.schema;
 
 import static graphql.Scalars.GraphQLString;
-import static graphql.introspection.Introspection.DirectiveLocation.INTERFACE;
-import static graphql.introspection.Introspection.DirectiveLocation.OBJECT;
 import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -14,24 +11,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.annotation.Repeatable;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import jakarta.annotation.security.RolesAllowed;
 
-import org.jboss.jandex.IndexView;
-import org.jboss.jandex.Indexer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -40,23 +31,18 @@ import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnionType;
 import io.smallrye.graphql.api.Directive;
 import io.smallrye.graphql.api.OneOf;
 import io.smallrye.graphql.api.federation.Key;
 import io.smallrye.graphql.api.federation.Key.Keys;
-import io.smallrye.graphql.bootstrap.Bootstrap;
 import io.smallrye.graphql.execution.SchemaPrinter;
-import io.smallrye.graphql.execution.TestConfig;
 import io.smallrye.graphql.schema.directiveswithenumvalues.MyEnum;
 import io.smallrye.graphql.schema.directiveswithenumvalues.MyEnumValueDirective;
 import io.smallrye.graphql.schema.directiveswithenumvalues.MyObject;
 import io.smallrye.graphql.schema.directiveswithenumvalues.SomeApi;
-import io.smallrye.graphql.schema.model.Schema;
 import io.smallrye.graphql.schema.rolesallowedschemas.Customer;
 import io.smallrye.graphql.schema.rolesallowedschemas.RolesSchema1;
 import io.smallrye.graphql.schema.rolesallowedschemas.RolesSchema2;
@@ -68,22 +54,15 @@ import io.smallrye.graphql.schema.schemadirectives.Schema1;
 import io.smallrye.graphql.schema.schemadirectives.Schema2;
 import io.smallrye.graphql.schema.schemadirectives.Schema3;
 import io.smallrye.graphql.schema.schemadirectives.Schema4;
-import io.smallrye.graphql.spi.config.Config;
 
-class SchemaTest {
-    private final TestConfig config = (TestConfig) Config.get();
-
-    @AfterEach
-    void tearDown() {
-        config.reset();
-    }
+class SchemaTest extends SchemaTestBase {
 
     @Test
     void testSchemaWithDirectives() throws URISyntaxException, IOException {
         GraphQLSchema graphQLSchema = createGraphQLSchema(
                 Directive.class, IntArrayTestDirective.class, FieldDirective.class, ArgumentDirective.class,
-                OperationDirective.class, TestTypeWithDirectives.class, DirectivesTestApi.class, TestInterfaceDirective.class,
-                TestInterfaceDirectiveImpl.class);
+                OperationDirective.class, TestTypeWithDirectives.class, DirectivesTestApi.class,
+                TestInterfaceDirective.class, TestInterfaceDirectiveImpl.class);
 
         GraphQLDirective typeDirective = graphQLSchema.getDirective("intArrayTestDirective");
         assertEquals("intArrayTestDirective", typeDirective.getName());
@@ -101,7 +80,7 @@ class SchemaTest {
         assertEquals("intArrayTestDirective", intArrayTestDirective.getName());
         GraphQLArgument argument = intArrayTestDirective.getArgument("value");
         assertEquals("value", argument.getName());
-        assertArrayEquals(new Object[] { 1, 2, 3 }, argument.toAppliedArgument().getValue());
+        assertEquals(Arrays.asList(1, 2, 3), argument.toAppliedArgument().getValue());
 
         GraphQLFieldDefinition valueField = testTypeWithDirectives.getFieldDefinition("value");
         GraphQLDirective fieldDirectiveInstance = valueField.getDirective("fieldDirective");
@@ -171,7 +150,8 @@ class SchemaTest {
         assertEquals(3, unionDirectives.size(), "Union SomeUnion should have 3 @unionDirective instances");
         Set<String> expectedDirectivesArgValues = new HashSet<>(Arrays.asList("A", "B", "C"));
         unionDirectives.forEach(directive -> directive.getArguments()
-                .forEach(argument -> assertFalse(expectedDirectivesArgValues.add(argument.toAppliedArgument().getValue()),
+                .forEach(argument -> assertFalse(
+                        expectedDirectivesArgValues.add(argument.toAppliedArgument().getValue()),
                         "Unexpected directive argument value")));
         assertTrue(unionWithDirectives.getDirectives("InputDirective").isEmpty(),
                 "Union SomeUnion should not have a directive @inputDirective");
@@ -180,8 +160,8 @@ class SchemaTest {
 
     @Test
     void schemaWithInputDirectives() {
-        GraphQLSchema graphQLSchema = createGraphQLSchema(InputDirective.class, OutputDirective.class, InputTestApi.class,
-                InputTestApi.InputWithDirectives.class, InputTestApi.SomeObject.class);
+        GraphQLSchema graphQLSchema = createGraphQLSchema(InputDirective.class, OutputDirective.class,
+                InputTestApi.class, InputTestApi.InputWithDirectives.class, InputTestApi.SomeObject.class);
 
         GraphQLInputObjectType inputWithDirectives = graphQLSchema.getTypeAs("InputWithDirectivesInput");
         assertNotNull(inputWithDirectives.getDirective("inputDirective"),
@@ -234,82 +214,15 @@ class SchemaTest {
     }
 
     @Test
-    void testSchemaWithFederationEnabled() {
-        config.federationEnabled = true;
-        // need to set it as system property because the SchemaBuilder doesn't have access to the Config object
-        System.setProperty("smallrye.graphql.federation.enabled", "true");
-        try {
-            GraphQLSchema graphQLSchema = createGraphQLSchema(Repeatable.class, Directive.class, Key.class, Keys.class,
-                    TestTypeWithFederation.class, FederationTestApi.class);
-
-            GraphQLDirective keyDirective = graphQLSchema.getDirective("key");
-            assertEquals("key", keyDirective.getName());
-            assertTrue(keyDirective.isRepeatable());
-            assertEquals(
-                    "Designates an object type as an entity and specifies its key fields " +
-                            "(a set of fields that the subgraph can use to uniquely identify any instance " +
-                            "of the entity). You can apply multiple @key directives to a single entity " +
-                            "(to specify multiple valid sets of key fields).",
-                    keyDirective.getDescription());
-            assertEquals(EnumSet.of(OBJECT, INTERFACE), keyDirective.validLocations());
-            assertEquals(2, keyDirective.getArguments().size());
-            assertEquals("String",
-                    ((GraphQLScalarType) ((GraphQLNonNull) keyDirective.getArgument("fields").getType()).getWrappedType())
-                            .getName());
-            assertEquals("Boolean",
-                    ((GraphQLScalarType) keyDirective.getArgument("resolvable").getType()).getName());
-
-            GraphQLUnionType entityType = (GraphQLUnionType) graphQLSchema.getType("_Entity");
-            assertNotNull(entityType);
-            assertEquals(1, entityType.getTypes().size());
-            assertEquals(TestTypeWithFederation.class.getSimpleName(), entityType.getTypes().get(0).getName());
-
-            GraphQLObjectType queryRoot = graphQLSchema.getQueryType();
-            assertEquals(3, queryRoot.getFields().size());
-
-            GraphQLFieldDefinition entities = queryRoot.getField("_entities");
-            assertEquals(1, entities.getArguments().size());
-            assertEquals("[_Any!]!", entities.getArgument("representations").getType().toString());
-            assertEquals("[_Entity]!", entities.getType().toString());
-
-            GraphQLFieldDefinition service = queryRoot.getField("_service");
-            assertEquals(0, service.getArguments().size());
-            assertEquals("_Service!", service.getType().toString());
-
-            GraphQLFieldDefinition query = queryRoot.getField("testTypeWithFederation");
-            assertEquals(1, query.getArguments().size());
-            assertEquals(GraphQLString, query.getArgument("arg").getType());
-            assertEquals("TestTypeWithFederation", ((GraphQLObjectType) query.getType()).getName());
-
-            GraphQLObjectType type = graphQLSchema.getObjectType("TestTypeWithFederation");
-            assertEquals(2, type.getDirectives().size());
-            assertKeyDirective(type.getDirectives().get(0), "id", null);
-            assertKeyDirective(type.getDirectives().get(1), "type id", true);
-            assertEquals(3, type.getFields().size());
-            assertEquals("id", type.getFields().get(0).getName());
-            assertEquals(GraphQLString, type.getFields().get(0).getType());
-            assertEquals("type", type.getFields().get(1).getName());
-            assertEquals(GraphQLString, type.getFields().get(1).getType());
-            assertEquals("value", type.getFields().get(2).getName());
-            assertEquals(GraphQLString, type.getFields().get(2).getType());
-
-            GraphQLObjectType serviceType = graphQLSchema.getObjectType("_Service");
-            assertEquals(1, serviceType.getFields().size());
-            assertEquals("sdl", serviceType.getFields().get(0).getName());
-            assertEquals("String!", serviceType.getFields().get(0).getType().toString());
-        } finally {
-            System.clearProperty("smallrye.graphql.federation.enabled");
-        }
-    }
-
-    @Test
     void testSchemasWithValidSchemaDirectives() {
-        GraphQLSchema graphQLSchema = createGraphQLSchema(Directive.class, Repeatable.class, RepeatableSchemaDirective.class,
-                NonRepeatableSchemaDirective.class, Schema1.class, Schema2.class, Schema3.class);
+        GraphQLSchema graphQLSchema = createGraphQLSchema(Directive.class, Repeatable.class,
+                RepeatableSchemaDirective.class, NonRepeatableSchemaDirective.class, Schema1.class, Schema2.class,
+                Schema3.class);
         assertEquals(graphQLSchema.getSchemaAppliedDirectives().size(), 5);
         Set<String> expectedArgValues = new HashSet<>(Arrays.asList("name1", "name2", "name3", "name4"));
         graphQLSchema.getSchemaAppliedDirectives().stream()
-                .filter(graphQLAppliedDirective -> graphQLAppliedDirective.getName().equals("repeatableSchemaDirective"))
+                .filter(graphQLAppliedDirective -> graphQLAppliedDirective.getName()
+                        .equals("repeatableSchemaDirective"))
                 .collect(Collectors.toList()).forEach(composeDirective -> composeDirective.getArguments()
                         .forEach(argument -> assertTrue(!expectedArgValues.add(argument.getValue()),
                                 "Unexpected directive argument value")));
@@ -321,15 +234,15 @@ class SchemaTest {
         Exception exception = assertThrows(SchemaBuilderException.class,
                 () -> createGraphQLSchema(Directive.class, Repeatable.class, RepeatableSchemaDirective.class,
                         NonRepeatableSchemaDirective.class, Schema3.class, Schema4.class));
-        String expectedMessage = "The @nonRepeatableSchemaDirective directive is not repeatable, but was used more than once in the GraphQL schema.";
+        String expectedMessage = "The @nonRepeatableSchemaDirective directive is not repeatable, but was used more " +
+                "than once in the GraphQL schema.";
         assertEquals(expectedMessage, exception.getMessage());
     }
 
     @Test
     void testSchemasWithRolesAllowedDirectives() {
         GraphQLSchema graphQLSchema = createGraphQLSchema(Customer.class, RolesAllowed.class, RolesSchema1.class,
-                RolesSchema2.class,
-                RolesSchema3.class);
+                RolesSchema2.class, RolesSchema3.class);
 
         // QUERY ROOT
         GraphQLObjectType queryRoot = graphQLSchema.getQueryType();
@@ -424,16 +337,6 @@ class SchemaTest {
         assertEquals("Indicates an Input Object is a OneOf Input Object.", oneOfDirective.getDescription());
     }
 
-    private void assertKeyDirective(GraphQLDirective graphQLDirective, String fieldsValue, Boolean resolvableValue) {
-        assertEquals("key", graphQLDirective.getName());
-        assertEquals(2, graphQLDirective.getArguments().size());
-        assertEquals("fields", graphQLDirective.getArguments().get(0).getName());
-        assertEquals("resolvable", graphQLDirective.getArguments().get(1).getName());
-        assertEquals(fieldsValue, graphQLDirective.getArguments().get(0).toAppliedArgument().getArgumentValue().getValue());
-        assertEquals(resolvableValue, graphQLDirective.getArguments().get(1).toAppliedArgument().getArgumentValue().getValue());
-        assertEquals(true, graphQLDirective.getArguments().get(1).getArgumentDefaultValue().getValue());
-    }
-
     private void assertRolesAllowedDirective(GraphQLFieldDefinition field, String roleValue) {
         assertNotNull(field);
 
@@ -446,16 +349,11 @@ class SchemaTest {
         assertEquals(1, field.getDirective("rolesAllowed").getArguments().size());
         assertEquals("value", field.getDirective("rolesAllowed").getArguments().get(0).getName());
         assertEquals(roleValue,
-                field.getDirective("rolesAllowed").getArgument("value").toAppliedArgument().getArgumentValue().getValue());
-
-    }
-
-    private GraphQLSchema createGraphQLSchema(Class<?>... api) {
-        Schema schema = SchemaBuilder.build(scan(api));
-        assertNotNull(schema, "Schema should not be null");
-        GraphQLSchema graphQLSchema = Bootstrap.bootstrap(schema, true);
-        assertNotNull(graphQLSchema, "GraphQLSchema should not be null");
-        return graphQLSchema;
+                field.getDirective("rolesAllowed")
+                        .getArgument("value")
+                        .toAppliedArgument()
+                        .getArgumentValue()
+                        .getValue());
     }
 
     private void assertOperationWithDirectives(GraphQLFieldDefinition operation) {
@@ -464,24 +362,5 @@ class SchemaTest {
         assertNotNull(operationDirective, () -> name + " should have directive @operationDirective");
         GraphQLDirective argumentDirective = operation.getArgument("arg").getDirective("argumentDirective");
         assertNotNull(argumentDirective, () -> "Argument arg of " + name + " should have directive @argumentDirective");
-    }
-
-    private IndexView scan(Class<?>... classes) {
-        Indexer indexer = new Indexer();
-        Stream.of(classes).forEach(cls -> index(indexer, cls));
-        return indexer.complete();
-    }
-
-    private void index(Indexer indexer, Class<?> cls) {
-        try {
-            indexer.index(getResourceStream(cls));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private InputStream getResourceStream(Class<?> type) {
-        String name = type.getName().replace(".", "/") + ".class";
-        return Thread.currentThread().getContextClassLoader().getResourceAsStream(name);
     }
 }

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTestBase.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/SchemaTestBase.java
@@ -1,0 +1,68 @@
+package io.smallrye.graphql.schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
+import org.junit.jupiter.api.AfterEach;
+
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLSchema;
+import io.smallrye.graphql.bootstrap.Bootstrap;
+import io.smallrye.graphql.execution.TestConfig;
+import io.smallrye.graphql.schema.model.Schema;
+import io.smallrye.graphql.spi.config.Config;
+
+public abstract class SchemaTestBase {
+    protected final TestConfig config = (TestConfig) Config.get();
+
+    @AfterEach
+    void tearDown() {
+        config.reset();
+    }
+
+    protected void assertKeyDirective(GraphQLDirective graphQLDirective, String fieldsValue, Boolean resolvableValue) {
+        assertEquals("key", graphQLDirective.getName());
+        assertEquals(2, graphQLDirective.getArguments().size());
+        assertEquals("fields", graphQLDirective.getArguments().get(0).getName());
+        assertEquals("resolvable", graphQLDirective.getArguments().get(1).getName());
+        assertEquals(fieldsValue,
+                ((Map<?, ?>) graphQLDirective.getArguments().get(0).toAppliedArgument().getArgumentValue().getValue())
+                        .get("value"));
+        assertEquals(resolvableValue, graphQLDirective.getArguments().get(1).toAppliedArgument().getArgumentValue().getValue());
+        assertEquals(true, graphQLDirective.getArguments().get(1).getArgumentDefaultValue().getValue());
+    }
+
+    protected GraphQLSchema createGraphQLSchema(Class<?>... api) {
+        Schema schema = SchemaBuilder.build(scan(api));
+        assertNotNull(schema, "Schema should not be null");
+        GraphQLSchema graphQLSchema = Bootstrap.bootstrap(schema, true);
+        assertNotNull(graphQLSchema, "GraphQLSchema should not be null");
+        return graphQLSchema;
+    }
+
+    protected IndexView scan(Class<?>... classes) {
+        Indexer indexer = new Indexer();
+        Stream.of(classes).forEach(cls -> index(indexer, cls));
+        return indexer.complete();
+    }
+
+    protected void index(Indexer indexer, Class<?> cls) {
+        try {
+            indexer.index(getResourceStream(cls));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected InputStream getResourceStream(Class<?> type) {
+        String name = type.getName().replace(".", "/") + ".class";
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream(name);
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/schema/TestTypeWithFederation.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/schema/TestTypeWithFederation.java
@@ -1,9 +1,10 @@
 package io.smallrye.graphql.schema;
 
+import io.smallrye.graphql.api.federation.FieldSet;
 import io.smallrye.graphql.api.federation.Key;
 
-@Key(fields = "id")
-@Key(fields = "type id", resolvable = true)
+@Key(fields = @FieldSet("id"))
+@Key(fields = @FieldSet("type id"), resolvable = true)
 public class TestTypeWithFederation {
     private String type;
     private String id;

--- a/server/tck/src/test/java/io/smallrye/graphql/test/apps/federation/ProductEntity.java
+++ b/server/tck/src/test/java/io/smallrye/graphql/test/apps/federation/ProductEntity.java
@@ -3,9 +3,10 @@ package io.smallrye.graphql.test.apps.federation;
 import org.eclipse.microprofile.graphql.Id;
 import org.eclipse.microprofile.graphql.Name;
 
+import io.smallrye.graphql.api.federation.FieldSet;
 import io.smallrye.graphql.api.federation.Key;
 
-@Key(fields = "id")
+@Key(fields = @FieldSet("id"))
 @Name("Product")
 public class ProductEntity {
     static ProductEntity product(String id, String name) {

--- a/tools/maven-plugin-tests/testing-project-federation/src/main/java/org/acme/Foo.java
+++ b/tools/maven-plugin-tests/testing-project-federation/src/main/java/org/acme/Foo.java
@@ -1,8 +1,9 @@
 package org.acme;
 
+import io.smallrye.graphql.api.federation.FieldSet;
 import io.smallrye.graphql.api.federation.Key;
 
-@Key(fields = "id")
+@Key(fields = @FieldSet("id"))
 public class Foo {
 
     private Integer number;


### PR DESCRIPTION
#2020
Added the following scalars:
```graphql
"Scalar for FieldSet"
scalar FieldSet

"Scalar for Policy"
scalar Policy

"Scalar for Scope"
scalar Scope
```
This is a breaking change, since the usage of the following Federation directives is changed:

- `@Key`
- `@Provides`
- `@Requires`
- `@Policy`
- `@RequiresScopes`

For example, this:
```graphql
@Key(fields = "sku package")
```
Changes to this:
```graphql
@Key(fields = @FieldSet("sku package"))
```

Does this need to be a breaking change? Technically, we could change the following methods:

- io.smallrye.graphql.schema.creator.DirectiveTypeCreator#create
- io.smallrye.graphql.schema.helper.Directives#toDirectiveInstance

To detect if any of the above directives are used, and convert them to appropriate scalars. All of them are string based and are easy to convert. We would probably need to fix some other stuff as well, but I find the first option to be much cleaner. This is also aligned with how `@Link` will be implemented, since its [Import](https://specs.apollo.dev/link/v1.0/#@link.import) type is not string based.

Here is how outputted schema looks like:
```graphql
directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE

type Product @key(fields : "sku package") @policy(policies : [["policy1", "policy2"], ["policy3"]]) @requiresScopes(scopes : [["scope1", "scope2"], ["scope3"]]) {
...
}

"Scalar for FieldSet"
scalar FieldSet
```