### PR TITLE
Remove @Specializes and @Priority annotations from CDISmallRyeContext

### DIFF
--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/context/CDISmallRyeContext.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/context/CDISmallRyeContext.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import jakarta.annotation.Priority;
-import jakarta.enterprise.inject.Specializes;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 
@@ -25,8 +23,6 @@ import io.smallrye.graphql.schema.model.Field;
  * This way, we make sure that an @Inject-ed SmallRyeContext is never cached and calls to it always check
  * if there is a new context instance assigned to the current thread.
  */
-@Specializes
-@Priority(Integer.MAX_VALUE)
 public class CDISmallRyeContext extends SmallRyeContext {
 
     public CDISmallRyeContext(String createdBy) {


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/pull/49834#issuecomment-3245332952

From what I can see, these two annotations have no real effect; the parent class is not even a CDI bean (since you are using `annotated` discovery mode and it bears no bean defining annotation).
It should therefore be safe to remove them.

In Quarkus, the specialization annotation would have been just ignored up until the above linked PR.
In CDI Full (such as Weld in WFLY) it would be taken into consideration but again, the parent class isn't a bean so there is nothing to specialize.
The `@Priority` also seems redundant as that's used for alternatives which is not the case of this class/bean either.

The only other case I can think of would be some heavy extension-based modification in application servers that I am unaware of - so I am hoping the CI here would expose those :)