### PR TITLE
Fix overly ambitious caching when using nested queries

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -68,7 +68,6 @@ public class ExecutionService {
     private final BatchLoaderHelper batchLoaderHelper = new BatchLoaderHelper();
     private final DataFetcherFactory dataFetcherFactory = new DataFetcherFactory();
     private final Schema schema;
-    private final DataLoaderRegistry dataLoaderRegistry;
 
     private final EventEmitter eventEmitter = EventEmitter.getInstance();
 
@@ -89,13 +88,6 @@ public class ExecutionService {
 
         this.graphQLSchema = graphQLSchema;
         this.schema = schema;
-
-        List<Operation> batchOperations = schema.getBatchOperations();
-        if (batchOperations != null && !batchOperations.isEmpty()) {
-            this.dataLoaderRegistry = getDataLoaderRegistry(batchOperations);
-        } else {
-            this.dataLoaderRegistry = null;
-        }
 
         // use schema's hash as prefix to differentiate between multiple apps
         this.executionIdPrefix = Integer.toString(Objects.hashCode(graphQLSchema));
@@ -179,8 +171,10 @@ public class ExecutionService {
                 smallRyeContext.getOperationName().ifPresent(executionBuilder::operationName);
 
                 // DataLoaders
-                if (this.dataLoaderRegistry != null) {
-                    executionBuilder.dataLoaderRegistry(this.dataLoaderRegistry);
+                List<Operation> batchOperations = schema.getBatchOperations();
+                if (!batchOperations.isEmpty()) {
+                    DataLoaderRegistry dataLoaderRegistry = getDataLoaderRegistry(batchOperations);
+                    executionBuilder.dataLoaderRegistry(dataLoaderRegistry);
                 }
 
                 ExecutionInput executionInput = executionBuilder.build();


### PR DESCRIPTION
Well, this is awkward, it would seem that I have been too overly ambitious with my caching in my previous pull request!

This fixes the result of nested queries being cached when with the exact same variables.

As I am busy at the moment at work at the moment, I have just reverted back to its previous state (https://github.com/rubik-cube-man/smallrye-graphql/commit/0ad787459b9fdde120563dce68ff1c7306a30359#diff-33bf1ec886c73ea51d9e3bb9708cd51f9e093867e8739d37b3507558a435d5e7L74)

Apologies for that!