### PR TITLE
Support non-object values for JSON scalars

### DIFF
--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
@@ -59,6 +59,7 @@ public class Scalars {
     private static final String IMPORT = "Import";
     private static final String POLICY = "Policy";
     private static final String SCOPE = "Scope";
+    private static final String JSON = "JSON";
 
     private Scalars() {
     }
@@ -120,7 +121,8 @@ public class Scalars {
     }
 
     public static void addJson() {
-        populateScalar("jakarta.json.JsonObject", "JSON", Object.class.getName());
+        populateScalar("jakarta.json.JsonValue", JSON, Object.class.getName());
+        populateScalar("jakarta.json.JsonObject", JSON, Object.class.getName());
     }
 
     static {


### PR DESCRIPTION
Extend support for JSON scalars, to include not only JSON objects, but also any other JSON value, like strings, numbers and arrays.