### PR TITLE
Introduce a BOM (Bill of Materials) for SmallRye GraphQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -509,6 +509,14 @@
                                 <includes>
                                     <include>io.smallrye:*</include>
                                 </includes>
+                                <excludes>
+                                    <exclude>io.smallrye:smallrye-graphql-integration-tests</exclude>
+                                    <exclude>io.smallrye:smallrye-graphql-client-generator-test</exclude>
+                                    <exclude>io.smallrye:smallrye-graphql-maven-plugin-tests</exclude>
+                                    <exclude>io.smallrye:smallrye-graphql-tck</exclude>
+                                    <exclude>io.smallrye:smallrye-graphql-client-tck</exclude>
+                                    <exclude>io.smallrye:smallrye-graphql-documentation</exclude>
+                                </excludes>
                             </modules>
                         </bom>
                     </boms>

--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,33 @@
                     <lineEnding>LF</lineEnding>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.sundr</groupId>
+                <artifactId>sundr-maven-plugin</artifactId>
+                <version>0.200.0</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <boms>
+                        <bom>
+                            <artifactId>smallrye-graphql-bom</artifactId>
+                            <name>SmallRye: GraphQL Bill Of Materials</name>
+
+                            <modules>
+                                <includes>
+                                    <include>io.smallrye:*</include>
+                                </includes>
+                            </modules>
+                        </bom>
+                    </boms>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-bom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Motivation

Currently, users who depend on multiple SmallRye GraphQL artifacts must explicitly specify the version for each dependency, as shown in the example below:

```
<dependency>
  <groupId>io.smallrye</groupId>
  <artifactId>smallrye-graphql-api</artifactId>
  <version>${smallrye-graphql.version}</version>
</dependency>
<dependency>
  <groupId>io.smallrye</groupId>
  <artifactId>smallrye-graphql-cdi</artifactId>
  <version>${smallrye-graphql.version}</version>
</dependency>
...
```

This approach introduces unnecessary complexity, especially when integrating SmallRye GraphQL via frameworks like Quarkus. If a user needs to override the SmallRye GraphQL version, they must do so for each individual artifact.
Solution

I have a list of 11 dependencies to make sure a override it all from quarkus graphql client.

This PR introduces a Bill of Materials (BOM) for SmallRye GraphQL, allowing users to manage all SmallRye GraphQL dependencies with a single import:

```
<dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>io.smallrye</groupId>
      <artifactId>smallrye-graphql-bom</artifactId>
      <version>${smallrye-graphql.version}</version>
      <type>pom</type>
      <scope>import</scope>
    </dependency>
  </dependencies>
</dependencyManagement>
```

With this change, users can:

- add SmallRye GraphQL dependencies without explicitly specifying versions:

```
<dependency>
  <groupId>io.smallrye</groupId>
  <artifactId>smallrye-graphql-client</artifactId>
</dependency>
```

- override smallrye-graphql version with a single entry on dependencyManagement

This simplifies version management and improves maintainability, making it easier to update SmallRye GraphQL across projects.

Impact

    Reduces the number of explicit version declarations needed in projects using SmallRye GraphQL.
    Simplifies dependency management for Quarkus users relying on quarkus-smallrye-graphql-client.
    Improves maintainability by centralizing version management in a BOM.

Let me know if you need any adjustments! 🚀