### PR TITLE
Allow using a sub-interface of a generic interface as API with Typesafe client

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientBuilder.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientBuilder.java
@@ -188,7 +188,7 @@ public class VertxTypesafeGraphQLClientBuilder implements TypesafeGraphQLClientB
                 allowUnexpectedResponseFields);
 
         return apiClass.cast(Proxy.newProxyInstance(getClassLoader(apiClass), new Class<?>[] { apiClass },
-                (proxy, method, args) -> invoke(graphQLClient, method, args)));
+                (proxy, method, args) -> invoke(apiClass, graphQLClient, method, args)));
     }
 
     private void applyConfigFor(Class<?> apiClass) {
@@ -221,9 +221,9 @@ public class VertxTypesafeGraphQLClientBuilder implements TypesafeGraphQLClientB
         return vertx != null ? vertx : VertxManager.get();
     }
 
-    private Object invoke(VertxTypesafeGraphQLClientProxy graphQlClient, java.lang.reflect.Method method,
+    private Object invoke(Class<?> apiClass, VertxTypesafeGraphQLClientProxy graphQlClient, java.lang.reflect.Method method,
             Object... args) {
-        MethodInvocation methodInvocation = MethodInvocation.of(method, args);
+        MethodInvocation methodInvocation = MethodInvocation.of(apiClass, method, args);
         if (methodInvocation.isDeclaredInCloseable()) {
             graphQlClient.close();
             return null; // void

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/MethodInvocation.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/MethodInvocation.java
@@ -8,6 +8,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
@@ -31,6 +32,10 @@ import io.smallrye.graphql.client.typesafe.api.Multiple;
 public class MethodInvocation implements NamedElement {
     public static MethodInvocation of(Method method, Object... args) {
         return new MethodInvocation(new TypeInfo(null, method.getDeclaringClass()), method, args);
+    }
+
+    public static MethodInvocation of(Type apiInterface, Method method, Object... args) {
+        return new MethodInvocation(new TypeInfo(null, apiInterface), method, args);
     }
 
     private final TypeInfo type;


### PR DESCRIPTION
Goal
----
I want to be able to write a GraphQL api and provide a Java interface for my clients, whilst keeping GraphQL strength of allowing clients to choose exactly what data they will receive. For that, we could use generics.

So, as the writer of the GraphQL endpoint, I would for example give this to my clients:

```
public interface MyApi<T> {
    Uni<T> getItem();
}
```

`T` could be for example: `public record MyItemSimple(String name) {}` or `public record MyItemFull(String name, String extraLongDescription) {}`

Then, on the client side, I would be able to choose between: 
```
@GraphQLClientApi
public interface MyApiSimple extends MyApi<MyItemSimple> {
}
```
or
```
@GraphQLClientApi
public interface MyApiFull extends MyApi<MyItemFull> {
}
```
depending on the data needed, and `getItem()` would return exactly that.

Problem
----

That fails with:
```
java.lang.UnsupportedOperationException: can't resolve type variable of a T

	at io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo.resolveTypeVariable(TypeInfo.java:111)
	at io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo.getTypeName(TypeInfo.java:97)
	at io.smallrye.graphql.client.impl.typesafe.QueryBuilder.fields(QueryBuilder.java:56)
	at io.smallrye.graphql.client.impl.typesafe.QueryBuilder.recursionCheckedFields(QueryBuilder.java:73)
```
The only way to get it working is to explicitly override the generic method.

Solution
---
This PR provides a way to fix this and makes the scenario described here as expected.