### PR TITLE
Fixed wrapper nonnull types

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
@@ -512,17 +512,10 @@ public class Annotations {
 
     private static Map<DotName, AnnotationInstance> getAnnotations(org.jboss.jandex.Type type) {
         Map<DotName, AnnotationInstance> annotationMap = new HashMap<>();
-
-        if (type.kind().equals(org.jboss.jandex.Type.Kind.PARAMETERIZED_TYPE)) {
-            org.jboss.jandex.Type typeInCollection = type.asParameterizedType().arguments().get(0);
-            annotationMap.putAll(getAnnotations(typeInCollection));
-        } else {
-            List<AnnotationInstance> annotations = type.annotations();
-            for (AnnotationInstance annotationInstance : annotations) {
-                annotationMap.put(annotationInstance.name(), annotationInstance);
-            }
+        List<AnnotationInstance> annotations = type.annotations();
+        for (AnnotationInstance annotationInstance : annotations) {
+            annotationMap.put(annotationInstance.name(), annotationInstance);
         }
-
         return annotationMap;
     }
 

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/WrapperCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/WrapperCreator.java
@@ -86,18 +86,16 @@ public class WrapperCreator {
             Annotations annotationsInParameterizedType = Annotations.getAnnotationsForArray(typeInCollection,
                     methodTypeInCollection);
 
-            return NonNullHelper.markAsNonNull(typeInCollection, annotationsInParameterizedType, true);
+            return NonNullHelper.markAsNonNull(typeInCollection, annotationsInParameterizedType, false);
         }
         return false;
     }
 
     private static Type getTypeInCollection(Type type) {
         if (Classes.isArray(type)) {
-            Type typeInArray = type.asArrayType().component();
-            return getTypeInCollection(typeInArray);
+            return type.asArrayType().componentType();
         } else if (Classes.isParameterized(type)) {
-            Type typeInCollection = type.asParameterizedType().arguments().get(0);
-            return getTypeInCollection(typeInCollection);
+            return type.asParameterizedType().arguments().get(0);
         }
         return type;
     }

--- a/server/implementation/src/test/resources/schemaTest.graphql
+++ b/server/implementation/src/test/resources/schemaTest.graphql
@@ -18,7 +18,7 @@ directive @include(
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 "test-description"
-directive @intArrayTestDirective(value: [Int]) on OBJECT | INTERFACE
+directive @intArrayTestDirective(value: [Int!]) on OBJECT | INTERFACE
 
 "Indicates an Input Object is a OneOf Input Object."
 directive @oneOf on INPUT_OBJECT


### PR DESCRIPTION
fixes:#1366
`NonNull` annotation is only applied now where it needs to be (in wrapper hierarchy)
There are some maybe weird behaviors when it comes to arrays: `@NonNull String[] => [String!]!` even tho it should be `[String]!`.

some other changes:
- primitive types that are elements of collection/arrays -> are now `nonNull` by default

/cc @jmartisk 