### PR TITLE
Fix directives building 

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/DirectiveIndexer.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/DirectiveIndexer.java
@@ -1,0 +1,73 @@
+package io.smallrye.graphql.schema;
+
+import java.io.IOException;
+
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
+
+import io.smallrye.graphql.api.OneOf;
+import io.smallrye.graphql.api.federation.Authenticated;
+import io.smallrye.graphql.api.federation.ComposeDirective;
+import io.smallrye.graphql.api.federation.Extends;
+import io.smallrye.graphql.api.federation.External;
+import io.smallrye.graphql.api.federation.FieldSet;
+import io.smallrye.graphql.api.federation.Inaccessible;
+import io.smallrye.graphql.api.federation.InterfaceObject;
+import io.smallrye.graphql.api.federation.Key;
+import io.smallrye.graphql.api.federation.Override;
+import io.smallrye.graphql.api.federation.Provides;
+import io.smallrye.graphql.api.federation.Requires;
+import io.smallrye.graphql.api.federation.Shareable;
+import io.smallrye.graphql.api.federation.Tag;
+import io.smallrye.graphql.api.federation.link.Import;
+import io.smallrye.graphql.api.federation.link.Link;
+import io.smallrye.graphql.api.federation.link.Purpose;
+import io.smallrye.graphql.api.federation.policy.Policy;
+import io.smallrye.graphql.api.federation.policy.PolicyGroup;
+import io.smallrye.graphql.api.federation.policy.PolicyItem;
+import io.smallrye.graphql.api.federation.requiresscopes.RequiresScopes;
+import io.smallrye.graphql.api.federation.requiresscopes.ScopeGroup;
+import io.smallrye.graphql.api.federation.requiresscopes.ScopeItem;
+
+class DirectiveIndexer {
+    static IndexView directiveIndex() {
+        Indexer indexer = new Indexer();
+
+        try {
+            // directives from the API module
+            indexer.indexClass(io.smallrye.graphql.api.Deprecated.class);
+            indexer.indexClass(java.lang.Deprecated.class);
+            indexer.indexClass(OneOf.class);
+
+            indexer.indexClass(Authenticated.class);
+            indexer.indexClass(ComposeDirective.class);
+            indexer.indexClass(Extends.class);
+            indexer.indexClass(External.class);
+            indexer.indexClass(FieldSet.class);
+            indexer.indexClass(Inaccessible.class);
+            indexer.indexClass(InterfaceObject.class);
+            indexer.indexClass(Key.class);
+            indexer.indexClass(Override.class);
+            indexer.indexClass(Provides.class);
+            indexer.indexClass(Requires.class);
+            indexer.indexClass(Shareable.class);
+            indexer.indexClass(Tag.class);
+
+            indexer.indexClass(Link.class);
+            indexer.indexClass(Import.class);
+            indexer.indexClass(Purpose.class);
+
+            indexer.indexClass(Policy.class);
+            indexer.indexClass(PolicyGroup.class);
+            indexer.indexClass(PolicyItem.class);
+
+            indexer.indexClass(RequiresScopes.class);
+            indexer.indexClass(ScopeGroup.class);
+            indexer.indexClass(ScopeItem.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return indexer.complete();
+    }
+}

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/DirectiveType.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/DirectiveType.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -88,6 +89,23 @@ public class DirectiveType {
 
     public void addArgumentType(DirectiveArgument type) {
         this.argumentTypes.add(type);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DirectiveType that = (DirectiveType) o;
+        return repeatable == that.repeatable && Objects.equals(className, that.className) && Objects.equals(name, that.name)
+                && Objects.equals(description, that.description) && Objects.equals(locations, that.locations)
+                && Objects.equals(argumentTypes, that.argumentTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className, name, description, locations, argumentTypes, repeatable);
     }
 
     @Override


### PR DESCRIPTION
See #2154 

In wundergraph cosmo `@link` is optional. 
Apollo requires it. Quarkus does not pass a complete index containing all directives, resulting in the `@link`and some others being ignored.
