### PR TITLE
Ensure that large messages sent over websockets are reassembled on the client

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
@@ -140,12 +140,12 @@ public class GraphQLTransportWSSubprotocolHandler implements WebSocketSubprotoco
             // make an effectively final copy of this value to use it in a lambda expression
             Cancellable finalTimeoutWaitingForConnectionAckMessage = timeoutWaitingForConnectionAckMessage;
 
-            webSocket.handler(text -> {
+            webSocket.textMessageHandler(text -> {
                 if (log.isTraceEnabled()) {
                     log.trace("<<< " + text);
                 }
                 try {
-                    JsonObject message = parseIncomingMessage(text.toString());
+                    JsonObject message = parseIncomingMessage(text);
                     MessageType messageType = getMessageType(message);
                     switch (messageType) {
                         case PING:

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
@@ -120,12 +120,12 @@ public class GraphQLWSSubprotocolHandler implements WebSocketSubprotocolHandler 
             // make an effectively final copy of this value to use it in a lambda expression
             Cancellable finalTimeoutWaitingForConnectionAckMessage = timeoutWaitingForConnectionAckMessage;
 
-            webSocket.handler(text -> {
+            webSocket.textMessageHandler(text -> {
                 if (log.isTraceEnabled()) {
                     log.trace("<<< " + text);
                 }
                 try {
-                    JsonObject message = parseIncomingMessage(text.toString());
+                    JsonObject message = parseIncomingMessage(text);
                     MessageType messageType = getMessageType(message);
                     switch (messageType) {
                         case GQL_CONNECTION_ERROR:

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientApi.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientApi.java
@@ -72,4 +72,11 @@ public class DynamicClientApi {
         return list;
     }
 
+    @Query
+    public Dummy longResponse() {
+        Dummy dummy = new Dummy();
+        dummy.setString("foo".repeat(500_000));
+        return dummy;
+    }
+
 }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientSingleOperationsOverWebsocketTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientSingleOperationsOverWebsocketTest.java
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith;
 
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClient;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClientBuilder;
+import io.vertx.ext.web.client.WebClientOptions;
 
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -17,6 +18,7 @@ public class DynamicClientSingleOperationsOverWebsocketTest extends DynamicClien
     public void prepare() {
         client = (VertxDynamicGraphQLClient) new VertxDynamicGraphQLClientBuilder()
                 .url(testingURL.toString() + "graphql")
+                .options(new WebClientOptions().setMaxWebSocketMessageSize(Integer.MAX_VALUE))
                 .executeSingleOperationsOverWebsocket(true)
                 .build();
     }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientSingleOperationsTestBase.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientSingleOperationsTestBase.java
@@ -202,4 +202,13 @@ public abstract class DynamicClientSingleOperationsTestBase {
         assertEquals("foo2", ret.get(1).getRenamedField());
     }
 
+    @Test
+    public void testLongPayloadResponse() throws ExecutionException, InterruptedException {
+        Document document = document(operation(
+                field("longResponse",
+                        field("string"))));
+        Response response = client.executeSync(document);
+        Dummy ret = response.getObject(Dummy.class, "longResponse");
+        assertEquals("foo".repeat(500_000), ret.getString());
+    }
 }


### PR DESCRIPTION
Currently, there is an issue when a message is sent over a websocket which is over the max frame size, that it is not correctly reassembled first. The current behaviour processes each frame of a message as a response, as opposed to joining the frames together first.

This change switches the handler() method to textMessageHandler() instead. This new method only passes the assembled message through.