### PR TITLE
fix TCK issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,8 +96,8 @@ jobs:
       - name: checkout Quarkus repository
         uses: actions/checkout@v2
         with:
-          repository: quarkusio/quarkus
-          ref: main
+          repository: mskacelik/quarkus
+          ref: srgql-2.9.1
           path: quarkus
 
       - uses: actions/setup-java@v3.10.0

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
@@ -512,9 +512,14 @@ public class Annotations {
 
     private static Map<DotName, AnnotationInstance> getAnnotations(org.jboss.jandex.Type type) {
         Map<DotName, AnnotationInstance> annotationMap = new HashMap<>();
-        List<AnnotationInstance> annotations = type.annotations();
-        for (AnnotationInstance annotationInstance : annotations) {
-            annotationMap.put(annotationInstance.name(), annotationInstance);
+        if (type.kind().equals(org.jboss.jandex.Type.Kind.PARAMETERIZED_TYPE)) {
+            org.jboss.jandex.Type typeInCollection = type.asParameterizedType().arguments().get(0);
+            annotationMap.putAll(getAnnotations(typeInCollection));
+        } else {
+            List<AnnotationInstance> annotations = type.annotations();
+            for (AnnotationInstance annotationInstance : annotations) {
+                annotationMap.put(annotationInstance.name(), annotationInstance);
+            }
         }
         return annotationMap;
     }


### PR DESCRIPTION
fix:#2148

The problem was that getAnnotations(type) only looked for the most outer wrapper; for example, for type @A List<@B C>, it only returned A but not A, B. This was because I changed it in the https://github.com/smallrye/smallrye-graphql/commit/fa02098cabe9db9be480d16425e0336e7532680c commit.

That said, I am not sure why the SRGQL TCK did not fail and Quarkus did...

I will delete the overridden configuration (outputs.json) on Quarkus when a new version of SRGQL is released...

/cc @jmartisk 