### PR TITLE
Make sure that exceptions are propagated when a WebSocket fails to open

### DIFF
--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
@@ -80,16 +80,17 @@ public class GraphQLWSSubprotocolHandler implements WebSocketSubprotocolHandler 
 
             webSocket.closeHandler((v) -> {
                 onClose.run();
+                Exception exception;
                 if (webSocket.closeStatusCode() != null) {
                     if (webSocket.closeStatusCode() == 1000) {
                         log.debug("WebSocket closed with status code 1000");
+                        exception = new UnexpectedCloseException("Connection closed before data was received", 1000);
                         // even if the status code is OK, any unfinished single-result operation
                         // should be marked as failed
-                        uniOperations.forEach((id, emitter) -> emitter.fail(
-                                new UnexpectedCloseException("Connection closed before data was received", 1000)));
+                        uniOperations.forEach((id, emitter) -> emitter.fail(exception));
                         multiOperations.forEach((id, emitter) -> emitter.complete());
                     } else {
-                        UnexpectedCloseException exception = new UnexpectedCloseException(
+                        exception = new UnexpectedCloseException(
                                 "Server closed the websocket connection with code: "
                                         + webSocket.closeStatusCode() + " and reason: " + webSocket.closeReason(),
                                 webSocket.closeStatusCode());
@@ -97,10 +98,12 @@ public class GraphQLWSSubprotocolHandler implements WebSocketSubprotocolHandler 
                         multiOperations.forEach((id, emitter) -> emitter.fail(exception));
                     }
                 } else {
-                    InvalidResponseException exception = new InvalidResponseException("Connection closed");
+                    exception = new InvalidResponseException("Connection closed");
                     uniOperations.forEach((id, emitter) -> emitter.fail(exception));
                     multiOperations.forEach((id, emitter) -> emitter.fail(exception));
                 }
+
+                initializationEmitter.fail(exception);
             });
             webSocket.exceptionHandler(this::failAllActiveOperationsWith);
 


### PR DESCRIPTION
If the WebSocket is closed before the CONNECTION_ACK is received, then the emitter is never notified, and anything trying to execute a query will hang indefinitely (unless a timeout is specified, but even then, you only get the timeout exception, instead of the actual reason your socket closed).