### PR TITLE
Skip empty types in union

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/QueryBuilder.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/QueryBuilder.java
@@ -95,6 +95,9 @@ public class QueryBuilder {
     }
 
     private String fieldsFragment(TypeInfo typeInfo) {
+        if (typeInfo.fields().findAny().isEmpty()) {
+            return "";
+        }
         return "... on " + typeInfo.getGraphQlTypeName() + fields(typeInfo);
     }
 

--- a/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/OperationModel.java
+++ b/client/model-builder/src/main/java/io/smallrye/graphql/client/model/helper/OperationModel.java
@@ -441,6 +441,9 @@ public class OperationModel implements NamedElement {
     }
 
     private String fieldsFragment(TypeModel type) {
+        if (type.fields().findAny().isEmpty()) {
+            return "";
+        }
         return "... on " + type.getGraphQlTypeName() + fields(type);
     }
 


### PR DESCRIPTION
In https://github.com/smallrye/smallrye-graphql/issues/2224 I have explained why currently you need to have as many `@JsonbSubtype` entries in `@JsonbTypeInfo` as interface.

This allow to create a query like this:
```graphql
query GetBooks {
  books {
    # __typename is added by the type-safe client to help with the deserialisation
    __typename
    ... on Textbook {
      title
      courses {
        # Only present in Textbook
        name
      }
    }
    ... on ColoringBook {
      title
      colors # Only present in ColoringBook
    }
  }
}
```
Source of the example: https://www.apollographql.com/docs/apollo-server/schema/unions-interfaces#querying-an-interface

---

In the Java client `Book` would be an interface and `Textbook` and `ColoringBook` the implementation.

Now if you are not interested at all by the attributes of `ColoringBook` you would want to create an empty class.

But currently the generated query is invalid, because it looks like this:

```graphql
    ... on ColoringBook {
    }
```

---

This PR is fixing this by not producing any fragment if the Type does not have fields.

For my concrete case https://github.com/smallrye/smallrye-graphql/issues/2224, the goal would be to reduce the generated query:

<details><summary>Currently generated query</summary>
<p>

```
query workItemsByReference(
  $arg0: ID = "jmini/a_project"
  $arg1: [String!]! = ["#1"]
  $arg2: NotesFilterType = ONLY_COMMENTS
) {
  workItemsByReference(contextNamespacePath: $arg0, refs: $arg1) {
    count
    nodes {
      archived
      closedAt
      confidential
      createdAt
      id
      iid
      lockVersion
      namespace {
        fullPath
        id
        visibility
      }
      reference
      state
      title
      updatedAt
      webUrl
      widgets {
        __typename
        ... on WorkItemWidgetAssignees {
          assignees {
            nodes {
              id
              username
            }
          }
          type
        }
        ... on WorkItemWidgetAwardEmoji {
          type
        }
        ... on WorkItemWidgetColor {
          type
        }
        ... on WorkItemWidgetCrmContacts {
          type
        }
        ... on WorkItemWidgetCurrentUserTodos {
          type
        }
        ... on WorkItemWidgetDescription {
          description
        }
        ... on WorkItemWidgetDesigns {
          type
        }
        ... on WorkItemWidgetDevelopment {
          type
        }
        ... on WorkItemWidgetEmailParticipants {
          type
        }
        ... on WorkItemWidgetHealthStatus {
          type
        }
        ... on WorkItemWidgetHierarchy {
          ancestors {
            count
            nodes {
              archived
              confidential
              createdAt
              id
              iid
              namespace {
                fullPath
                id
                visibility
              }
              reference
              state
              title
              webUrl
              workItemType {
                id
                name
              }
            }
          }
          children {
            count
            nodes {
              archived
              confidential
              createdAt
              id
              iid
              namespace {
                fullPath
                id
                visibility
              }
              reference
              state
              title
              webUrl
              workItemType {
                id
                name
              }
            }
          }
          parent {
            archived
            confidential
            createdAt
            id
            iid
            namespace {
              fullPath
              id
              visibility
            }
            reference
            state
            title
            webUrl
            workItemType {
              id
              name
            }
          }
        }
        ... on WorkItemWidgetIteration {
          type
        }
        ... on WorkItemWidgetLabels {
          labels {
            count
            nodes {
              color
              description
              id
              textColor
              title
            }
            pageInfo {
              endCursor
              hasNextPage
              startCursor
            }
          }
          type
        }
        ... on WorkItemWidgetLinkedItems {
          linkedItems {
            nodes {
              linkCreatedAt
              linkId
              linkType
              linkUpdatedAt
              workItem {
                archived
                confidential
                createdAt
                id
                iid
                namespace {
                  fullPath
                  id
                  visibility
                }
                reference
                state
                title
                webUrl
                workItemType {
                  id
                  name
                }
              }
            }
          }
          type
        }
        ... on WorkItemWidgetMilestone {
          type
        }
        ... on WorkItemWidgetNotes {
          discussions(filter: $arg2) {
            nodes {
              id
              notes {
                nodes {
                  author {
                    id
                    username
                  }
                  awardEmoji {
                    nodes {
                      name
                      unicode
                      unicodeVersion
                    }
                  }
                  body
                  id
                }
              }
            }
          }
          type
        }
        ... on WorkItemWidgetNotifications {
          type
        }
        ... on WorkItemWidgetParticipants {
          type
        }
        ... on WorkItemWidgetRolledupDates {
          type
        }
        ... on WorkItemWidgetStartAndDueDate {
          dueDate
          startDate
          type
        }
        ... on WorkItemWidgetStatus {
          status
        }
        ... on WorkItemWidgetTimeTracking {
          type
        }
        ... on WorkItemWidgetWeight {
          type
        }
      }
      workItemType {
        id
        name
      }
    }
  }
}

```

</p>
</details> 

This query is too big for the GraphQL server, but removing the non relevant widgets helps with the performance at server side:

<details><summary>Optimized query after this PR</summary>
<p>

```
query workItemsByReference(
  $arg0: ID = "jmini/a_project"
  $arg1: [String!]! = ["#1"]
  $arg2: NotesFilterType = ONLY_COMMENTS
) {
  workItemsByReference(contextNamespacePath: $arg0, refs: $arg1) {
    count
    nodes {
      archived
      closedAt
      confidential
      createdAt
      id
      iid
      lockVersion
      namespace {
        fullPath
        id
        visibility
      }
      reference
      state
      title
      updatedAt
      webUrl
      widgets {
        __typename
        ... on WorkItemWidgetAssignees {
          assignees {
            nodes {
              id
              username
            }
          }
          type
        }
        ... on WorkItemWidgetHierarchy {
          ancestors {
            count
            nodes {
              archived
              confidential
              createdAt
              id
              iid
              namespace {
                fullPath
                id
                visibility
              }
              reference
              state
              title
              webUrl
              workItemType {
                id
                name
              }
            }
          }
          children {
            count
            nodes {
              archived
              confidential
              createdAt
              id
              iid
              namespace {
                fullPath
                id
                visibility
              }
              reference
              state
              title
              webUrl
              workItemType {
                id
                name
              }
            }
          }
          parent {
            archived
            confidential
            createdAt
            id
            iid
            namespace {
              fullPath
              id
              visibility
            }
            reference
            state
            title
            webUrl
            workItemType {
              id
              name
            }
          }
        }
        ... on WorkItemWidgetLabels {
          labels {
            count
            nodes {
              color
              description
              id
              textColor
              title
            }
            pageInfo {
              endCursor
              hasNextPage
              startCursor
            }
          }
          type
        }
        ... on WorkItemWidgetLinkedItems {
          linkedItems {
            nodes {
              linkCreatedAt
              linkId
              linkType
              linkUpdatedAt
              workItem {
                archived
                confidential
                createdAt
                id
                iid
                namespace {
                  fullPath
                  id
                  visibility
                }
                reference
                state
                title
                webUrl
                workItemType {
                  id
                  name
                }
              }
            }
          }
          type
        }
        ... on WorkItemWidgetNotes {
          discussions(filter: $arg2) {
            nodes {
              id
              notes {
                nodes {
                  author {
                    id
                    username
                  }
                  awardEmoji {
                    nodes {
                      name
                      unicode
                      unicodeVersion
                    }
                  }
                  body
                  id
                }
              }
            }
          }
        }
      }
      workItemType {
        id
        name
      }
    }
  }
}
```

</p>
</details> 

Query can be tested without authentication in https://gitlab.com/-/graphql-explorer
