### PR TITLE
Extend custom error extension

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExecutionErrorsService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExecutionErrorsService.java
@@ -112,7 +112,12 @@ public class ExecutionErrorsService {
                         || (config.getErrorExtensionFields().isPresent()
                                 && config.getErrorExtensionFields().get().contains(entry.getKey()))) {
                     Object value = entry.getValue();
-                    addKeyValue(objectBuilder, entry.getKey(), value != null ? value.toString() : null);
+                    if (value instanceof JsonValue)
+                        addKeyValue(objectBuilder, entry.getKey(), (JsonValue) value);
+                    else if (value instanceof Map)
+                        addKeyValue(objectBuilder, entry.getKey(), JSON_PROVIDER.createObjectBuilder((Map) value).build());
+                    else
+                        addKeyValue(objectBuilder, entry.getKey(), value != null ? value.toString() : null);
                 }
             }
         }


### PR DESCRIPTION
For user error extension is ErrorExtensionProvider interface. And in the implementation I can create any big Json
But if I whant create graphql instrumentation and drop exception in it, I have a string, not json object

Example

Custom exception
```
public class GraphqlException extends GraphQLException implements GraphQLError {
    private final Throwable cause;
    private final GraphQLError error;

    public GraphqlException(Throwable cause, GraphQLError error) {
        super(cause);
        this.cause = cause;
        this.error = error;
    }

    public GraphqlException(Throwable cause) {
        super(cause);
        this.cause = cause;
        this.error = null;
    }

    @Override
    public List<SourceLocation> getLocations() {
        return error == null ? null : error.getLocations();
    }

    @Override
    public ErrorClassification getErrorType() {
        return error == null ? null : error.getErrorType();
    }

    @Override
    public List<Object> getPath() {
        return error == null ? null : error.getPath();
    }

    @Override
    public Map<String, Object> getExtensions() {
        if (cause instanceof BaseException baseException) {
            return (Map) baseException.getFullErrorInfo();
        }
        return GraphQLError.super.getExtensions();
    }
}
```

Custom instrumentation, which modifies ValidationError and add extension
```
@ApplicationScoped
public class ValidationInstrumentation implements Instrumentation {
    @Override
    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, InstrumentationState state) {
        return new SimpleInstrumentationContext<>() {
            @Override
            public void onCompleted(List<ValidationError> result, Throwable cause) {
                if (cause != null) {
                    throw new GraphqlException(cause);
                }
                if (result != null && !result.isEmpty()) {
                    List<ValidationError> errors = result.stream()
                            .map(validationError -> ValidationError.newValidationError()
                                    .sourceLocations(validationError.getLocations())
                                    .queryPath(validationError.getQueryPath())
                                    .description("Exception message")
                                    .validationErrorType(validationError.getValidationErrorType())
                                    .extensions(Map.of("error", Json.createObjectBuilder().add("type", "value").build(), "code", "validation"))
                                    .build()
                            )
                            .toList();
                    result.clear();
                    result.addAll(errors);
                }
            }
        };
    }
}
```
By default in this validation I received string
This PR allows pass any custom error extensions in response