### PR TITLE
Kotlin nullability feature for typesafe client (client model)

### DIFF
--- a/client/model-builder/pom.xml
+++ b/client/model-builder/pom.xml
@@ -50,6 +50,12 @@
             <artifactId>smallrye-graphql-api</artifactId>
             <scope>test</scope> <!--subscription annotation-->
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${version.kotlin}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -60,6 +66,41 @@
                 <configuration>
                     <parameters>true</parameters>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${version.kotlin.compiler}</version>
+                <executions>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <compilerPlugins>
+                        <plugin>all-open</plugin>
+                    </compilerPlugins>
+                    <args>
+                        <arg>-java-parameters</arg>
+                        <arg>-Xemit-jvm-type-annotations</arg>
+                    </args>
+                </configuration>
+
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${version.kotlin.compiler}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/ParameterModel.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/ParameterModel.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 
 import org.jboss.jandex.MethodParameterInfo;
 
+import io.smallrye.graphql.client.model.Annotations;
 import io.smallrye.graphql.client.model.Scalars;
 import io.smallrye.graphql.client.typesafe.api.Header;
 
@@ -179,11 +180,11 @@ public class ParameterModel implements NamedElement {
     /**
      * Adds an optional exclamation mark to the GraphQL input type name based on nullability.
      *
-     * @param type The {@link TypeModel} representing the type of the parameter.
      * @return An optional exclamation mark.
      */
     private String optionalExclamationMark(TypeModel type) {
-        return type.isNonNull() ? "!" : "";
+        // for some reason KOTLIN_NOT_NULL is not applied on type, but on parameter
+        return (parameter.hasAnnotation(Annotations.KOTLIN_NOT_NULL) || type.isNonNull()) ? "!" : "";
     }
 
     /**

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/TypeModel.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/TypeModel.java
@@ -141,7 +141,8 @@ public class TypeModel {
     public boolean isNonNull() {
         return isPrimitive() ||
                 type.hasAnnotation(Annotations.NON_NULL) ||
-                type.hasAnnotation(Annotations.JAKARTA_NON_NULL);
+                type.hasAnnotation(Annotations.JAKARTA_NON_NULL)
+                || type.hasAnnotation(Annotations.KOTLIN_NOT_NULL);
     }
 
     /**

--- a/client/model-builder/src/test/java/io/smallrye/graphql/client/model/ClientModelBuilderTest.java
+++ b/client/model-builder/src/test/java/io/smallrye/graphql/client/model/ClientModelBuilderTest.java
@@ -40,7 +40,7 @@ public class ClientModelBuilderTest {
     }
 
     @Test
-    void sclarClientModelTest() throws IOException {
+    void scalarClientModelTest() throws IOException {
         String configKey = "scalar";
         ClientModels clientModels = ClientModelBuilder.build(Index.of(ScalarClientApi.class));
         assertNotNull(clientModels.getClientModelByConfigKey(configKey));

--- a/client/model-builder/src/test/kotlin/ClientModelBuilderKotlinTest.kt
+++ b/client/model-builder/src/test/kotlin/ClientModelBuilderKotlinTest.kt
@@ -1,0 +1,43 @@
+package io.smallrye.graphql.client.model
+
+import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi
+import org.eclipse.microprofile.graphql.Query
+import org.jboss.jandex.Index
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+class ClientModelBuilderKotlinTest {
+    @GraphQLClientApi(configKey = "some-client")
+    interface ClientApi {
+        @Query
+        fun returnNonNullFloat(someFloat: Float): Float
+
+        @Query
+        fun returnNullableString(someString: String?): String?
+
+        @Query
+        fun returnList(list: List<String>): String
+
+        // fixme: nullability is bit inconsistent from kotlin
+
+    }
+
+    @Test
+    fun basicClientModelTest() {
+        val configKey = "some-client"
+        val clientModels = ClientModelBuilder.build(Index.of(ClientApi::class.java))
+        assertNotNull(clientModels)
+        val clientModel = clientModels.getClientModelByConfigKey(configKey)
+        assertNotNull(clientModel)
+        assertEquals(3, clientModel.operationMap.size)
+        assertOperation(clientModel, MethodKey("returnNonNullFloat", arrayOf(Float::class.java)), "query returnNonNullFloat(\$someFloat: Float!) { returnNonNullFloat(someFloat: \$someFloat) }")
+        assertOperation(clientModel, MethodKey("returnNullableString", arrayOf(String::class.java)), "query returnNullableString(\$someString: String) { returnNullableString(someString: \$someString) }")
+        assertOperation(clientModel, MethodKey("returnList", arrayOf(List::class.java)), "query returnList(\$list: [String!]!) { returnList(list: \$list) }")
+    }
+
+    private fun assertOperation(clientModel: ClientModel, methodKey: MethodKey, expectedQuery: String) {
+        val actualQuery = clientModel.operationMap[methodKey]
+        assertEquals(expectedQuery, actualQuery)
+    }
+}

--- a/common/schema-builder/pom.xml
+++ b/common/schema-builder/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>smallrye-graphql-schema-builder</artifactId>
     <name>SmallRye: GraphQL Common :: Schema Builder</name>
     <description>Creates the model from a Jandex index</description>
-        
+
     <dependencies>
 
         <!-- The API -->
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-metadata-jvm</artifactId>
-            <version>${version.kotlin.metadata.jvm}</version>
+            <version>${version.kotlin}</version>
         </dependency>
 
         <!-- Logging -->

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -1,0 +1,3 @@
+# SmallRye Graphql in Kotlin
+
+When working with SmallRye GraphQL in Kotlin, it is very important to use the `-Xemit-jvm-type-annotations` flag for the Kotlin compiler. This flag is important to generate the necessary annotations for reflection to work properly. The flag is supported as of Kotlin 1.3.70.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - Custom scalars: 'custom-scalar.md'
       - Inspecting executable directives: 'inspecting-executable-directives-on-server-side.md'
       - Namespaces: 'namespaces-on-server-side.md'
+      - Kotlin support: 'kotlin.md'
   - Typesafe client:
       - Basic usage: 'typesafe-client-usage.md'
       - Unions and Interfaces: 'typesafe-client-unions-and-interfaces.md'

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <version.kotlin.metadata.jvm>2.1.0</version.kotlin.metadata.jvm>
+        <version.kotlin>2.1.10</version.kotlin>
         <version.impsort.plugin>1.12.0</version.impsort.plugin>
         <version.kotlin.compiler>2.1.0</version.kotlin.compiler>
 


### PR DESCRIPTION
/cc @jmartisk
Ok, so with nullabilities in Kotlin, it is a bit complicated; when not having an `?` nullable operator for types, Kotlin automatically adds its own Kotlin `@NonNull` annotations, but not *ALWAYS*. For example, when having a `List<String>`, the annotation is only applied on the `List<>` part but not the argument String. So, making these two codes indistinguishable (via Jandex):
```kotlin
List<String?> // List<String>
```
On top of that, there are some weird behaviors like annotation is applied only on `MethodParameterInfo` and not the `Type` 

So, I only added a simple Kotlin nullability feature (see tests). So it can be consistent with the server side.
Java reflection implementation of typesafe client still does not have Kotlin nullability checking (todo?).

issue: #2142
@robp94