### PR TITLE
Update Java version in quality workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3.0.0
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: 'maven'
 


### PR DESCRIPTION
The quality workflow is failing because Java 17 is now mandatory to run the build:

```
Error:  Failed to execute goal net.revelc.code:impsort-maven-plugin:1.12.0:sort (sort-imports) on project smallrye-graphql-parent: Execution sort-imports of goal net.revelc.code:impsort-maven-plugin:1.12.0:sort failed: Unable to load the mojo 'sort' in the plugin 'net.revelc.code:impsort-maven-plugin:1.12.0' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: net/revelc/code/impsort/maven/plugin/SortMojo has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
Error:  -----------------------------------------------------
Error:  realm =    plugin>net.revelc.code:impsort-maven-plugin:1.12.0
Error:  strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
Error:  urls[0] = file:/home/runner/.m2/repository/net/revelc/code/impsort-maven-plugin/1.12.0/impsort-maven-plugin-1.12.0.jar
Error:  urls[1] = file:/home/runner/.m2/repository/com/github/javaparser/javaparser-core/3.26.2/javaparser-core-3.26.2.jar
Error:  urls[2] = file:/home/runner/.m2/repository/com/google/guava/guava/33.3.0-jre/guava-33.3.0-jre.jar
Error:  urls[3] = file:/home/runner/.m2/repository/com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.jar
Error:  urls[4] = file:/home/runner/.m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
Error:  urls[5] = file:/home/runner/.m2/repository/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar
Error:  urls[6] = file:/home/runner/.m2/repository/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.jar
Error:  urls[7] = file:/home/runner/.m2/repository/com/google/errorprone/error_prone_annotations/2.28.0/error_prone_annotations-2.28.0.jar
Error:  urls[8] = file:/home/runner/.m2/repository/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar
Error:  urls[9] = file:/home/runner/.m2/repository/org/codehaus/plexus/plexus-utils/4.0.1/plexus-utils-4.0.1.jar
Error:  Number of foreign imports: 1
Error:  import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
Error:  
Error:  -----------------------------------------------------
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
Error: Process completed with exit code 1.
```

source: https://github.com/smallrye/smallrye-graphql/actions/runs/12429957229/job/34704891918