### PR TITLE
Fix for Cache Access on wrong Dataloader

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -303,7 +303,7 @@ public class ExecutionService {
         return operation.getArguments().stream().allMatch(Argument::isSourceArgument);
     }
 
-    private <KEY> CacheKey<KEY> getCacheKeyFunction(){
+    private <KEY> CacheKey<KEY> getCacheKeyFunction() {
         return new CacheKey<>() {
             @Override
             public Object getKey(KEY input) {
@@ -318,7 +318,7 @@ public class ExecutionService {
                             .stream()
                             .mapToInt(Object::hashCode)
                             .reduce(Integer::sum);
-                } catch (Exception e){
+                } catch (Exception e) {
                     log.transformError(e);
                 }
                 if (cacheKey.isEmpty()) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -314,6 +314,7 @@ public class ExecutionService {
             public Object getKeyWithContext(KEY input, Object context) {
                 OptionalInt cacheKey = OptionalInt.empty();
                 try {
+                    // summarize hashcodes of all arguments
                     cacheKey = ((List<?>) ((HashMap<?, ?>) context).get("arguments"))
                             .stream()
                             .mapToInt(Object::hashCode)
@@ -324,7 +325,8 @@ public class ExecutionService {
                 if (cacheKey.isEmpty()) {
                     return getKey(input);
                 }
-                return cacheKey.getAsInt();
+                // add the hashcode of the key itself
+                return cacheKey.getAsInt() + input.hashCode();
             }
         };
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionService.java
@@ -8,7 +8,6 @@ import java.util.*;
 import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.smallrye.graphql.schema.model.Argument;
 import jakarta.json.JsonObject;
 
 import org.dataloader.*;
@@ -39,6 +38,7 @@ import io.smallrye.graphql.execution.datafetcher.helper.BatchLoaderHelper;
 import io.smallrye.graphql.execution.error.ExceptionHandler;
 import io.smallrye.graphql.execution.error.UnparseableDocumentException;
 import io.smallrye.graphql.execution.event.EventEmitter;
+import io.smallrye.graphql.schema.model.Argument;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Schema;
 import io.smallrye.graphql.schema.model.Type;

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionTest.java
@@ -1,12 +1,14 @@
 package io.smallrye.graphql.execution;
 
-import io.smallrye.graphql.test.TestSourceConfiguration;
+import static org.junit.jupiter.api.Assertions.*;
+
 import jakarta.json.*;
+
 import org.assertj.core.api.AutoCloseableSoftAssertions;
 import org.eclipse.parsson.JsonPointerImpl;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import io.smallrye.graphql.test.TestSourceConfiguration;
 
 /**
  * Test a basic query

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionTest.java
@@ -65,9 +65,9 @@ public class ExecutionTest extends ExecutionTestBase {
         Boolean active2 = Boolean.valueOf(active2Pointer.getValue(data).toString());
 
         JsonPointer state1Pointer = new JsonPointerImpl("/objectsWithConfig1/0/configuredSources/configuration/state");
-        var state1 = TestSourceConfiguration.TestSourceState.valueOf(((JsonString)state1Pointer.getValue(data)).getString());
+        var state1 = TestSourceConfiguration.TestSourceState.valueOf(((JsonString) state1Pointer.getValue(data)).getString());
         JsonPointer state2Pointer = new JsonPointerImpl("/objectsWithConfig2/0/configuredSources/configuration/state");
-        var state2 = TestSourceConfiguration.TestSourceState.valueOf(((JsonString)state2Pointer.getValue(data)).getString());
+        var state2 = TestSourceConfiguration.TestSourceState.valueOf(((JsonString) state2Pointer.getValue(data)).getString());
 
         try (AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions()) {
             softly.assertThat(active1).isNotEqualTo(active2);

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/TestEndpoint.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/TestEndpoint.java
@@ -18,7 +18,7 @@ import io.smallrye.graphql.execution.context.SmallRyeContextManager;
 @GraphQLApi
 public class TestEndpoint {
 
-    private static final List<TestObject> persistedObjects = List.of(createTestObject("Alice"),createTestObject("Bob"));
+    private static final List<TestObject> persistedObjects = List.of(createTestObject("Alice"), createTestObject("Bob"));
 
     @Query
     public TestObject getTestObject(String yourname) {
@@ -30,7 +30,7 @@ public class TestEndpoint {
     public List<TestObject> getTestObjects() {
         TestObject p = createTestObject("Phillip");
         TestObject c = createTestObject("Charmaine");
-        return Arrays.asList(new TestObject[]{p, c});
+        return Arrays.asList(new TestObject[] { p, c });
     }
 
     @Query("testObjectsPersisted")
@@ -97,7 +97,8 @@ public class TestEndpoint {
     }
 
     @Name("configuredSources")
-    public List<TestSourceWithConfiguration> getTestSourcesWithConfiguration(@Source List<TestObject> testObjects, @NonNull TestSourceConfiguration configuration) {
+    public List<TestSourceWithConfiguration> getTestSourcesWithConfiguration(@Source List<TestObject> testObjects,
+            @NonNull TestSourceConfiguration configuration) {
         return testObjects.stream()
                 .map(testObject -> new TestSourceWithConfiguration(configuration))
                 .toList();

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/TestEndpoint.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/TestEndpoint.java
@@ -5,11 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import org.eclipse.microprofile.graphql.DefaultValue;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Name;
-import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.Source;
+import org.eclipse.microprofile.graphql.*;
 
 import io.smallrye.graphql.api.Context;
 import io.smallrye.graphql.execution.context.SmallRyeContextManager;
@@ -22,6 +18,8 @@ import io.smallrye.graphql.execution.context.SmallRyeContextManager;
 @GraphQLApi
 public class TestEndpoint {
 
+    private static final List<TestObject> persistedObjects = List.of(createTestObject("Alice"),createTestObject("Bob"));
+
     @Query
     public TestObject getTestObject(String yourname) {
         TestObject testObject = createTestObject(yourname);
@@ -32,7 +30,12 @@ public class TestEndpoint {
     public List<TestObject> getTestObjects() {
         TestObject p = createTestObject("Phillip");
         TestObject c = createTestObject("Charmaine");
-        return Arrays.asList(new TestObject[] { p, c });
+        return Arrays.asList(new TestObject[]{p, c});
+    }
+
+    @Query("testObjectsPersisted")
+    public List<TestObject> getTestObjectsPersisted() {
+        return persistedObjects;
     }
 
     @Query
@@ -93,6 +96,13 @@ public class TestEndpoint {
         return batched;
     }
 
+    @Name("configuredSources")
+    public List<TestSourceWithConfiguration> getTestSourcesWithConfiguration(@Source List<TestObject> testObjects, @NonNull TestSourceConfiguration configuration) {
+        return testObjects.stream()
+                .map(testObject -> new TestSourceWithConfiguration(configuration))
+                .toList();
+    }
+
     @Query
     public ContextInfo testContext() {
         Context context = SmallRyeContextManager.getCurrentSmallRyeContext();
@@ -106,7 +116,7 @@ public class TestEndpoint {
         return contextInfo;
     }
 
-    private TestObject createTestObject(String name) {
+    private static TestObject createTestObject(String name) {
         String id = UUID.randomUUID().toString();
         TestObject testObject = new TestObject();
         testObject.setId(id);

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/TestSourceConfiguration.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/TestSourceConfiguration.java
@@ -1,0 +1,16 @@
+package io.smallrye.graphql.test;
+
+import org.eclipse.microprofile.graphql.Enum;
+import org.eclipse.microprofile.graphql.Name;
+import org.eclipse.microprofile.graphql.Type;
+
+@Type("TestSourceConfiguration")
+public record TestSourceConfiguration(boolean active, @Name("state") TestSourceState state) {
+
+    @Enum("TestSourceState")
+    public enum TestSourceState {
+        PENDING,
+        IN_PROGRESS,
+        DONE
+    }
+}

--- a/server/implementation/src/test/java/io/smallrye/graphql/test/TestSourceWithConfiguration.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/test/TestSourceWithConfiguration.java
@@ -1,0 +1,8 @@
+package io.smallrye.graphql.test;
+
+import org.eclipse.microprofile.graphql.NonNull;
+import org.eclipse.microprofile.graphql.Type;
+
+@Type("TestSourceWithConfiguration")
+public record TestSourceWithConfiguration(@NonNull TestSourceConfiguration configuration) {
+}


### PR DESCRIPTION
Hello,

I have created a fix for an issue about the caching of dataloaders.

The issue appears specifically on batch requests using source queries with further arguments.

I have added a test to clarify the problem.

My proposed solution implements a CacheKey function in the dataloader options. This enables the DataLoaderOptions to correctly map the different queries to the corresponding entitites.

Please have a look.

I am looking forward to your feedback!

Best regards
Paul Seyerlein

EDIT: Just a small hint regarding the GithubActions. You can disable the download logging using "-ntp" on the maven command. See [https://jdriven.com/blog/2024/11/Mastering-Maven-Disable-Logging-Of-Progress-Downloading-Artifacts](https://jdriven.com/blog/2024/11/Mastering-Maven-Disable-Logging-Of-Progress-Downloading-Artifacts)