### PR TITLE
Prevent NPE when superClassType is null, e.g. java.lang.Object

### DIFF
--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/TypeModel.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/TypeModel.java
@@ -7,11 +7,12 @@ import static io.smallrye.graphql.client.model.Classes.ERROR_OR;
 import static io.smallrye.graphql.client.model.Classes.OBJECT;
 import static io.smallrye.graphql.client.model.Classes.OPTIONAL;
 import static io.smallrye.graphql.client.model.Classes.TYPESAFE_RESPONSE;
-import static io.smallrye.graphql.client.model.Classes.isParameterized;
 import static io.smallrye.graphql.client.model.ScanningContext.getIndex;
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
+import io.smallrye.graphql.client.model.Annotations;
+import io.smallrye.graphql.client.model.Classes;
+import io.smallrye.graphql.client.model.Scalars;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -19,7 +20,6 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
@@ -27,10 +27,6 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
-
-import io.smallrye.graphql.client.model.Annotations;
-import io.smallrye.graphql.client.model.Classes;
-import io.smallrye.graphql.client.model.Scalars;
 
 /**
  * Represents a model for handling GraphQL types, including information about the underlying Jandex Type.
@@ -384,7 +380,8 @@ public class TypeModel {
      * @return A stream of {@link FieldModel} instances.
      */
     private Stream<FieldModel> fields(ClassInfo clazz) {
-        return (clazz == null) ? Stream.of()
+        // if clazz is null or clazz is java.lang.Object, return an empty stream
+        return (clazz == null || clazz.superClassType() == null) ? Stream.of()
                 : Stream.concat(
                         fields(getIndex().getClassByName(clazz.superClassType().name())), // to superClass
                         fieldsHelper(clazz)

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/TypeModel.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/TypeModel.java
@@ -10,9 +10,6 @@ import static io.smallrye.graphql.client.model.Classes.TYPESAFE_RESPONSE;
 import static io.smallrye.graphql.client.model.ScanningContext.getIndex;
 import static java.util.stream.Collectors.toList;
 
-import io.smallrye.graphql.client.model.Annotations;
-import io.smallrye.graphql.client.model.Classes;
-import io.smallrye.graphql.client.model.Scalars;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -20,6 +17,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
@@ -27,6 +25,10 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
+
+import io.smallrye.graphql.client.model.Annotations;
+import io.smallrye.graphql.client.model.Classes;
+import io.smallrye.graphql.client.model.Scalars;
 
 /**
  * Represents a model for handling GraphQL types, including information about the underlying Jandex Type.

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/TypeModel.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/TypeModel.java
@@ -380,7 +380,6 @@ public class TypeModel {
      * @return A stream of {@link FieldModel} instances.
      */
     private Stream<FieldModel> fields(ClassInfo clazz) {
-        // if clazz is null or clazz is java.lang.Object, return an empty stream
         return (clazz == null || clazz.superClassType() == null) ? Stream.of()
                 : Stream.concat(
                         fields(getIndex().getClassByName(clazz.superClassType().name())), // to superClass


### PR DESCRIPTION
There is a bug that when I add a custom type that is annotated with `@CustomScalar`, an NPE is thrown and the application cannot boot up due to the failure to generate the GraphQL model.

By making the `fields()` method a little bit more defensive, the issue is resolved and the custom type can be leveraged.

Here is a snapshot of the exception stacktrace:
```
java.lang.RuntimeException: java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
	[error]: Build step io.quarkus.smallrye.graphql.client.deployment.SmallRyeGraphQLClientProcessor#buildClientModel threw an exception: java.lang.NullPointerException: Cannot invoke "org.jboss.jandex.Type.name()" because the return value of "org.jboss.jandex.ClassInfo.superClassType()" is null
	at io.smallrye.graphql.client.model.helper.TypeModel.fields(TypeModel.java:387)
	at io.smallrye.graphql.client.model.helper.TypeModel.fields(TypeModel.java:387)
	at io.smallrye.graphql.client.model.helper.TypeModel.fields(TypeModel.java:375)
	at io.smallrye.graphql.client.model.helper.OperationModel.recursionCheckedFields(OperationModel.java:103)
	at io.smallrye.graphql.client.model.helper.OperationModel.fields(OperationModel.java:75)
	at io.smallrye.graphql.client.model.helper.OperationModel.field(OperationModel.java:141)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.smallrye.graphql.client.model.helper.OperationModel.recursionCheckedFields(OperationModel.java:105)
	at io.smallrye.graphql.client.model.helper.OperationModel.fields(OperationModel.java:75)
	at io.smallrye.graphql.client.model.helper.OperationModel.field(OperationModel.java:141)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.smallrye.graphql.client.model.helper.OperationModel.recursionCheckedFields(OperationModel.java:105)
	at io.smallrye.graphql.client.model.helper.OperationModel.fields(OperationModel.java:75)
	at io.smallrye.graphql.client.model.helper.OperationModel.recursionCheckedFields(OperationModel.java:94)
	at io.smallrye.graphql.client.model.helper.OperationModel.fields(OperationModel.java:75)
	at io.smallrye.graphql.client.model.helper.OperationModel.field(OperationModel.java:141)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.smallrye.graphql.client.model.helper.OperationModel.recursionCheckedFields(OperationModel.java:105)
	at io.smallrye.graphql.client.model.helper.OperationModel.fields(OperationModel.java:75)
	at io.smallrye.graphql.client.model.QueryBuilder.build(QueryBuilder.java:54)
	at io.smallrye.graphql.client.model.ClientModelBuilder.lambda$generateClientModels$0(ClientModelBuilder.java:62)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
	at io.smallrye.graphql.client.model.ClientModelBuilder.lambda$generateClientModels$1(ClientModelBuilder.java:61)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1116)
	at io.smallrye.graphql.client.model.ClientModelBuilder.generateClientModels(ClientModelBuilder.java:57)
	at io.smallrye.graphql.client.model.ClientModelBuilder.build(ClientModelBuilder.java:38)
	at io.quarkus.smallrye.graphql.client.deployment.SmallRyeGraphQLClientProcessor.buildClientModel(SmallRyeGraphQLClientProcessor.java:205)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:849)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:256)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2516)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2495)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1521)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	at org.jboss.threads.JBossThread.run(JBossThread.java:483)

	at io.quarkus.test.junit.QuarkusTestExtension.throwBootFailureException(QuarkusTestExtension.java:643)
	at io.quarkus.test.junit.QuarkusTestExtension.interceptBeforeAllMethod(QuarkusTestExtension.java:711)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
	[error]: Build step io.quarkus.smallrye.graphql.client.deployment.SmallRyeGraphQLClientProcessor#buildClientModel threw an exception: java.lang.NullPointerException: Cannot invoke "org.jboss.jandex.Type.name()" because the return value of "org.jboss.jandex.ClassInfo.superClassType()" is null
	at io.smallrye.graphql.client.model.helper.TypeModel.fields(TypeModel.java:387)
	at io.smallrye.graphql.client.model.helper.TypeModel.fields(TypeModel.java:387)
	at io.smallrye.graphql.client.model.helper.TypeModel.fields(TypeModel.java:375)
	at io.smallrye.graphql.client.model.helper.OperationModel.recursionCheckedFields(OperationModel.java:103)
	at io.smallrye.graphql.client.model.helper.OperationModel.fields(OperationModel.java:75)
	at io.smallrye.graphql.client.model.helper.OperationModel.field(OperationModel.java:141)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.smallrye.graphql.client.model.helper.OperationModel.recursionCheckedFields(OperationModel.java:105)
	at io.smallrye.graphql.client.model.helper.OperationModel.fields(OperationModel.java:75)
	at io.smallrye.graphql.client.model.helper.OperationModel.field(OperationModel.java:141)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.smallrye.graphql.client.model.helper.OperationModel.recursionCheckedFields(OperationModel.java:105)
	at io.smallrye.graphql.client.model.helper.OperationModel.fields(OperationModel.java:75)
	at io.smallrye.graphql.client.model.helper.OperationModel.recursionCheckedFields(OperationModel.java:94)
	at io.smallrye.graphql.client.model.helper.OperationModel.fields(OperationModel.java:75)
	at io.smallrye.graphql.client.model.helper.OperationModel.field(OperationModel.java:141)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.smallrye.graphql.client.model.helper.OperationModel.recursionCheckedFields(OperationModel.java:105)
	at io.smallrye.graphql.client.model.helper.OperationModel.fields(OperationModel.java:75)
	at io.smallrye.graphql.client.model.QueryBuilder.build(QueryBuilder.java:54)
	at io.smallrye.graphql.client.model.ClientModelBuilder.lambda$generateClientModels$0(ClientModelBuilder.java:62)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
	at io.smallrye.graphql.client.model.ClientModelBuilder.lambda$generateClientModels$1(ClientModelBuilder.java:61)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1116)
	at io.smallrye.graphql.client.model.ClientModelBuilder.generateClientModels(ClientModelBuilder.java:57)
	at io.smallrye.graphql.client.model.ClientModelBuilder.build(ClientModelBuilder.java:38)
	at io.quarkus.smallrye.graphql.client.deployment.SmallRyeGraphQLClientProcessor.buildClientModel(SmallRyeGraphQLClientProcessor.java:205)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:849)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:256)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2516)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2495)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1521)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	at org.jboss.threads.JBossThread.run(JBossThread.java:483)

```