### PR TITLE
Add support for Double values when formatting GraphQL variables for JSON.

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
@@ -69,6 +69,8 @@ public class RequestImpl implements Request {
                 varBuilder.add(k, (Boolean) v);
             } else if (v instanceof Long) {
                 varBuilder.add(k, (Long) v);
+            } else if (v instanceof Double) {
+                varBuilder.add(k, (Double) v);
             } else if (v == null) {
                 varBuilder.addNull(k);
             } else {

--- a/client/implementation/src/test/java/io/smallrye/graphql/client/RequestImplTest.java
+++ b/client/implementation/src/test/java/io/smallrye/graphql/client/RequestImplTest.java
@@ -29,6 +29,12 @@ public class RequestImplTest {
 
         request.setVariable("key", "foo");
         assertEquals("{\"query\":\"example\",\"variables\":{\"key\":\"foo\"}}", request.toJson());
+
+        request.setVariable("key", 5L);
+        assertEquals("{\"query\":\"example\",\"variables\":{\"key\":5}}", request.toJson());
+
+        request.setVariable("key", 5.5);
+        assertEquals("{\"query\":\"example\",\"variables\":{\"key\":5.5}}", request.toJson());
     }
 
     @Test


### PR DESCRIPTION
This addresses an issue in executing GraphQL queries with defined variables of the Float scalar, e.g.
```
mutation updateScoreTest($id_val: ID!, $input_score: Float!) {
  updateGameScore(id: $id_val, score: $input_score) {
    ...
  }
}
```
where the value submitted to the GraphQL Float variable is interpreted in Java as a Double.

Similar to what was addressed in https://github.com/smallrye/smallrye-graphql/pull/1999 for Long and https://github.com/smallrye/smallrye-graphql/pull/1710 for Boolean, RequestImpl method `_formatJsonVariables` does not contain a condition for handling Doubles, so the value falls through to an attempt to convert to JsonStructure, which causes an ignored exception. The value is never set in a variable and thus the GraphQL server, upon receiving the request, ends up with a `null` value for the variable, which could cause incorrect behavior for a nullable variable or an error from the GraphQL server if the variable marked non-null.

Handling Double should cover support for the Float scalar, since GraphQL spec defines it as a signed double precision floating point number. I've added a condition to `_formatJsonVariables` to handle Double instances so that they are assigned to the variable in the constructed JSON and included with the request as expected, and updated the primitive types test in RequestImplTest to include a Double example (I also added a Long example to the test to cover the use case that was addressed in #1999).

