### PR TITLE
Schema Builder doesn't support inheriting interface field with subtype

### DIFF
--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -186,7 +186,7 @@ public class SchemaBuilderTest {
         Type containerInterface = interfaces.get("ContainerInterface");
         Field containerInterfaceField = containerInterface.getFields().get("inheritField");
 
-        // TODO: Should be FieldInterface according to GraphQL Spec: https://spec.graphql.org/October2021/#sec-Objects.Type-Validation
+        // TODO: Should be FieldType according to GraphQL Spec: https://spec.graphql.org/October2021/#sec-Objects.Type-Validation
         assertEquals("io.smallrye.graphql.index.inherit.FieldInterface",
                 containerTypeField.getReference().getClassName());
         assertEquals("io.smallrye.graphql.index.inherit.FieldInterface",

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -186,8 +186,8 @@ public class SchemaBuilderTest {
         Type containerInterface = interfaces.get("ContainerInterface");
         Field containerInterfaceField = containerInterface.getFields().get("inheritField");
 
-        // TODO: Should be FieldType according to GraphQL Spec: https://spec.graphql.org/October2021/#sec-Objects.Type-Validation
-        assertEquals("io.smallrye.graphql.index.inherit.FieldInterface",
+        // Should be FieldType according to GraphQL Spec: https://spec.graphql.org/October2021/#sec-Objects.Type-Validation
+        assertEquals("io.smallrye.graphql.index.inherit.FieldType",
                 containerTypeField.getReference().getClassName());
         assertEquals("io.smallrye.graphql.index.inherit.FieldInterface",
                 containerInterfaceField.getReference().getClassName());

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -172,6 +172,28 @@ public class SchemaBuilderTest {
     }
 
     @Test
+    public void testSchemaWithInheritFieldBySubtype() {
+        Indexer indexer = new Indexer();
+        indexDirectory(indexer, "io/smallrye/graphql/index/inherit/");
+
+        IndexView index = indexer.complete();
+        Schema schema = SchemaBuilder.build(index);
+        // Get Types
+        Map<String, Type> types = schema.getTypes();
+        Map<String, Type> interfaces = schema.getInterfaces();
+        Type containerType = types.get("ContainerType");
+        Field containerTypeField = containerType.getFields().get("inheritField");
+        Type containerInterface = interfaces.get("ContainerInterface");
+        Field containerInterfaceField = containerInterface.getFields().get("inheritField");
+
+        // TODO: Should be FieldInterface according to GraphQL Spec: https://spec.graphql.org/October2021/#sec-Objects.Type-Validation
+        assertEquals("io.smallrye.graphql.index.inherit.FieldInterface",
+                containerTypeField.getReference().getClassName());
+        assertEquals("io.smallrye.graphql.index.inherit.FieldInterface",
+                containerInterfaceField.getReference().getClassName());
+    }
+
+    @Test
     public void testSchemaWithDirectives() throws IOException {
         Indexer indexer = new Indexer();
         Path apiDir = Paths.get(System.getProperty("user.dir"), "../../server/api/target/classes/io/smallrye/graphql/api")

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/inherit/ContainerInterface.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/inherit/ContainerInterface.java
@@ -1,0 +1,5 @@
+package io.smallrye.graphql.index.inherit;
+
+public interface ContainerInterface {
+    FieldInterface getInheritField();
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/inherit/ContainerType.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/inherit/ContainerType.java
@@ -1,0 +1,8 @@
+package io.smallrye.graphql.index.inherit;
+
+public class ContainerType implements ContainerInterface {
+
+    public FieldType getInheritField() {
+        return new FieldType();
+    }
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/inherit/FieldInterface.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/inherit/FieldInterface.java
@@ -1,0 +1,5 @@
+package io.smallrye.graphql.index.inherit;
+
+public interface FieldInterface {
+    String getVal();
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/inherit/FieldType.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/inherit/FieldType.java
@@ -1,0 +1,7 @@
+package io.smallrye.graphql.index.inherit;
+
+public class FieldType implements FieldInterface {
+    public String getVal() {
+        return "";
+    }
+}

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/inherit/InheritAPI.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/inherit/InheritAPI.java
@@ -1,0 +1,12 @@
+package io.smallrye.graphql.index.inherit;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class InheritAPI {
+    @Query
+    public ContainerInterface getContainer() {
+        return null;
+    }
+}


### PR DESCRIPTION
Suppose we have the GraphQL Schema below
```
interface FieldInterface {...}
type FieldType implements FieldInterface {...}
interface ContainerInterface {
  field: FieldInterface
}
```
According to GraphQL [spec](https://spec.graphql.org/October2021/#sec-Objects.Type-Validation), we can have a type
```
type ContainerType {
  field: FieldType
}
```
However, as my test cases show, if I define the Java Classes/Interfaces the same way as the GraphQL type relationship, the schema builder would generate `field: FieldInterface` instead of `field: FieldType` in `ContainerType`.