### PR TITLE
Remove 'provided' scope from some client dependencies

### DIFF
--- a/client/implementation-vertx/pom.xml
+++ b/client/implementation-vertx/pom.xml
@@ -27,17 +27,14 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.json.bind</groupId>
             <artifactId>jakarta.json.bind-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <!-- The Client API is copied into SmallRye for now -->
         <!--        <dependency>-->


### PR DESCRIPTION
Kinda a continuation of https://github.com/smallrye/smallrye-graphql/pull/2196
The idea is that a standalone Java SE app should only need to declare the `smallrye-graphql-client-implementation-vertx` dependency and be able to fully run with just that. This fixes the usage of dynamic client this way