### PR TITLE
Set correct api group description

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/GroupHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/GroupHelper.java
@@ -59,7 +59,7 @@ public class GroupHelper {
     /**
      * Get the description on a class type
      *
-     * @param annotations annotation on the class
+     * @param graphQLApiAnnotation annotation on the class
      * @return the optional description
      */
     private static Optional<String> getDescription(AnnotationInstance graphQLApiAnnotation) {
@@ -67,12 +67,15 @@ public class GroupHelper {
         if (apiClass.annotationsMap().containsKey(Annotations.DESCRIPTION)) {
             List<AnnotationInstance> descriptionAnnotations = apiClass.annotationsMap().get(Annotations.DESCRIPTION);
             if (descriptionAnnotations != null && !descriptionAnnotations.isEmpty()) {
-                AnnotationValue value = descriptionAnnotations.get(0).value();
-                if (value != null && value.asString() != null && !value.asString().isEmpty()) {
-                    return Optional.of(value.asString());
+                for (AnnotationInstance descriptionAnnotation : descriptionAnnotations) {
+                    if (descriptionAnnotation.target().equals(graphQLApiAnnotation.target())){
+                        AnnotationValue value = descriptionAnnotation.value();
+                        if (value != null && value.asString() != null && !value.asString().isEmpty()) {
+                            return Optional.of(value.asString());
+                        }
+                    }
                 }
             }
-
         }
         return Optional.empty();
     }

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/GroupHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/GroupHelper.java
@@ -68,7 +68,7 @@ public class GroupHelper {
             List<AnnotationInstance> descriptionAnnotations = apiClass.annotationsMap().get(Annotations.DESCRIPTION);
             if (descriptionAnnotations != null && !descriptionAnnotations.isEmpty()) {
                 for (AnnotationInstance descriptionAnnotation : descriptionAnnotations) {
-                    if (descriptionAnnotation.target().equals(graphQLApiAnnotation.target())){
+                    if (descriptionAnnotation.target().equals(graphQLApiAnnotation.target())) {
                         AnnotationValue value = descriptionAnnotation.value();
                         if (value != null && value.asString() != null && !value.asString().isEmpty()) {
                             return Optional.of(value.asString());


### PR DESCRIPTION
See #2173

Hi. Schema build generate not correct description on api group. For example if use this code
```
@Description("Group description")
@Name("Group")
@GraphQLApi
public class Api {
    @Query
    @Description("Method description")
    public String method() {
        return "method";
    }
}
```
wiil be generated next part of schema, which contains first available description (it takes description from method, becouse in annotation instances it is first element)
```
"Method description"
type GroupQuery {
  "Method description"
  method: String
}
///
```
Need check that annotation instance target equals api class