### PR TITLE
Gather bean validation violations in a single field error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: wildfly-extras/wildfly-graphql-feature-pack
-          ref: main
+          ref: smallrye-graphql-2.11
           path: wildfly-graphql-feature-pack
 
       - uses: actions/setup-java@v3.0.0


### PR DESCRIPTION
Change BeanValidationError path to go from root to field, in accordance with the spec.