### PR TITLE
Add custom scalar support to client value formatter

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/core/utils/ValueFormatter.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/core/utils/ValueFormatter.java
@@ -1,18 +1,22 @@
 package io.smallrye.graphql.client.impl.core.utils;
 
-import java.lang.reflect.Array;
-import java.time.LocalDate;
-import java.util.UUID;
-
+import io.smallrye.graphql.api.CustomFloatScalar;
+import io.smallrye.graphql.api.CustomIntScalar;
+import io.smallrye.graphql.api.CustomStringScalar;
 import io.smallrye.graphql.client.core.exceptions.BuildException;
 import io.smallrye.graphql.client.impl.core.EnumImpl;
 import io.smallrye.graphql.client.impl.core.InputObjectImpl;
 import io.smallrye.graphql.client.impl.core.VariableImpl;
+import java.lang.reflect.Array;
+import java.time.LocalDate;
+import java.util.UUID;
 
 public class ValueFormatter {
 
-    private final static Class<?>[] QUOTED_VALUES = new Class[] { String.class, Character.class, LocalDate.class, UUID.class };
-    private final static Class<?>[] UNQUOTED_VALUES = new Class[] { Number.class, Boolean.class, Enum.class };
+    private final static Class<?>[] QUOTED_VALUES = new Class[] { String.class, Character.class, LocalDate.class, UUID.class,
+            CustomStringScalar.class };
+    private final static Class<?>[] UNQUOTED_VALUES = new Class[] { Number.class, Boolean.class, Enum.class,
+            CustomIntScalar.class, CustomFloatScalar.class };
 
     public static boolean assignableFrom(Class<?> clazz, Class<?>[] candidates) {
         for (Class<?> candidate : candidates) {
@@ -39,6 +43,15 @@ public class ValueFormatter {
             return _processArray(value);
         } else if (value instanceof Iterable) {
             return _processIterable((Iterable<?>) value);
+        } else if (value instanceof CustomStringScalar) {
+            CustomStringScalar css = (CustomStringScalar) value;
+            return _getAsQuotedString(String.valueOf(css.stringValueForSerialization()));
+        } else if (value instanceof CustomIntScalar) {
+            CustomIntScalar cis = (CustomIntScalar) value;
+            return cis.intValueForSerialization().toString();
+        } else if (value instanceof CustomFloatScalar) {
+            CustomFloatScalar cfs = (CustomFloatScalar) value;
+            return cfs.floatValueForSerialization().toString();
         } else {
             if (assignableFrom(value.getClass(), QUOTED_VALUES)) {
                 return _getAsQuotedString(String.valueOf(value));

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/core/utils/ValueFormatter.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/core/utils/ValueFormatter.java
@@ -13,10 +13,8 @@ import java.util.UUID;
 
 public class ValueFormatter {
 
-    private final static Class<?>[] QUOTED_VALUES = new Class[] { String.class, Character.class, LocalDate.class, UUID.class,
-            CustomStringScalar.class };
-    private final static Class<?>[] UNQUOTED_VALUES = new Class[] { Number.class, Boolean.class, Enum.class,
-            CustomIntScalar.class, CustomFloatScalar.class };
+    private final static Class<?>[] QUOTED_VALUES = new Class[] { String.class, Character.class, LocalDate.class, UUID.class };
+    private final static Class<?>[] UNQUOTED_VALUES = new Class[] { Number.class, Boolean.class, Enum.class };
 
     public static boolean assignableFrom(Class<?> clazz, Class<?>[] candidates) {
         for (Class<?> candidate : candidates) {

--- a/client/implementation/src/test/java/io/smallrye/graphql/client/impl/core/utils/ValueFormatterTest.java
+++ b/client/implementation/src/test/java/io/smallrye/graphql/client/impl/core/utils/ValueFormatterTest.java
@@ -3,9 +3,13 @@ package io.smallrye.graphql.client.impl.core.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.smallrye.graphql.api.CustomFloatScalar;
+import io.smallrye.graphql.api.CustomIntScalar;
+import io.smallrye.graphql.api.CustomStringScalar;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Date;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 class ValueFormatterTest {
@@ -13,17 +17,11 @@ class ValueFormatterTest {
     @Test
     public void testUnsupportedInput() {
 
-        assertThrows(IllegalStateException.class, () -> {
-            ValueFormatter.format(new Object());
-        });
+        assertThrows(IllegalStateException.class, () -> ValueFormatter.format(new Object()));
 
-        assertThrows(IllegalStateException.class, () -> {
-            ValueFormatter.format(Map.of("test", "value"));
-        });
+        assertThrows(IllegalStateException.class, () -> ValueFormatter.format(Map.of("test", "value")));
 
-        assertThrows(IllegalStateException.class, () -> {
-            ValueFormatter.format(new Date());
-        });
+        assertThrows(IllegalStateException.class, () -> ValueFormatter.format(new Date()));
     }
 
     @Test
@@ -34,9 +32,63 @@ class ValueFormatterTest {
         assertEquals(Order.ASC.toString(), value);
     }
 
+    @Test
+    public void testCustomStringScalarInput() {
+
+        final var customString = new CustomString();
+        final var value = ValueFormatter.format(customString);
+
+        assertEquals("\"" + customString.stringValueForSerialization() + "\"", value);
+    }
+
+    @Test
+    public void testCustomIntScalarInput() {
+
+        final var customInt = new CustomInt();
+        final var value = ValueFormatter.format(customInt);
+
+        assertEquals(customInt.intValueForSerialization().toString(), value);
+    }
+
+    @Test
+    public void testCustomFloatScalarInput() {
+
+        final var customFloat = new CustomFloat();
+        final var value = ValueFormatter.format(customFloat);
+
+        assertEquals(customFloat.floatValueForSerialization().toString(), value);
+    }
+
     enum Order {
         ASC,
         DESC
+    }
+
+    // custom string scalar
+    static class CustomString implements CustomStringScalar {
+
+        @Override
+        public String stringValueForSerialization() {
+            return "test value";
+        }
+    }
+
+    // custom int scalar
+    static class CustomInt implements CustomIntScalar {
+
+        @Override
+        public BigInteger intValueForSerialization() {
+            return BigInteger.valueOf(123);
+        }
+    }
+
+    // custom float scalar
+    static class CustomFloat implements CustomFloatScalar {
+
+        @Override
+        public BigDecimal floatValueForSerialization() {
+            return BigDecimal.valueOf(12.3f);
+        }
     }
 
 }


### PR DESCRIPTION
In the event that a request contains fields that are objects and within those objects there are field definitions with a type other than the primitives in the ValueFormatter, such as:
```
class CreateEntity {
    List<DependentEntity> dependent;
}
class DependentEntity {
    MyCustomScalar value;
}
class MyCustomScalar implements CustomStringScalar {
...
}
```
an IllegalStateException is thrown as below:
```
java.lang.IllegalStateException: Could not format class MyCustomScalar: Unsupported type.
	at io.smallrye.graphql.client.impl.core.utils.ValueFormatter.format(ValueFormatter.java:48)
	at io.smallrye.graphql.client.impl.core.InputObjectFieldImpl.build(InputObjectFieldImpl.java:14)
	at io.smallrye.graphql.client.impl.core.InputObjectImpl.build(InputObjectImpl.java:14)
	at io.smallrye.graphql.client.impl.core.utils.ValueFormatter.format(ValueFormatter.java:34)
	at io.smallrye.graphql.client.impl.core.utils.ValueFormatter._processIterable(ValueFormatter.java:63)
	at io.smallrye.graphql.client.impl.core.utils.ValueFormatter.format(ValueFormatter.java:41)
	at io.smallrye.graphql.client.impl.core.InputObjectFieldImpl.build(InputObjectFieldImpl.java:14)
	at io.smallrye.graphql.client.impl.core.InputObjectImpl.build(InputObjectImpl.java:14)
	at io.smallrye.graphql.client.impl.core.utils.ValueFormatter.format(ValueFormatter.java:34)
	at io.smallrye.graphql.client.impl.core.ArgumentImpl.build(ArgumentImpl.java:12)
	at io.smallrye.graphql.client.impl.core.FieldImpl._buildArgs(FieldImpl.java:45)
	at io.smallrye.graphql.client.impl.core.FieldImpl.build(FieldImpl.java:19)
	at io.smallrye.graphql.client.impl.core.OperationImpl.lambda$buildWrapper$0(OperationImpl.java:77)
	at java.base/java.util.Arrays$ArrayList.forEach(Arrays.java:4305)
	at io.smallrye.graphql.client.impl.core.OperationImpl.buildWrapper(OperationImpl.java:77)
	at io.smallrye.graphql.client.impl.core.OperationImpl._buildFields(OperationImpl.java:68)
	at io.smallrye.graphql.client.impl.core.OperationImpl.build(OperationImpl.java:43)
	at io.smallrye.graphql.client.impl.core.DocumentImpl.build(DocumentImpl.java:11)
	at io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClient.buildRequest(VertxDynamicGraphQLClient.java:384)
	at io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClient.executeSync(VertxDynamicGraphQLClient.java:115)
```

However, when the field is actually a custom scalar, the formatter should be able to support the serialization. This PR fixes the issue with the formatter.