### PR TITLE
(2.8.x) Avoid keeping a static reference to the ServiceLoader

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/config/Config.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/config/Config.java
@@ -18,13 +18,12 @@ import io.smallrye.graphql.execution.datafetcher.DataFetcherException;
  */
 public interface Config {
     static Logger LOG = Logger.getLogger(Config.class);
-    ServiceLoader<Config> configs = ServiceLoader.load(Config.class);
     Config config = init();
 
     static Config init() {
         Config c;
         try {
-            c = configs.iterator().next();
+            c = ServiceLoader.load(Config.class).iterator().next();
         } catch (Exception ex) {
             c = new Config() {
                 @Override


### PR DESCRIPTION
backport of https://github.com/smallrye/smallrye-graphql/pull/2132 to 2.8.x