### PR TITLE
bump version of graphql-java 22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <version.jakarta.servlet>6.0.0</version.jakarta.servlet>
         <version.jakarta.websocket>2.0.0</version.jakarta.websocket>
         <version.graphql-java-federation>4.4.0</version.graphql-java-federation>
-        <version.graphql-java>22.1</version.graphql-java>
+        <version.graphql-java>22.2</version.graphql-java>
         <version.extended-scalars>21.0</version.extended-scalars>
         <verison.io.micrometer>1.11.3</verison.io.micrometer>
         <version.vertx>4.5.4</version.vertx>


### PR DESCRIPTION
/cc @jmartisk 

There still is a need to update the Quarkus/WildFly branch later – I am not sure if this commit is going to be part of 2.9.3 or 2.10.0.