### PR TITLE
Avoid unnecessary conversion of JsonValue objects

### DIFF
--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponse.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponse.java
@@ -159,6 +159,8 @@ public class ExecutionResponse {
         final JsonValue jsonValue;
         if (pojo == null) {
             return JsonValue.NULL;
+        } else if (pojo instanceof JsonValue) {
+            return (JsonValue) pojo;
         } else if (pojo instanceof Map) {
             JsonObjectBuilder jsonObjectBuilder = jsonObjectFactory.createObjectBuilder();
             Map<String, Object> map = (Map<String, Object>) pojo;


### PR DESCRIPTION
When returning `JSON` scalar data from a field, we can return the `JsonValue` object as is, without recursively traversing the pojo.

This makes a difference when the field payload is large, as it avoids performing unnecessary work on the event loop thread. [Here](https://github.com/dpolysiou/smallrye-graphql-event-loop-blocking-reproducer) is an example where an unreasonably large field leads to blocking the event loop thread.