### PR TITLE
Fix broken link to the page "Customizing JSON deserializers" on the docs site

### DIFF
--- a/docs/dynamic-client-usage.md
+++ b/docs/dynamic-client-usage.md
@@ -31,7 +31,7 @@ DynamicGraphQLClient client;
 ```
 
 The above example assumes that configuration for the client is present in system properties. For a full list of
-supported configuration properties, see [Client configuration reference](/client_configuration)
+supported configuration properties, see [Client configuration reference](client_configuration.md)
 
 The other way to build a client is programmatically using a builder:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ edit_uri: edit/main/docs/
 nav:
   - Overview: 'index.md'
   - Server side features:
-      - Customizing JSON deserializers: 'custom-json-deserializers.md'
+      - Customizing JSON (de)serializers: 'custom-json-serializers-deserializers.md'
       - Directives: 'directives.md'
       - Federation: 'federation.md'
       - Custom error extensions: 'custom-error-extensions.md'


### PR DESCRIPTION
Fixes issue https://github.com/smallrye/smallrye-graphql/issues/2069

Also includes a minor fix to the `mkdocs build` warning "...an absolute path was used for '/client_configuration' ..."