### PR TITLE
Prevent dropping the exception when websocket can't be established, a…

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
@@ -246,7 +246,7 @@ class VertxTypesafeGraphQLClientProxy {
             webSocketHandler().subscribe().with(handler -> {
                 handlerRef.set(handler);
                 operationId.set(handler.executeMulti(request, rawEmitter));
-            });
+            }, rawEmitter::fail);
         });
         return rawMulti
                 .onCancellation().invoke(() -> {
@@ -284,6 +284,7 @@ class VertxTypesafeGraphQLClientProxy {
                                         log.debug("Using websocket subprotocol handler: " + handler);
                                     } else {
                                         handlerEmitter.fail(result.cause());
+                                        webSocketHandler.set(null);
                                     }
                                 });
                     });


### PR DESCRIPTION
…nd don't cache the result in that case

[backport of https://github.com/jmartisk/smallrye-graphql/pull/new/2.7.x-q38595](https://github.com/smallrye/smallrye-graphql/pull/2030)