### PR TITLE
Add support for the client supporting serializing enum values

### DIFF
--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
@@ -70,6 +70,8 @@ public class RequestImpl implements Request {
                 varBuilder.add(k, (Long) v);
             } else if (v instanceof Double) {
                 varBuilder.add(k, (Double) v);
+            } else if (v instanceof Enum<?>) {
+                varBuilder.add(k, ((Enum<?>) v).name());
             } else if (v == null) {
                 varBuilder.addNull(k);
             } else {

--- a/client/implementation/src/test/java/io/smallrye/graphql/client/RequestImplTest.java
+++ b/client/implementation/src/test/java/io/smallrye/graphql/client/RequestImplTest.java
@@ -49,5 +49,18 @@ public class RequestImplTest {
         map.put("ids", arr);
         request.setVariable("key", map);
         assertEquals("{\"query\":\"example\",\"variables\":{\"key\":{\"ids\":[1,2]}}}", request.toJson());
+
+        request.setVariable("key", new TestRecord(TestEnum.TEST));
+        assertEquals("{\"query\":\"example\",\"variables\":{\"key\":{\"enumValue\":\"TEST\"}}}", request.toJson());
+
+        request.setVariable("key", TestEnum.TEST);
+        assertEquals("{\"query\":\"example\",\"variables\":{\"key\":\"TEST\"}}", request.toJson());
+    }
+
+    public record TestRecord(TestEnum enumValue) {
+    }
+
+    public enum TestEnum {
+        TEST
     }
 }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DummyEnum.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DummyEnum.java
@@ -1,0 +1,8 @@
+package io.smallrye.graphql.tests.client.dynamic;
+
+public enum DummyEnum {
+    ZERO,
+    ONE,
+    TWO,
+    THREE
+}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientApi.java
@@ -44,6 +44,13 @@ public class DynamicClientApi {
     }
 
     @Query
+    public Dummy queryWithArgument3(@Name(value = "obj") DummyEnum obj) {
+        Dummy ret = new Dummy();
+        ret.setInteger(obj.ordinal());
+        return ret;
+    }
+
+    @Query
     public Dummy withRenamedField() {
         Dummy ret = new Dummy();
         ret.setRenamedField("foo");

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientInjectionTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientInjectionTest.java
@@ -39,7 +39,7 @@ public class DynamicClientInjectionTest {
                         "dummy/mp-graphql/url=http://localhost:9090/client-injection-test/graphql\n" +
                                 "dummy/mp-graphql/header/My-Custom-Header=Header-Value"),
                         "META-INF/microprofile-config.properties")
-                .addClasses(DynamicClientApi.class, DummyObject.class, Dummy.class);
+                .addClasses(DynamicClientApi.class, DummyObject.class, DummyEnum.class, Dummy.class);
     }
 
     @Inject

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientSingleOperationsTestBase.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientSingleOperationsTestBase.java
@@ -36,7 +36,7 @@ public abstract class DynamicClientSingleOperationsTestBase {
     @Deployment
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class, "integration-test.war")
-                .addClasses(DynamicClientApi.class, DummyObject.class, Dummy.class);
+                .addClasses(DynamicClientApi.class, DummyObject.class, DummyEnum.class, Dummy.class);
     }
 
     @ArquillianResource
@@ -94,6 +94,17 @@ public abstract class DynamicClientSingleOperationsTestBase {
                 .getData();
         System.out.println(data);
         assertEquals("a", data.getJsonObject("queryWithArgument2").getJsonObject("dummyObject").getString("a"));
+    }
+
+    @Test
+    public void testStringQueryWithEnum() throws ExecutionException, InterruptedException {
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("x", DummyEnum.TWO);
+        JsonObject data = client
+                .executeSync("query($x: DummyEnum) {queryWithArgument3(obj: $x){integer}}", vars)
+                .getData();
+        System.out.println(data);
+        assertEquals(2, data.getJsonObject("queryWithArgument3").getInt("integer"));
     }
 
     @Test


### PR DESCRIPTION
Previously, if you tried to use an enum as a variable, it would error, as it would try to be serialized to JSON. As there was no applicable JSON serializer associated with this enum it would fail.

This changes makes sure that enums are serialized as a string.