### PR TITLE
Vertx client implementation requires yasson at runtime

### DIFF
--- a/client/implementation-vertx/pom.xml
+++ b/client/implementation-vertx/pom.xml
@@ -49,6 +49,11 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.smallrye</groupId>
@@ -63,11 +68,6 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-graphql-client-model-builder</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/docs/client-standalone.md
+++ b/docs/client-standalone.md
@@ -19,11 +19,10 @@ This is a full script runnable directly with [JBang](https://www.jbang.dev/) tha
 uses a dynamic client for connecting to [countries.trevorblades.com](https://countries.trevorblades.com)
 to obtain a list of countries from its database.
 
-```
+```java
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS io.smallrye:smallrye-graphql-client-implementation-vertx:1.5.0
+//DEPS io.smallrye:smallrye-graphql-client-implementation-vertx:RELEASE
 
-import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClientBuilder;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClientBuilder;
@@ -55,4 +54,4 @@ class Client {
 }
 ```
 
-Save this file as `client.java` and execute with `jbang client.java`.
+Save this file as `Client.java` and execute with `jbang Client.java`.


### PR DESCRIPTION
Version `1.5.0` was quite behind, I have tried to update to the newest version and I noticed the need for additional dependencies.