### PR TITLE
Prevent dropping the exception when websocket can't be established, a…

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
@@ -250,7 +250,7 @@ class VertxTypesafeGraphQLClientProxy {
             webSocketHandler().subscribe().with(handler -> {
                 handlerRef.set(handler);
                 operationId.set(handler.executeMulti(request, rawEmitter));
-            });
+            }, rawEmitter::fail);
         });
         return rawMulti
                 .onCancellation().invoke(() -> {
@@ -288,6 +288,7 @@ class VertxTypesafeGraphQLClientProxy {
                                         log.debug("Using websocket subprotocol handler: " + handler);
                                     } else {
                                         handlerEmitter.fail(result.cause());
+                                        webSocketHandler.set(null);
                                     }
                                 });
                     });


### PR DESCRIPTION
…nd don't cache the result in that case

https://github.com/quarkusio/quarkus/issues/38595