### PR TITLE
Update Release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,47 @@
+name: SmallRye Prepare Release
+
+on:
+  pull_request:
+    types: [ closed ]
+    paths:
+      - '.github/project.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  prepare-gradle:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: git author
+        run: |
+          git config --global user.name "SmallRye CI"
+          git config --global user.email "smallrye@googlegroups.com"
+
+      - uses: radcortez/project-metadata-action@main
+        name: retrieve project metadata
+        id: metadata
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          metadata-file-path: '.github/project.yml'
+
+      - name: Prepare Gradle
+        run: |
+          echo "version=${{steps.metadata.outputs.current-version}}" > tools/gradle-plugin/gradle.properties
+          git add tools/gradle-plugin/gradle.properties
+          git commit -m "Update Gradle plugin version"
+          git push
+
+  prepare-release:
+    needs: [prepare-gradle]
+    name: Prepare Release
+    if: ${{ github.event.pull_request.merged == true}}
+    uses: smallrye/.github/.github/workflows/prepare-release.yml@main
+    secrets: inherit

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -1,0 +1,30 @@
+name: Publish Gradle
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        description: Tag version to perform release
+        type: string
+
+jobs:
+  publish-gradle:
+    name: Publish Gradle
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        name: checkout ${{inputs.version}}
+        with:
+          ref: ${{inputs.version}}
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: gradle release ${{inputs.version}}
+        run: |
+          mkdir -p ~/.gradle ; echo -e "gradle.publish.key=${{secrets.GRADLE_PUBLISH_KEY}}\ngradle.publish.secret=${{secrets.GRADLE_PUBLISH_SECRET}}" > ~/.gradle/gradle.properties
+          cd tools/gradle-plugin && gradle publishPlugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,71 +1,36 @@
 name: SmallRye Release
-
+run-name: Perform ${{github.event.inputs.tag || github.ref_name}} Release
 on:
-  pull_request:
-    types: [closed]
-    paths:
-      - '.github/project.yml'
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+
+permissions:
+  attestations: write
+  id-token: write
+  # Needed for the publish-* workflows
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    name: release
-    if: ${{github.event.pull_request.merged == true}}
-    env:
-      GITHUB_TOKEN: ${{secrets.RELEASE_TOKEN}}
+  perform-release:
+    name: Perform Release
+    uses: smallrye/.github/.github/workflows/perform-release.yml@main
+    secrets: inherit
+    with:
+      version: ${{github.event.inputs.tag || github.ref_name}}
 
-    steps:
-      - uses: radcortez/project-metadata-action@main
-        name: retrieve project metadata
-        id: metadata
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          metadata-file-path: '.github/project.yml'
-
-      - uses: actions/checkout@v2
-        with:
-          token: ${{secrets.RELEASE_TOKEN}}
-
-      - uses: actions/setup-java@v1.4.3
-        with:
-          java-version: 17
-          server-id: 'oss.sonatype'
-          server-username: 'MAVEN_DEPLOY_USERNAME'
-          server-password: 'MAVEN_DEPLOY_TOKEN'
-          gpg-private-key: ${{secrets.MAVEN_GPG_PRIVATE_KEY}}
-          gpg-passphrase: 'MAVEN_GPG_PASSPHRASE'
-
-      - name: Install graphviz
-        run: sudo apt install graphviz
-
-      - name: maven release ${{steps.metadata.outputs.current-version}}
-        env:
-          MAVEN_DEPLOY_USERNAME: ${{secrets.MAVEN_DEPLOY_USERNAME}}
-          MAVEN_DEPLOY_TOKEN: ${{secrets.MAVEN_DEPLOY_TOKEN}}
-          MAVEN_GPG_PASSPHRASE: ${{secrets.MAVEN_GPG_PASSPHRASE}}
-        run: |
-          java -version
-          git config --global user.name "SmallRye CI"
-          git config --global user.email "smallrye@googlegroups.com"
-          git checkout -b release
-          # update gradle version plugin
-          echo "version=${{steps.metadata.outputs.current-version}}" > tools/gradle-plugin/gradle.properties
-          git add tools/gradle-plugin/gradle.properties
-          git commit -m "Update Gradle plugin version"
-          mvn -X -e -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}
-          git checkout ${{github.base_ref}}
-          git rebase release
-          mvn -X -e -B release:perform -Prelease
-          git push
-          git push --tags
-
-      - name: Gradle plugin release ${{steps.metadata.outputs.current-version}}
-        run: |
-          mkdir -p ~/.gradle ; echo -e "gradle.publish.key=${{secrets.GRADLE_PUBLISH_KEY}}\ngradle.publish.secret=${{secrets.GRADLE_PUBLISH_SECRET}}" > ~/.gradle/gradle.properties
-          cd tools/gradle-plugin && gradle publishPlugins
-
-      - uses: radcortez/milestone-release-action@main
-        name: milestone release
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          milestone-title: ${{steps.metadata.outputs.current-version}}
+  publish-gradle:
+    name: Publish Gradle
+    uses: ./.github/workflows/publish-gradle.yml
+    secrets: inherit
+    with:
+      version: ${{github.event.inputs.tag || github.ref_name}}

--- a/.github/workflows/review-release.yml
+++ b/.github/workflows/review-release.yml
@@ -1,4 +1,4 @@
-name: SmallRye Pre Release
+name: SmallRye Review Release
 
 on:
   pull_request:
@@ -17,6 +17,12 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           metadata-file-path: '.github/project.yml'
+
+      - name: Validate version
+        if: contains(steps.metadata.outputs.current-version, 'SNAPSHOT')
+        run: |
+          echo '::error::Cannot release a SNAPSHOT version.'
+          exit 1
 
       - uses: radcortez/milestone-review-action@main
         name: milestone review

--- a/.github/workflows/update-milestone.yml
+++ b/.github/workflows/update-milestone.yml
@@ -1,0 +1,17 @@
+name: Update Milestone
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    name: update-milestone
+    if: ${{github.event.pull_request.merged == true}}
+
+    steps:
+      - uses: radcortez/milestone-set-action@main
+        name: milestone set
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
To use the new release process... I'm unsure if this will work on the first try (probably not :) and will require some adjustments).

This project also releases a Gradle plugin. I did that on the preparation workflow before executing the central one. The files should be updated and tagged:
https://github.com/smallrye/smallrye-graphql/pull/2236/files#diff-ddf2bab74923dcd43f9f8d05e50bb1adc9ee5366a394d151d1f04a54a6079486

There is a separate workflow that executes to do the actual Gradle release after the central one and tag:
https://github.com/smallrye/smallrye-graphql/pull/2236/files#diff-8d232d862a776c1047b335f66544717bd08e86abac7de606a02ffa018563476f

This also seems to require `graphviz` that most likely we don't have available in the central repo:
https://github.com/smallrye/smallrye-graphql/pull/2236/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L38-L39