### PR TITLE
Update yasson to 3.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <version.smallrye-stork>2.3.2</version.smallrye-stork>
 
         <version.jakarta-json>2.1.2</version.jakarta-json>
-        <version.yasson>3.0.3</version.yasson>
+        <version.yasson>3.0.4</version.yasson>
         <version.jakarta-validation>3.0.2</version.jakarta-validation>
         <version.jakarta-annotation>2.1.1</version.jakarta-annotation>
         <version.jakarta.servlet>6.0.0</version.jakarta.servlet>

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/ExecutionTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import jakarta.json.*;
 
 import org.assertj.core.api.AutoCloseableSoftAssertions;
-import org.eclipse.parsson.JsonPointerImpl;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.graphql.test.TestSourceConfiguration;
@@ -61,15 +60,15 @@ public class ExecutionTest extends ExecutionTestBase {
     public void testBatchSourceConfigurationQuery() {
         JsonObject data = executeAndGetData(TEST_BATCH_SOURCE_CONFIGURATION_QUERY);
 
-        JsonPointer active1Pointer = new JsonPointerImpl("/objectsWithConfig1/0/configuredSources/configuration/active");
-        Boolean active1 = Boolean.valueOf(active1Pointer.getValue(data).toString());
-        JsonPointer active2Pointer = new JsonPointerImpl("/objectsWithConfig2/0/configuredSources/configuration/active");
-        Boolean active2 = Boolean.valueOf(active2Pointer.getValue(data).toString());
+        Boolean active1 = data.getJsonArray("objectsWithConfig1").get(0).asJsonObject().getJsonObject("configuredSources")
+                .getJsonObject("configuration").getBoolean("active");
+        Boolean active2 = data.getJsonArray("objectsWithConfig2").get(0).asJsonObject().getJsonObject("configuredSources")
+                .getJsonObject("configuration").getBoolean("active");
 
-        JsonPointer state1Pointer = new JsonPointerImpl("/objectsWithConfig1/0/configuredSources/configuration/state");
-        var state1 = TestSourceConfiguration.TestSourceState.valueOf(((JsonString) state1Pointer.getValue(data)).getString());
-        JsonPointer state2Pointer = new JsonPointerImpl("/objectsWithConfig2/0/configuredSources/configuration/state");
-        var state2 = TestSourceConfiguration.TestSourceState.valueOf(((JsonString) state2Pointer.getValue(data)).getString());
+        var state1 = TestSourceConfiguration.TestSourceState.valueOf(data.getJsonArray("objectsWithConfig1").get(0)
+                .asJsonObject().getJsonObject("configuredSources").getJsonObject("configuration").getString("state"));
+        var state2 = TestSourceConfiguration.TestSourceState.valueOf(data.getJsonArray("objectsWithConfig2").get(0)
+                .asJsonObject().getJsonObject("configuredSources").getJsonObject("configuration").getString("state"));
 
         try (AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions()) {
             softly.assertThat(active1).isNotEqualTo(active2);


### PR DESCRIPTION
Update yasson dependency to 3.0.4. This in turn also increased the version of parsson to 1.1.7.

We had some very strange JSON serialization issues occurring. After doing some digging, we bumped the yasson version, and it fixed the issue. We suspect that the issue was resolved with this change: https://github.com/eclipse-ee4j/parsson/pull/55