### PR TITLE
added some ignored tokens for name validations (dynamic)

### DIFF
--- a/client/api/src/main/java/io/smallrye/graphql/client/core/utils/validation/NameValidation.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/core/utils/validation/NameValidation.java
@@ -12,7 +12,8 @@ public class NameValidation {
     /**
      * The regular expression patterns for a valid GraphQL names.
      */
-    private static final String _NAME_REGEX = "[a-zA-Z_][a-zA-Z0-9_]*";
+    private static final String _IGNORED_TOKENS_REGEX = "[,\\s]*"; // for now, whitespaces and commas
+    private static final String _NAME_REGEX = _IGNORED_TOKENS_REGEX + "[a-zA-Z_][a-zA-Z0-9_]*" + _IGNORED_TOKENS_REGEX;
     private static final String _FIELD_NAME_REGEX = "^" + _NAME_REGEX + "(:" + _NAME_REGEX + ")?$";
     private static final Pattern NAME_PATTERN = Pattern.compile(_NAME_REGEX);
     private static final Pattern FIELD_NAME_PATTERN = Pattern.compile(_FIELD_NAME_REGEX);

--- a/client/tck/src/main/java/tck/graphql/dynamic/core/FieldsTest.java
+++ b/client/tck/src/main/java/tck/graphql/dynamic/core/FieldsTest.java
@@ -58,6 +58,11 @@ public class FieldsTest {
         assertDoesNotThrow(() -> field("_:v1"));
         assertDoesNotThrow(() -> field("___"));
         assertDoesNotThrow(() -> field("o"));
+        assertDoesNotThrow(() -> field(" valid_name "));
+        assertDoesNotThrow(() -> field("o1: b"));
+        assertDoesNotThrow(() -> field("o12 ,,, : ,,, bbbee1"));
+        assertDoesNotThrow(() -> field(",,,,valid_name,,,,"));
+        assertDoesNotThrow(() -> field("foo:\tbar"));
     }
 
     @Test
@@ -66,7 +71,6 @@ public class FieldsTest {
         assertThrows(IllegalArgumentException.class, () -> field(""));
         assertThrows(IllegalArgumentException.class, () -> field("invalid_nam&e"));
         assertThrows(IllegalArgumentException.class, () -> field("1invalid_name"));
-        assertThrows(IllegalArgumentException.class, () -> field(" invalid_name"));
         assertThrows(IllegalArgumentException.class, () -> field(":invalid_name"));
         assertThrows(IllegalArgumentException.class, () -> field("invalid name"));
         assertThrows(IllegalArgumentException.class, () -> field("invalid_name:"));
@@ -74,5 +78,7 @@ public class FieldsTest {
         assertThrows(IllegalArgumentException.class, () -> field("a:1"));
         assertThrows(IllegalArgumentException.class, () -> field("invalid::name"));
         assertThrows(IllegalArgumentException.class, () -> field("field:name:name2"));
+        assertThrows(IllegalArgumentException.class, () -> field(" invalid,name"));
+        assertThrows(IllegalArgumentException.class, () -> field("invalid\tname"));
     }
 }

--- a/client/tck/src/main/java/tck/graphql/dynamic/core/FragmentReferencesTest.java
+++ b/client/tck/src/main/java/tck/graphql/dynamic/core/FragmentReferencesTest.java
@@ -20,6 +20,7 @@ public class FragmentReferencesTest {
         assertDoesNotThrow(() -> fragmentRef("_"));
         assertDoesNotThrow(() -> fragmentRef("frag_ment"));
         assertDoesNotThrow(() -> fragmentRef("one"));
+        assertDoesNotThrow(() -> fragmentRef(" two,, ,"));
     }
 
     @Test
@@ -33,5 +34,6 @@ public class FragmentReferencesTest {
         assertThrows(IllegalArgumentException.class, () -> fragmentRef("in:valid"));
         assertThrows(IllegalArgumentException.class, () -> fragmentRef("inv@lid"));
         assertThrows(IllegalArgumentException.class, () -> fragmentRef("on"));
+        assertThrows(IllegalArgumentException.class, () -> fragmentRef(" invalid_frag,ment"));
     }
 }

--- a/client/tck/src/main/java/tck/graphql/dynamic/core/FragmentsTest.java
+++ b/client/tck/src/main/java/tck/graphql/dynamic/core/FragmentsTest.java
@@ -46,6 +46,7 @@ public class FragmentsTest {
         assertDoesNotThrow(() -> fragment("_"));
         assertDoesNotThrow(() -> fragment("frag_ment"));
         assertDoesNotThrow(() -> fragment("one"));
+        assertDoesNotThrow(() -> fragment(",,,two "));
     }
 
     @Test
@@ -60,5 +61,6 @@ public class FragmentsTest {
         assertThrows(IllegalArgumentException.class, () -> fragment("...fragmentinvalid"));
         assertThrows(IllegalArgumentException.class, () -> fragment("inv@lid"));
         assertThrows(IllegalArgumentException.class, () -> fragment("on"));
+        assertThrows(IllegalArgumentException.class, () -> fragment("frag,ment"));
     }
 }

--- a/client/tck/src/main/java/tck/graphql/dynamic/core/OperationsTest.java
+++ b/client/tck/src/main/java/tck/graphql/dynamic/core/OperationsTest.java
@@ -16,6 +16,7 @@ public class OperationsTest {
         assertDoesNotThrow(() -> operation("_myOperation"));
         assertDoesNotThrow(() -> operation("my_operation"));
         assertDoesNotThrow(() -> operation("my123Operation"));
+        assertDoesNotThrow(() -> operation(",, ,myOperation ,"));
         assertDoesNotThrow(() -> operation("o"));
         assertDoesNotThrow(() -> operation("_"));
         assertDoesNotThrow(() -> operation("op_eration"));
@@ -35,6 +36,7 @@ public class OperationsTest {
         assertThrows(IllegalArgumentException.class, () -> operation("InvalidName::"));
         assertThrows(IllegalArgumentException.class, () -> operation("@InvalidName"));
         assertThrows(IllegalArgumentException.class, () -> operation("my.Operation"));
+        assertThrows(IllegalArgumentException.class, () -> operation("my,Operation"));
         assertThrows(IllegalArgumentException.class, () -> operation("my-Operation"));
     }
 }

--- a/client/tck/src/main/java/tck/graphql/dynamic/core/VariableTypesTest.java
+++ b/client/tck/src/main/java/tck/graphql/dynamic/core/VariableTypesTest.java
@@ -18,12 +18,14 @@ public class VariableTypesTest {
         assertDoesNotThrow(() -> varType("v"));
         assertDoesNotThrow(() -> varType("_"));
         assertDoesNotThrow(() -> varType("va_lid"));
+        assertDoesNotThrow(() -> varType(" ,va_lid,, "));
         assertDoesNotThrow(() -> varType("_valid"));
     }
 
     @Test
     public void varTypesShouldThrowExceptionForInvalidName() {
         assertThrows(IllegalArgumentException.class, () -> varType("Invalid:Name"));
+        assertThrows(IllegalArgumentException.class, () -> varType("Invalid,Name"));
         assertThrows(IllegalArgumentException.class, () -> varType("123InvalidName"));
         assertThrows(IllegalArgumentException.class, () -> varType("invalid-Name"));
         assertThrows(IllegalArgumentException.class, () -> varType("invalid name"));
@@ -39,12 +41,14 @@ public class VariableTypesTest {
         assertDoesNotThrow(() -> nonNull("v"));
         assertDoesNotThrow(() -> nonNull("_"));
         assertDoesNotThrow(() -> nonNull("va_lid"));
+        assertDoesNotThrow(() -> nonNull(" ,va_lid,, "));
         assertDoesNotThrow(() -> nonNull("_valid"));
     }
 
     @Test
     public void nonNullsShouldThrowExceptionForInvalidName() {
         assertThrows(IllegalArgumentException.class, () -> nonNull("Invalid:Name"));
+        assertThrows(IllegalArgumentException.class, () -> nonNull("Invalid,Name"));
         assertThrows(IllegalArgumentException.class, () -> nonNull("123InvalidName"));
         assertThrows(IllegalArgumentException.class, () -> nonNull("invalid-Name"));
         assertThrows(IllegalArgumentException.class, () -> nonNull("invalid name"));
@@ -60,12 +64,14 @@ public class VariableTypesTest {
         assertDoesNotThrow(() -> list("v"));
         assertDoesNotThrow(() -> list("_"));
         assertDoesNotThrow(() -> list("va_lid"));
+        assertDoesNotThrow(() -> list(" ,va_lid,, "));
         assertDoesNotThrow(() -> list("_valid"));
     }
 
     @Test
     public void listsShouldThrowExceptionForInvalidName() {
         assertThrows(IllegalArgumentException.class, () -> list("Invalid:Name"));
+        assertThrows(IllegalArgumentException.class, () -> list("Invalid,Name"));
         assertThrows(IllegalArgumentException.class, () -> list("123InvalidName"));
         assertThrows(IllegalArgumentException.class, () -> list("invalidName-"));
         assertThrows(IllegalArgumentException.class, () -> list("invalid name"));


### PR DESCRIPTION
/cc @jmartisk 
fix:#2096

see: https://spec.graphql.org/draft/#sec-Language.Source-Text.Ignored-Tokens

I only added commas and whitespaces.

Afaik, these ignored tokens are ignored by the graphql runtime.