### PR TITLE
removed unnecessary "data": null if request failed before execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,8 +96,8 @@ jobs:
       - name: checkout Quarkus repository
         uses: actions/checkout@v2
         with:
-          repository: quarkusio/quarkus
-          ref: main
+          repository: mskacelik/quarkus
+          ref: srgql-2.11.1
           path: quarkus
 
       - uses: actions/setup-java@v4

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponse.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponse.java
@@ -100,6 +100,9 @@ public class ExecutionResponse {
     }
 
     private JsonObjectBuilder addDataToResponse(JsonObjectBuilder returnObjectBuilder, ExecutionResult executionResult) {
+        if (!executionResult.isDataPresent()) {
+            return returnObjectBuilder;
+        }
         Object pojoData = executionResult.getData();
         return addDataToResponse(returnObjectBuilder, pojoData);
     }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/customscalars/CustomScalarTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/customscalars/CustomScalarTest.java
@@ -84,12 +84,12 @@ public class CustomScalarTest {
         assertThat(graphQLAssured
                 .post("query { inAsScalarRequired(scalar: null) }"))
                 .contains("NullValueForNonNullArgument@[inAsScalarRequired]")
-                .contains("\"data\":null");
+                .doesNotContain("\"data\":");
 
         assertThat(graphQLAssured
                 .post("query { inAsScalarRequired }"))
                 .contains("MissingFieldArgument@[inAsScalarRequired]")
-                .contains("\"data\":null");
+                .doesNotContain("\"data\":");
     }
 
     @Test
@@ -131,7 +131,7 @@ public class CustomScalarTest {
                 .post("query { inAsScalarListRequired(scalars: [null]) }"))
                 .contains("WrongType@[inAsScalarListRequired]")
                 .contains("must not be null")
-                .contains("\"data\":null");
+                .doesNotContain("\"data\":");
     }
 
     @Test

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/error/UnparseableDocumentTestCase.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/error/UnparseableDocumentTestCase.java
@@ -1,11 +1,13 @@
 package io.smallrye.graphql.tests.error;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
 import java.net.URL;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Query;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -47,7 +49,14 @@ public class UnparseableDocumentTestCase {
         String exceptionMessage = "Unparseable input document";
 
         String response = graphQLAssured.post(request);
-        MatcherAssert.assertThat(response, Matchers.containsString(exceptionMessage));
+        assertThat(response, containsString(exceptionMessage));
+        // The response should not contain the "data" field.
+        // See: https://spec.graphql.org/draft/#sec-Response-Format
+        //// If the request included execution, the response map must contain an entry with key data.
+        //// The value of this entry is described in the "Data" section.
+        //// If the request failed before execution due to a syntax error, missing information,
+        //// or validation error, this entry must not be present.
+        assertThat(response, not(containsString("\"data\":")));
     }
 
 }


### PR DESCRIPTION
https://spec.graphql.org/draft/#sec-Response-Format
> If the request included execution, the response map must contain an entry with key data. The value of this entry is described in the “Data” section. If the request failed before execution due to a syntax error, missing information, or validation error, this entry must not be present.

The only exception is our bean validation, responses during an error contain this field:
```
"data" : {
    operationName: null
}
```

There was no need to change anything on the client side.


fix:#2081