### PR TITLE
Added label argument to @override directive

### DIFF
--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/Override.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/Override.java
@@ -12,7 +12,7 @@ import io.smallrye.common.annotation.Experimental;
 import io.smallrye.graphql.api.Directive;
 
 /**
- * <b><code>directive @override(from: String!) on FIELD_DEFINITION</code></b>
+ * <b><code>directive @override(from: String!, label: String) on FIELD_DEFINITION</code></b>
  *
  * @see <a href="https://www.apollographql.com/docs/federation/federated-types/federated-directives/#override">federation
  *      spec</a>
@@ -30,4 +30,9 @@ public @interface Override {
             +
             "If you're performing composition with the Rover CLI, this must match the name of the subgraph in the YAML config file you provide to rover supergraph compose.")
     String from();
+
+    @Description("A string of arbitrary arguments. Supported in this release:\n" +
+            "percent(<percent-value>) - The percentage of traffic for the field that's resolved by this subgraph. The" +
+            " remaining percentage is resolved by the other (from) subgraph.")
+    String label() default "";
 }

--- a/server/api/src/main/java/io/smallrye/graphql/api/federation/Override.java
+++ b/server/api/src/main/java/io/smallrye/graphql/api/federation/Override.java
@@ -31,7 +31,7 @@ public @interface Override {
             "If you're performing composition with the Rover CLI, this must match the name of the subgraph in the YAML config file you provide to rover supergraph compose.")
     String from();
 
-    @Description("A string of arbitrary arguments. Supported in this release:\n" +
+    @Description("A string of arbitrary arguments. Currently supported:\n" +
             "percent(<percent-value>) - The percentage of traffic for the field that's resolved by this subgraph. The" +
             " remaining percentage is resolved by the other (from) subgraph.")
     String label() default "";


### PR DESCRIPTION
With Apollo Federation 2.7 optional `label` argument was added to `@override` directive:
https://www.apollographql.com/docs/federation/federated-types/federated-directives/#label