### PR TITLE
Added hint if schema build is failing due conflicting field name

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/AbstractCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/AbstractCreator.java
@@ -163,7 +163,8 @@ abstract class AbstractCreator implements Creator<Type> {
         operations.keySet().forEach(fieldName -> {
             if (type.getFields().keySet().contains(fieldName)) {
                 throw new SchemaBuilderException(String.format("Type '%s' already contains field named '%s'" +
-                        " so source field, with the same name, cannot be applied", type.getName(), fieldName));
+                        " so source field, with the same name, cannot be applied. You can resolve this conflict using @Ignore on the type's field.", type.getName(),
+                        fieldName));
             }
         });
         return operations;

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/AbstractCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/AbstractCreator.java
@@ -163,7 +163,8 @@ abstract class AbstractCreator implements Creator<Type> {
         operations.keySet().forEach(fieldName -> {
             if (type.getFields().keySet().contains(fieldName)) {
                 throw new SchemaBuilderException(String.format("Type '%s' already contains field named '%s'" +
-                        " so source field, with the same name, cannot be applied. You can resolve this conflict using @Ignore on the type's field.", type.getName(),
+                        " so source field, with the same name, cannot be applied. You can resolve this conflict using @Ignore on the type's field.",
+                        type.getName(),
                         fieldName));
             }
         });

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -165,7 +165,7 @@ public class SchemaBuilderTest {
         } catch (SchemaBuilderException e) {
             // ok
             assertEquals(
-                    "Type 'SomeClass' already contains field named 'password' so source field, with the same name, cannot be applied",
+                    "Type 'SomeClass' already contains field named 'password' so source field, with the same name, cannot be applied. You can resolve this conflict using @Ignore on the type's field.",
                     e.getMessage());
         }
     }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -149,7 +149,8 @@ public class SchemaBuilderTest {
         } catch (SchemaBuilderException e) {
             // ok
             assertEquals("Type 'SomeClass' already contains field named 'password' so source field, " +
-                    "with the same name, cannot be applied", e.getMessage());
+                    "with the same name, cannot be applied. You can resolve this conflict using @Ignore on the type's field.",
+                    e.getMessage());
         }
     }
 


### PR DESCRIPTION
This just adds some hint how to resolve a naming conflict due  schema build is failing. 

The original error message (io.smallrye.graphql.schema.SchemaBuilderException):
```
Type 'MyEntity' already contains field named 'items' so source field, with the same name, cannot be applied
```
would become:
```
Type 'MyEntity' already contains field named 'items' so source field, with the same name, cannot be applied. You can resolve this conflict using @Ignore on the type's field.
```

