### PR TITLE
Add support for @JsonbNillable

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/FieldInfo.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/reflection/FieldInfo.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Optional;
 
+import jakarta.json.bind.annotation.JsonbNillable;
 import jakarta.json.bind.annotation.JsonbProperty;
 
 import org.eclipse.microprofile.graphql.Name;
@@ -25,11 +26,16 @@ public class FieldInfo {
     FieldInfo(TypeInfo container, Field field) {
         this.container = container;
         this.field = field;
-        JsonbProperty jsonbPropertyAnnotation = field.getAnnotation(JsonbProperty.class);
-        if (jsonbPropertyAnnotation != null) {
-            includeIfNull = jsonbPropertyAnnotation.nillable();
+        JsonbNillable jsonbNillableAnnotation = field.getAnnotation(JsonbNillable.class);
+        if (jsonbNillableAnnotation != null) {
+            this.includeIfNull = true;
         } else {
-            includeIfNull = false;
+            JsonbProperty jsonbPropertyAnnotation = field.getAnnotation(JsonbProperty.class);
+            if (jsonbPropertyAnnotation != null) {
+                this.includeIfNull = jsonbPropertyAnnotation.nillable();
+            } else {
+                this.includeIfNull = false;
+            }
         }
         this.name = computeName();
     }

--- a/client/tck/src/main/java/tck/graphql/typesafe/NillableBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/NillableBehavior.java
@@ -1,0 +1,42 @@
+package tck.graphql.typesafe;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import org.eclipse.microprofile.graphql.Mutation;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
+
+class NillableBehavior {
+    private final TypesafeGraphQLClientFixture fixture = TypesafeGraphQLClientFixture.load();
+
+    @GraphQLClientApi
+    interface StringMutationApi {
+        @Mutation
+        String createSome(SomeInput s);
+    }
+
+    @Test
+    void nillableFieldsAreSet() {
+        fixture.returnsData("'createSome':'foo'");
+        StringMutationApi api = fixture.build(StringMutationApi.class);
+
+        String response = api.createSome(new SomeInput("all", "a", "b", "c"));
+
+        then(fixture.query()).isEqualTo("mutation createSome($s: SomeInput) { createSome(s: $s) }");
+        then(fixture.variables()).isEqualTo("{'s':{'name':'all','first':'a','second':'b','third':'c'}}");
+        then(response).isEqualTo("foo");
+    }
+
+    @Test
+    void nillableFieldsAreNull() {
+        fixture.returnsData("'createSome':'bar'");
+        StringMutationApi api = fixture.build(StringMutationApi.class);
+
+        String response = api.createSome(new SomeInput("none"));
+
+        then(fixture.query()).isEqualTo("mutation createSome($s: SomeInput) { createSome(s: $s) }");
+        then(fixture.variables()).isEqualTo("{'s':{'name':'none','second':null,'third':null}}");
+        then(response).isEqualTo("bar");
+    }
+}

--- a/client/tck/src/main/java/tck/graphql/typesafe/SomeInput.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/SomeInput.java
@@ -1,0 +1,47 @@
+package tck.graphql.typesafe;
+
+import java.util.Objects;
+
+import jakarta.json.bind.annotation.JsonbNillable;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import org.eclipse.microprofile.graphql.Input;
+
+@Input("SomeInput")
+public class SomeInput {
+    private String name;
+
+    @JsonbProperty("first")
+    private String firstAtrribute;
+
+    @JsonbProperty(value = "second", nillable = true)
+    private String secondAtrribute;
+
+    @JsonbNillable
+    private String third;
+
+    public SomeInput() {
+    }
+
+    public SomeInput(String name) {
+        this.name = name;
+    }
+
+    public SomeInput(String name, String first, String second, String third) {
+        this.name = name;
+        this.firstAtrribute = first;
+        this.secondAtrribute = second;
+        this.third = third;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, firstAtrribute, secondAtrribute, third);
+    }
+
+    @Override
+    public String toString() {
+        return "SomeInput [name=" + name + ", firstAtrribute=" + firstAtrribute + ", secondAtrribute=" + secondAtrribute
+                + ", third=" + third + "]";
+    }
+}


### PR DESCRIPTION
If you want the type-safe client to send an explicit null value to the server,  you can do this:

```java
    /**
     * Fixed due date for the work item.
     */
    @JsonbProperty(value = "dueDateFixed", nillable = true)
    private Date dueDateFixed;
```

This works fine as discussed in https://github.com/smallrye/smallrye-graphql/issues/2251 but the `nillable` attribute is deprecated in [`@JsonbProperty`](https://jakarta.ee/specifications/jsonb/3.0/apidocs/jakarta.json.bind/jakarta/json/bind/annotation/jsonbproperty#nillable())

This PR adds support for @JsonbNillable that can be used like this:

```java
    /**
     * Fixed due date for the work item.
     */
    @JsonbNillable
    private Date dueDateFixed;
```


Fixes https://github.com/smallrye/smallrye-graphql/issues/2253
