### PR TITLE
Build fixes for the 3.y.z branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version.smallrye-mutiny>3.2.0</version.smallrye-mutiny>
         <version.smallrye-mutiny-zero>1.2.0</version.smallrye-mutiny-zero>
         <version.smallrye-context-propagation>2.3.0</version.smallrye-context-propagation>
-        <version.smallrye-stork>2.7.9</version.smallrye-stork>
+        <version.smallrye-stork>3.0.0.beta2</version.smallrye-stork>
 
         <version.jakarta-json>2.1.3</version.jakarta-json>
         <version.yasson>3.0.4</version.yasson>

--- a/tools/gradle-plugin/build.gradle
+++ b/tools/gradle-plugin/build.gradle
@@ -28,17 +28,18 @@ repositories {
 
 dependencies {
     api gradleApi()
-    implementation "io.smallrye:jandex:3.0.0"
-    implementation "io.smallrye:smallrye-graphql:${version}"
-    implementation "io.smallrye:smallrye-graphql-schema-builder:${version}"
-    implementation "jakarta.json.bind:jakarta.json.bind-api:2.0.0"
-    implementation "jakarta.validation:jakarta.validation-api:3.0.2"
-    implementation "org.eclipse:yasson:2.0.4"
-    implementation "org.jboss.logging:jboss-logging:3.6.1.Final"
+    implementation enforcedPlatform("io.smallrye:smallrye-graphql-parent:${version}")
+    implementation "io.smallrye:jandex"
+    implementation "io.smallrye:smallrye-graphql"
+    implementation "io.smallrye:smallrye-graphql-schema-builder"
+    implementation "jakarta.json.bind:jakarta.json.bind-api"
+    implementation "jakarta.validation:jakarta.validation-api"
+    implementation "org.eclipse:yasson"
+    implementation "org.jboss.logging:jboss-logging"
 
     testImplementation gradleTestKit()
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.14.0'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 test {

--- a/tools/gradle-plugin/settings.gradle
+++ b/tools/gradle-plugin/settings.gradle
@@ -1,14 +1,14 @@
 plugins {
-    id "com.gradle.enterprise" version "3.19.2"
+    id "com.gradle.develocity" version "4.4.2"
 }
 
-gradleEnterprise {
+develocity {
     buildScan {
         // plugin configuration
-        //See also: https://docs.gradle.com/enterprise/gradle-plugin/
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service';
-        termsOfServiceAgree = 'yes'
-        publishOnFailure()
+        //See also: https://docs.gradle.com/develocity/gradle/4.4/gradle-plugin/
+        termsOfUseUrl = 'https://gradle.com/legal/gradle-technologies-terms-of-use/'
+        termsOfUseAgree = 'yes'
+        publishing.onlyIf { !it.buildResult.failures.empty }
     }
 }
 


### PR DESCRIPTION
Wanted to work on one issue, but there seem to be few issues regarding the build, so this PR attempts to fix them.
5f08e6ae17822758a41f0c5294d6705f099238dd and bdeaa693c294f85dc9716d52a8db36c517d14c68 might be worth backporting to 2.x.

Regarding the b6611d43df2c8dad9e6f8af5a726892109ff5caf, it contains the fix for the https://github.com/smallrye/smallrye-stork/issues/1201
Which was not backported 2.x, so either, a) we will ask for backport, or b) we would just use SR Stork 3.x instead, which I think is fine since it aligns with the Vertx 5 migration of SR GQL 3.x.