### PR TITLE
Fixed Federation version of @interfaceObject

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/LinkProcessor.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/LinkProcessor.java
@@ -41,7 +41,7 @@ public class LinkProcessor {
     private static final Pattern FEDERATION_VERSION_PATTERN = Pattern.compile("/v([\\d.]+)$");
     private static final Map<String, String> FEDERATION_DIRECTIVES_VERSION = Map.of(
             "@composeDirective", "2.1",
-            "@interfaceObject", "2.4",
+            "@interfaceObject", "2.3",
             "@authenticated", "2.5",
             "@requiresScopes", "2.5",
             "@policy", "2.6");


### PR DESCRIPTION
As per [documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#interfaceobject), the minimum version that supports the `@interfaceObject` directive is 2.3, not 2.4,