### PR TITLE
Fix type variable resolution for multi-level parameterized hierarchies.

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/FieldCreator.java
@@ -100,7 +100,8 @@ public class FieldCreator extends ModelCreator {
             Type fieldType = getFieldType(fieldInfo, methodType);
 
             Reference reference = referenceCreator.createReferenceForPojoField(fieldType, methodType,
-                    annotationsForPojo, direction, parentObjectReference);
+                    annotationsForPojo, direction, parentObjectReference,
+                    methodInfo.declaringClass().name().toString());
 
             Field field = new Field(methodInfo.name(), MethodHelper.getPropertyName(direction, methodInfo.name()), name,
                     reference);
@@ -126,7 +127,8 @@ public class FieldCreator extends ModelCreator {
         Type fieldType = getFieldType(fieldInfo, method.parameterType(position));
 
         Reference reference = referenceCreator.createReferenceForPojoField(fieldType,
-                method.parameterType(position), annotationsForPojo, Direction.IN, parentObjectReference);
+                method.parameterType(position), annotationsForPojo, Direction.IN, parentObjectReference,
+                method.declaringClass().name().toString());
 
         String fieldName = fieldInfo != null ? fieldInfo.name() : null;
         Field field = new Field(null, fieldName, name, reference);
@@ -157,7 +159,8 @@ public class FieldCreator extends ModelCreator {
             Type fieldType = getFieldType(fieldInfo);
 
             Reference reference = referenceCreator.createReferenceForPojoField(fieldType, fieldType,
-                    annotationsForPojo, direction, parentObjectReference);
+                    annotationsForPojo, direction, parentObjectReference,
+                    fieldInfo.declaringClass().name().toString());
 
             Field field = new Field(null,
                     fieldInfo.name(),

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/ReferenceCreator.java
@@ -1,7 +1,6 @@
 package io.smallrye.graphql.schema.creator;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -29,6 +28,7 @@ import io.smallrye.graphql.schema.helper.TypeAutoNameStrategy;
 import io.smallrye.graphql.schema.helper.TypeNameHelper;
 import io.smallrye.graphql.schema.model.AdaptTo;
 import io.smallrye.graphql.schema.model.AdaptWith;
+import io.smallrye.graphql.schema.model.ParametrizedTypeEntry;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Scalars;
@@ -179,7 +179,16 @@ public class ReferenceCreator {
             Annotations annotations,
             Direction direction,
             Reference parentObjectReference) {
-        return getReference(direction, fieldType, methodType, annotations, parentObjectReference);
+        return createReferenceForPojoField(fieldType, methodType, annotations, direction, parentObjectReference, null);
+    }
+
+    public Reference createReferenceForPojoField(Type fieldType,
+            Type methodType,
+            Annotations annotations,
+            Direction direction,
+            Reference parentObjectReference,
+            String declaringClassName) {
+        return getReference(direction, fieldType, methodType, annotations, parentObjectReference, declaringClassName);
     }
 
     /**
@@ -195,8 +204,7 @@ public class ReferenceCreator {
             ClassInfo classInfo,
             boolean createAdapedToType,
             boolean createAdapedWithType,
-            Map<String, Reference> classParametrizedTypes,
-            Map<String, Reference> extendedClassParametrizedTypes,
+            Map<String, ParametrizedTypeEntry> parametrizedTypes,
             boolean addParametrizedTypeNameExtension) {
 
         Annotations annotationsForClass = Annotations.getAnnotationsForClass(classInfo);
@@ -211,8 +219,7 @@ public class ReferenceCreator {
                 // TODO: First check the class annotations for @Type, if we get one that has that, use it, else any/all
                 // ?
 
-                // translate parametrizedTypeArgumentsReferences to match class implementing interface
-                Map<String, Reference> parametrizedTypeArgumentsReferencesImpl = null;
+                Map<String, ParametrizedTypeEntry> parametrizedTypeArgumentsReferencesImpl = null;
                 if (!classInfo.typeParameters().isEmpty()) {
                     ParameterizedType interfaceType = null;
                     for (Type it : impl.interfaceTypes()) {
@@ -220,22 +227,25 @@ public class ReferenceCreator {
                             interfaceType = it.asParameterizedType();
                         }
                     }
-                    parametrizedTypeArgumentsReferencesImpl = new HashMap<>();
+                    parametrizedTypeArgumentsReferencesImpl = new LinkedHashMap<>();
+                    String implClassName = impl.name().toString();
                     int i = 0;
                     for (TypeVariable tp : classInfo.typeParameters()) {
                         Type type = interfaceType.arguments().get(i++);
                         if (type.kind() == Type.Kind.TYPE_VARIABLE) {
-                            parametrizedTypeArgumentsReferencesImpl.put(
-                                    type.asTypeVariable().identifier(),
-                                    classParametrizedTypes.get(tp.identifier()));
+                            String implId = type.asTypeVariable().identifier();
+                            Reference ref = findReferenceByIdentifier(parametrizedTypes, tp.identifier());
+                            if (ref != null) {
+                                parametrizedTypeArgumentsReferencesImpl.put(
+                                        compositeKey(implClassName, implId),
+                                        new ParametrizedTypeEntry(implClassName, implId, ref));
+                            }
                         }
                     }
-
                 }
 
                 createReference(direction, impl, createAdapedToType, createAdapedWithType,
                         parametrizedTypeArgumentsReferencesImpl,
-                        null, // todo: maybe?
                         referenceType.equals(ReferenceType.INTERFACE));
             }
         }
@@ -244,7 +254,7 @@ public class ReferenceCreator {
                 annotationsForClass,
                 this.autoNameStrategy,
                 referenceType,
-                classParametrizedTypes);
+                addParametrizedTypeNameExtension ? parametrizedTypes : null);
 
         Reference existing = getIfExist(name, referenceType);
 
@@ -257,8 +267,7 @@ public class ReferenceCreator {
                 .className(className)
                 .name(name)
                 .type(referenceType)
-                .classParametrizedTypes(classParametrizedTypes)
-                .extendedClassParametrizedTypes(extendedClassParametrizedTypes)
+                .parametrizedTypes(parametrizedTypes)
                 .addParametrizedTypeNameExtension(addParametrizedTypeNameExtension)
                 .build();
 
@@ -309,6 +318,15 @@ public class ReferenceCreator {
             Type methodType,
             Annotations annotations,
             Reference parentObjectReference) {
+        return getReference(direction, fieldType, methodType, annotations, parentObjectReference, null);
+    }
+
+    private Reference getReference(Direction direction,
+            Type fieldType,
+            Type methodType,
+            Annotations annotations,
+            Reference parentObjectReference,
+            String declaringClassName) {
 
         // In some case, like operations and interfaces, there is no fieldType
         if (fieldType == null) {
@@ -335,27 +353,31 @@ public class ReferenceCreator {
             // Java Array
             Type typeInArray = fieldType.asArrayType().component();
             Type typeInMethodArray = methodType.asArrayType().component();
-            return getReference(direction, typeInArray, typeInMethodArray, annotations, parentObjectReference);
+            return getReference(direction, typeInArray, typeInMethodArray, annotations, parentObjectReference,
+                    declaringClassName);
         } else if (Classes.isCollection(fieldType) || Classes.isUnwrappedType(fieldType)) {
             // Collections and unwrapped types
             Type typeInCollection = fieldType.asParameterizedType().arguments().get(0);
             Type typeInMethodCollection = methodType.asParameterizedType().arguments().get(0);
-            return getReference(direction, typeInCollection, typeInMethodCollection, annotations, parentObjectReference);
+            return getReference(direction, typeInCollection, typeInMethodCollection, annotations, parentObjectReference,
+                    declaringClassName);
         } else if (Classes.isMap(fieldType)) {
             ParameterizedType parameterizedFieldType = fieldType.asParameterizedType();
             List<Type> fieldArguments = parameterizedFieldType.arguments();
             ParameterizedType entryType = ParameterizedType.create(Classes.ENTRY, fieldArguments.toArray(Type[]::new), null);
-            return getReference(direction, entryType, entryType, annotations, parentObjectReference);
+            return getReference(direction, entryType, entryType, annotations, parentObjectReference,
+                    declaringClassName);
         } else if (fieldType.kind().equals(Type.Kind.WILDCARD_TYPE)) {
             // <? extends Something>
             WildcardType wildcardType = fieldType.asWildcardType();
             Type extendsBound = wildcardType.extendsBound();
-            return getReference(direction, extendsBound, extendsBound, annotations, parentObjectReference);
+            return getReference(direction, extendsBound, extendsBound, annotations, parentObjectReference,
+                    declaringClassName);
         } else if (fieldType.kind().equals(Type.Kind.CLASS)) {
             ClassInfo classInfo = ScanningContext.getIndex().getClassByName(fieldType.name());
             if (classInfo != null) {
 
-                Map<String, Reference> extendedClassParametrizedTypeArgumentsReferences = null;
+                Map<String, ParametrizedTypeEntry> parametrizedTypeEntries = null;
                 ParameterizedType parametrizedParentType = findParametrizedParentType(classInfo);
                 if (parametrizedParentType != null) {
                     ClassInfo ci = ScanningContext.getIndex().getClassByName(parametrizedParentType.name());
@@ -364,7 +386,7 @@ public class ReferenceCreator {
                                 "No class info found for parametrizedParentType name [" + parametrizedParentType.name() + "]");
                     }
 
-                    extendedClassParametrizedTypeArgumentsReferences = collectParametrizedTypes(ci,
+                    parametrizedTypeEntries = collectParametrizedTypes(ci,
                             parametrizedParentType.arguments(),
                             direction, parentObjectReference);
                 }
@@ -372,8 +394,7 @@ public class ReferenceCreator {
                 boolean shouldCreateAdapedToType = AdaptToHelper.shouldCreateTypeInSchema(annotations);
                 boolean shouldCreateAdapedWithType = AdaptWithHelper.shouldCreateTypeInSchema(annotations);
                 return createReference(direction, classInfo, shouldCreateAdapedToType, shouldCreateAdapedWithType,
-                        null,
-                        extendedClassParametrizedTypeArgumentsReferences,
+                        parametrizedTypeEntries,
                         false);
             } else {
                 return getNonIndexedReference(direction, fieldType);
@@ -387,24 +408,31 @@ public class ReferenceCreator {
             if (classInfo != null) {
 
                 List<Type> parametrizedTypeArguments = fieldType.asParameterizedType().arguments();
-                Map<String, Reference> parametrizedTypeArgumentsReferences = collectParametrizedTypes(classInfo,
+                Map<String, ParametrizedTypeEntry> parametrizedTypeEntries = collectParametrizedTypes(classInfo,
                         parametrizedTypeArguments, direction, parentObjectReference);
                 boolean shouldCreateAdapedToType = AdaptToHelper.shouldCreateTypeInSchema(annotations);
                 boolean shouldCreateAdapedWithType = AdaptWithHelper.shouldCreateTypeInSchema(annotations);
                 return createReference(direction, classInfo, shouldCreateAdapedToType, shouldCreateAdapedWithType,
-                        parametrizedTypeArgumentsReferences, null, true);
+                        parametrizedTypeEntries, true);
             } else {
                 return getNonIndexedReference(direction, fieldType);
             }
         } else if (fieldType.kind().equals(Type.Kind.TYPE_VARIABLE)) {
-            if (parentObjectReference == null || parentObjectReference.getAllParametrizedTypes() == null) {
+            if (parentObjectReference == null || !parentObjectReference.hasParametrizedTypes()) {
                 throw new SchemaBuilderException("Don't know what to do with [" + fieldType + "] of kind [" + fieldType.kind()
                         + "] as parent object reference is missing or incomplete: " + parentObjectReference);
             }
 
-            LOG.debug("Type variable: " + fieldType.asTypeVariable().name() + " identifier: "
-                    + fieldType.asTypeVariable().identifier());
-            Reference ret = parentObjectReference.getAllParametrizedTypes().get(fieldType.asTypeVariable().identifier());
+            String identifier = fieldType.asTypeVariable().identifier();
+            LOG.debug("Type variable: " + fieldType.asTypeVariable().name() + " identifier: " + identifier);
+
+            Reference ret = null;
+            if (declaringClassName != null) {
+                ret = parentObjectReference.getParametrizedTypeByDeclaringClass(declaringClassName, identifier);
+            }
+            if (ret == null) {
+                ret = parentObjectReference.findByIdentifier(identifier);
+            }
 
             if (ret == null) {
                 throw new SchemaBuilderException("Don't know what to do with [" + fieldType + "] of kind [" + fieldType.kind()
@@ -418,36 +446,87 @@ public class ReferenceCreator {
         }
     }
 
-    private Map<String, Reference> collectParametrizedTypes(ClassInfo classInfo, List<? extends Type> parametrizedTypeArguments,
+    private Map<String, ParametrizedTypeEntry> collectParametrizedTypes(ClassInfo classInfo,
+            List<? extends Type> parametrizedTypeArguments,
             Direction direction, Reference parentObjectReference) {
-        Map<String, Reference> parametrizedTypeArgumentsReferences = null;
+        Map<String, ParametrizedTypeEntry> entries = null;
         if (parametrizedTypeArguments != null) {
-            List<TypeVariable> tvl = new ArrayList<>();
-            collectTypeVariables(tvl, classInfo);
-            parametrizedTypeArgumentsReferences = new LinkedHashMap<>();
+            List<TypeVariable> typeParams = classInfo.typeParameters();
+            entries = new LinkedHashMap<>();
+            String className = classInfo.name().toString();
             int i = 0;
             for (Type pat : parametrizedTypeArguments) {
-                if (i >= tvl.size()) {
+                if (i >= typeParams.size()) {
                     throw new SchemaBuilderException(
                             "List of type variables is not correct for class " + classInfo + " and generics argument " + pat);
                 } else {
-                    parametrizedTypeArgumentsReferences.put(tvl.get(i++).identifier(),
-                            getReference(direction, pat, null, null, parentObjectReference));
+                    String identifier = typeParams.get(i++).identifier();
+                    Reference ref = getReference(direction, pat, null, null, parentObjectReference);
+                    entries.put(compositeKey(className, identifier),
+                            new ParametrizedTypeEntry(className, identifier, ref));
                 }
             }
+            resolveAncestorTypeVariables(entries, classInfo, direction, parentObjectReference);
         }
-        return parametrizedTypeArgumentsReferences;
+        return entries;
     }
 
-    private void collectTypeVariables(List<TypeVariable> tvl, ClassInfo classInfo) {
-        if (classInfo == null)
-            return;
-        if (classInfo.typeParameters() != null) {
-            tvl.addAll(classInfo.typeParameters());
+    private String compositeKey(String className, String identifier) {
+        return className + ":" + identifier;
+    }
+
+    private Reference findReferenceByIdentifier(Map<String, ParametrizedTypeEntry> entries, String identifier) {
+        if (entries == null) {
+            return null;
         }
-        if (classInfo.superClassType() != null) {
-            collectTypeVariables(tvl, ScanningContext.getIndex().getClassByName(classInfo.superName()));
+        for (ParametrizedTypeEntry entry : entries.values()) {
+            if (entry.getIdentifier().equals(identifier)) {
+                return entry.getReference();
+            }
         }
+        return null;
+    }
+
+    private void resolveAncestorTypeVariables(Map<String, ParametrizedTypeEntry> resolved, ClassInfo classInfo,
+            Direction direction, Reference parentObjectReference) {
+        ClassInfo current = classInfo;
+        while (current != null && current.superClassType() != null) {
+            if (current.superClassType().kind() != Type.Kind.PARAMETERIZED_TYPE) {
+                current = ScanningContext.getIndex().getClassByName(current.superName());
+                continue;
+            }
+            ParameterizedType superType = current.superClassType().asParameterizedType();
+            current = ScanningContext.getIndex().getClassByName(superType.name());
+            if (current != null) {
+                mapSuperTypeParameters(resolved, current, superType, direction, parentObjectReference);
+            }
+        }
+    }
+
+    private void mapSuperTypeParameters(Map<String, ParametrizedTypeEntry> resolved, ClassInfo superClassInfo,
+            ParameterizedType superType, Direction direction, Reference parentObjectReference) {
+        List<TypeVariable> superTypeParams = superClassInfo.typeParameters();
+        List<Type> superArgs = superType.arguments();
+        String superClassName = superClassInfo.name().toString();
+        for (int i = 0; i < superTypeParams.size() && i < superArgs.size(); i++) {
+            String superParamId = superTypeParams.get(i).identifier();
+            String key = compositeKey(superClassName, superParamId);
+            if (resolved.containsKey(key)) {
+                continue;
+            }
+            Reference ref = resolveTypeArgument(superArgs.get(i), resolved, direction, parentObjectReference);
+            if (ref != null) {
+                resolved.put(key, new ParametrizedTypeEntry(superClassName, superParamId, ref));
+            }
+        }
+    }
+
+    private Reference resolveTypeArgument(Type arg, Map<String, ParametrizedTypeEntry> resolved,
+            Direction direction, Reference parentObjectReference) {
+        if (arg.kind() == Type.Kind.TYPE_VARIABLE) {
+            return findReferenceByIdentifier(resolved, arg.asTypeVariable().identifier());
+        }
+        return getReference(direction, arg, null, null, parentObjectReference);
     }
 
     private ParameterizedType findParametrizedParentType(ClassInfo classInfo) {

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/AbstractCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/AbstractCreator.java
@@ -57,7 +57,7 @@ abstract class AbstractCreator implements Creator<Type> {
                 annotations,
                 referenceCreator.getTypeAutoNameStrategy(),
                 referenceType(),
-                reference.getClassParametrizedTypes());
+                reference.isAddParametrizedTypeNameExtension() ? reference.getParametrizedTypes() : null);
 
         // Description
         String description = DescriptionHelper.getDescriptionForType(annotations).orElse(null);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/EnumCreator.java
@@ -56,7 +56,7 @@ public class EnumCreator implements Creator<EnumType> {
                 annotations,
                 autoNameStrategy,
                 ReferenceType.ENUM,
-                reference.getAllParametrizedTypes());
+                reference.getParametrizedTypes());
 
         // Description
         Optional<String> maybeDescription = DescriptionHelper.getDescriptionForType(annotations);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/InputTypeCreator.java
@@ -61,7 +61,7 @@ public class InputTypeCreator implements Creator<InputType> {
                 annotations,
                 fieldCreator.getTypeAutoNameStrategy(),
                 ReferenceType.INPUT,
-                reference.getClassParametrizedTypes());
+                reference.isAddParametrizedTypeNameExtension() ? reference.getParametrizedTypes() : null);
 
         // Description
         String description = DescriptionHelper.getDescriptionForType(annotations).orElse(null);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/UnionCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/type/UnionCreator.java
@@ -38,7 +38,7 @@ public class UnionCreator implements Creator<UnionType> {
                 annotations,
                 referenceCreator.getTypeAutoNameStrategy(),
                 ReferenceType.UNION,
-                reference.getAllParametrizedTypes());
+                reference.getParametrizedTypes());
 
         // Description
         Optional<String> maybeDescription = DescriptionHelper.getDescriptionForType(annotations);

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/TypeNameHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/TypeNameHelper.java
@@ -1,6 +1,8 @@
 package io.smallrye.graphql.schema.helper;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
@@ -10,7 +12,7 @@ import org.jboss.logging.Logger;
 
 import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.Classes;
-import io.smallrye.graphql.schema.model.Reference;
+import io.smallrye.graphql.schema.model.ParametrizedTypeEntry;
 import io.smallrye.graphql.schema.model.ReferenceType;
 
 /**
@@ -51,9 +53,9 @@ public class TypeNameHelper {
             Annotations annotationsForThisClass,
             TypeAutoNameStrategy autoNameStrategy,
             ReferenceType referenceType,
-            Map<String, Reference> classParametrizedTypes) {
+            Map<String, ParametrizedTypeEntry> parametrizedTypes) {
 
-        String parametrizedTypeNameExtension = createParametrizedTypeNameExtension(classParametrizedTypes);
+        String parametrizedTypeNameExtension = createParametrizedTypeNameExtension(parametrizedTypes);
 
         if (Classes.isEnum(classInfo)) {
             return getNameForClassType(classInfo, annotationsForThisClass, Annotations.ENUM, parametrizedTypeNameExtension,
@@ -75,13 +77,16 @@ public class TypeNameHelper {
         }
     }
 
-    public static String createParametrizedTypeNameExtension(Map<String, Reference> classParametrizedTypes) {
-        if (classParametrizedTypes == null || classParametrizedTypes.isEmpty())
+    public static String createParametrizedTypeNameExtension(Map<String, ParametrizedTypeEntry> parametrizedTypes) {
+        if (parametrizedTypes == null || parametrizedTypes.isEmpty())
             return null;
         StringBuilder sb = new StringBuilder();
-        for (Reference gp : classParametrizedTypes.values()) {
-            sb.append(UNDERSCORE);
-            sb.append(gp.getName());
+        Set<String> seen = new LinkedHashSet<>();
+        for (ParametrizedTypeEntry entry : parametrizedTypes.values()) {
+            if (seen.add(entry.getIdentifier())) {
+                sb.append(UNDERSCORE);
+                sb.append(entry.getReference().getName());
+            }
         }
         return sb.toString();
     }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -445,39 +445,102 @@ public class SchemaBuilderTest {
         Map<String, Type> outputTypes = schema.getTypes();
         Map<String, InputType> inputTypes = schema.getInputs();
 
-        assertEquals(7, queries.size());
-        assertEquals(8, outputTypes.size());
-        assertEquals(8, inputTypes.size());
+        assertEquals(13, queries.size());
+        assertEquals(14, outputTypes.size());
+        assertEquals(14, inputTypes.size());
 
-        assertType(outputTypes, "Bar", Set.of(new Pair("Int", "barField")));
-        assertType(outputTypes, "FirstClass",
-                Set.of(new Pair("Int", "firstClassField"), new Pair<>("Bar", "secondClassField")));
-        assertType(outputTypes, "SecondClass_Bar", Set.of(new Pair("Bar", "secondClassField")));
-        assertType(outputTypes, "ThirdClass_String",
-                Set.of(new Pair("String", "secondClassField"), new Pair("String", "thirdClassField")));
-        assertType(outputTypes, "FourthClass",
-                Set.of(new Pair("String", "fourthClassField"), new Pair("Bar", "fifthClassField1"),
-                        new Pair("String", "fifthClassField2")));
-        assertType(outputTypes, "FifthClass_Bar_String",
-                Set.of(new Pair("Bar", "fifthClassField1"), new Pair("String", "fifthClassField2")));
-        assertType(outputTypes, "NewFirstClass",
-                Set.of(new Pair("Float", "renamedFirstClassField"), new Pair<>("Bar", "secondClassField")));
-        assertType(outputTypes, "NewSecondClass_Bar", Set.of(new Pair("Bar", "renamedSecondClassField")));
+        assertType(outputTypes, "Bar", Map.of("barField", "Int!"));
+        assertType(outputTypes, "FirstClass", Map.of(
+                "firstClassField", "Int!",
+                "secondClassField", "Bar"));
+        assertType(outputTypes, "SecondClass_Bar", Map.of("secondClassField", "Bar"));
+        assertType(outputTypes, "ThirdClass_String", Map.of(
+                "secondClassField", "String",
+                "thirdClassField", "String"));
+        assertType(outputTypes, "FourthClass", Map.of(
+                "fourthClassField", "String",
+                "fifthClassField1", "Bar",
+                "fifthClassField2", "String"));
+        assertType(outputTypes, "FifthClass_Bar_String", Map.of(
+                "fifthClassField1", "Bar",
+                "fifthClassField2", "String"));
+        assertType(outputTypes, "NewFirstClass", Map.of(
+                "renamedFirstClassField", "Float!",
+                "secondClassField", "Bar"));
+        assertType(outputTypes, "NewSecondClass_Bar", Map.of("renamedSecondClassField", "Bar"));
 
-        assertType(inputTypes, "BarInput", Set.of(new Pair("Int", "barField")));
-        assertType(inputTypes, "FirstClassInput",
-                Set.of(new Pair("Int", "firstClassField"), new Pair<>("BarInput", "secondClassField")));
-        assertType(inputTypes, "SecondClass_BarInputInput", Set.of(new Pair("BarInput", "secondClassField")));
-        assertType(inputTypes, "ThirdClass_StringInput",
-                Set.of(new Pair("String", "secondClassField"), new Pair("String", "thirdClassField")));
-        assertType(inputTypes, "FourthClassInput",
-                Set.of(new Pair("String", "fourthClassField"), new Pair("BarInput", "fifthClassField1"),
-                        new Pair("String", "fifthClassField2")));
-        assertType(inputTypes, "FifthClass_String_BarInputInput",
-                Set.of(new Pair("String", "fifthClassField1"), new Pair("BarInput", "fifthClassField2")));
-        assertType(inputTypes, "NewFirstClassInput",
-                Set.of(new Pair("Float", "renamedFirstClassField"), new Pair<>("BarInput", "secondClassField")));
-        assertType(inputTypes, "NewSecondClassInput_BarInput", Set.of(new Pair("BarInput", "renamedSecondClassField")));
+        assertType(inputTypes, "BarInput", Map.of("barField", "Int!"));
+        assertType(inputTypes, "FirstClassInput", Map.of(
+                "firstClassField", "Int!",
+                "secondClassField", "BarInput"));
+        assertType(inputTypes, "SecondClass_BarInputInput", Map.of("secondClassField", "BarInput"));
+        assertType(inputTypes, "ThirdClass_StringInput", Map.of(
+                "secondClassField", "String",
+                "thirdClassField", "String"));
+        assertType(inputTypes, "FourthClassInput", Map.of(
+                "fourthClassField", "String",
+                "fifthClassField1", "BarInput",
+                "fifthClassField2", "String"));
+        assertType(inputTypes, "FifthClass_String_BarInputInput", Map.of(
+                "fifthClassField1", "String",
+                "fifthClassField2", "BarInput"));
+        assertType(inputTypes, "NewFirstClassInput", Map.of(
+                "renamedFirstClassField", "Float!",
+                "secondClassField", "BarInput"));
+        assertType(inputTypes, "NewSecondClassInput_BarInput", Map.of("renamedSecondClassField", "BarInput"));
+
+        // GenericLeaf -> GenericSpecialized<Integer> -> GenericMiddle<Integer> ->
+        // GenericBase<Integer>
+        assertType(outputTypes, "GenericLeaf", Map.of(
+                "baseField", "Int",
+                "baseArrayField", "[Int]"));
+        assertType(inputTypes, "GenericLeafInput", Map.of(
+                "baseField", "Int",
+                "baseArrayField", "[Int]"));
+
+        // GenericMiddle<String> used directly in query; B->String must propagate to
+        // GenericBase's A->String
+        assertType(outputTypes, "GenericMiddle_String_String", Map.of(
+                "baseField", "String",
+                "baseArrayField", "[String]"));
+        assertType(inputTypes, "GenericMiddle_String_StringInput", Map.of(
+                "baseField", "String",
+                "baseArrayField", "[String]"));
+
+        // FullyConcretePair -> HalfConcretePair<Bar> -> GenericPair<Bar, String>
+        assertType(outputTypes, "FullyConcretePair", Map.of(
+                "first", "Bar",
+                "second", "String"));
+        assertType(inputTypes, "FullyConcretePairInput", Map.of(
+                "first", "BarInput",
+                "second", "String"));
+
+        // ConcreteFromNonGeneric -> NonGenericMiddle -> GenericRoot<String>
+        assertType(outputTypes, "ConcreteFromNonGeneric", Map.of(
+                "rootField", "String",
+                "concreteField", "Int!"));
+        assertType(inputTypes, "ConcreteFromNonGenericInput", Map.of(
+                "rootField", "String",
+                "concreteField", "Int!"));
+
+        assertType(outputTypes, "LeafFromMiddleWithT", Map.of(
+                "middleValue", "String",
+                "middleArrayValue", "[String]",
+                "baseValue", "Int"));
+        assertType(inputTypes, "LeafFromMiddleWithTInput", Map.of(
+                "middleValue", "String",
+                "middleArrayValue", "[String]",
+                "baseValue", "Int"));
+
+        // NestedCollections — List<Integer>, List<List<Integer>>, List<List<List<Integer>>>
+        assertType(outputTypes, "NestedCollections", Map.of(
+                "singleList", "[Int]",
+                "doubleList", "[[Int]]",
+                "tripleList", "[[[Int]]]"));
+        assertType(inputTypes, "NestedCollectionsInput", Map.of(
+                "singleList", "[Int]",
+                "doubleList", "[[Int]]",
+                "tripleList", "[[[Int]]]"));
     }
 
     private Operation getQueryByName(Schema schema, String name) {
@@ -519,48 +582,21 @@ public class SchemaBuilderTest {
         }
     }
 
-    private void assertType(Map<String, ? extends Reference> types, String typeName, Set<Pair<String, String>> expectedFields) {
+    private void assertType(Map<String, ? extends Reference> types, String typeName,
+            Map<String, String> expectedFields) {
         Reference type = types.get(typeName);
-        assertNotNull(type);
+        assertNotNull(type, "Type '" + typeName + "' not found in schema");
 
         final Map<String, Field> fields = (type instanceof Type) ? ((Type) type).getFields() : ((InputType) type).getFields();
 
         assertNotNull(fields);
         assertEquals(expectedFields.size(), fields.size());
 
-        expectedFields.forEach((expectedField) -> {
-            Field actualField = fields.get(expectedField.getVal2());
-            assertNotNull(actualField);
-            assertEquals(expectedField.getVal1(), actualField.getReference().getName());
+        expectedFields.forEach((fieldName, expectedGraphQLType) -> {
+            Field actualField = fields.get(fieldName);
+            assertNotNull(actualField, "Field '" + fieldName + "' not found in type '" + typeName + "'");
+            assertEquals(expectedGraphQLType, actualField.getGraphQLType(),
+                    "Field '" + fieldName + "' in type '" + typeName + "'");
         });
-    }
-
-    private static class Pair<K, V> {
-        private K val1;
-        private V val2;
-
-        public K getVal1() {
-            return val1;
-        }
-
-        public void setVal1(K val1) {
-            this.val1 = val1;
-        }
-
-        public V getVal2() {
-            return val2;
-        }
-
-        public void setVal2(V val2) {
-            this.val2 = val2;
-        }
-
-        public Pair(K val1, V val2) {
-            this.val1 = val1;
-            this.val2 = val2;
-        }
-
-        public Pair() {
-        }
     }
 }

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/generic/parametrized/ParametrizedTypesResources.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/generic/parametrized/ParametrizedTypesResources.java
@@ -1,5 +1,7 @@
 package io.smallrye.graphql.index.generic.parametrized;
 
+import java.util.List;
+
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Input;
 import org.eclipse.microprofile.graphql.Query;
@@ -175,6 +177,228 @@ public class ParametrizedTypesResources {
 
     @Query
     public RenamedSecondClass<Bar> seventhQuery(RenamedSecondClass<Bar> renamedSecondClass) {
+        return null;
+    }
+
+    static class GenericBase<A> {
+        A baseField;
+        A[] baseArrayField;
+
+        public GenericBase() {
+        }
+
+        public A getBaseField() {
+            return baseField;
+        }
+
+        public void setBaseField(A baseField) {
+            this.baseField = baseField;
+        }
+
+        public A[] getBaseArrayField() {
+            return baseArrayField;
+        }
+
+        public void setBaseArrayField(A[] baseArrayField) {
+            this.baseArrayField = baseArrayField;
+        }
+    }
+
+    static class GenericMiddle<B> extends GenericBase<B> {
+
+        public GenericMiddle() {
+        }
+    }
+
+    static class GenericSpecialized<C extends Number> extends GenericMiddle<C> {
+
+        public GenericSpecialized() {
+        }
+    }
+
+    static class GenericLeaf extends GenericSpecialized<Integer> {
+
+        public GenericLeaf() {
+        }
+    }
+
+    static class GenericPair<X, Y> {
+        X first;
+        Y second;
+
+        public GenericPair() {
+        }
+
+        public X getFirst() {
+            return first;
+        }
+
+        public void setFirst(X first) {
+            this.first = first;
+        }
+
+        public Y getSecond() {
+            return second;
+        }
+
+        public void setSecond(Y second) {
+            this.second = second;
+        }
+    }
+
+    static class HalfConcretePair<T> extends GenericPair<T, String> {
+
+        public HalfConcretePair() {
+        }
+    }
+
+    static class FullyConcretePair extends HalfConcretePair<Bar> {
+
+        public FullyConcretePair() {
+        }
+    }
+
+    static class GenericRoot<R> {
+        R rootField;
+
+        public GenericRoot() {
+        }
+
+        public R getRootField() {
+            return rootField;
+        }
+
+        public void setRootField(R rootField) {
+            this.rootField = rootField;
+        }
+    }
+
+    static class NonGenericMiddle extends GenericRoot<String> {
+
+        public NonGenericMiddle() {
+        }
+    }
+
+    static class ConcreteFromNonGeneric extends NonGenericMiddle {
+        int concreteField;
+
+        public ConcreteFromNonGeneric() {
+        }
+
+        public int getConcreteField() {
+            return concreteField;
+        }
+
+        public void setConcreteField(int concreteField) {
+            this.concreteField = concreteField;
+        }
+    }
+
+    static class BaseWithT<T> {
+        T baseValue;
+
+        public BaseWithT() {
+        }
+
+        public T getBaseValue() {
+            return baseValue;
+        }
+
+        public void setBaseValue(T baseValue) {
+            this.baseValue = baseValue;
+        }
+    }
+
+    static class MiddleWithT<T> extends BaseWithT<Integer> {
+        T middleValue;
+        T[] middleArrayValue;
+
+        public MiddleWithT() {
+        }
+
+        public T getMiddleValue() {
+            return middleValue;
+        }
+
+        public void setMiddleValue(T middleValue) {
+            this.middleValue = middleValue;
+        }
+
+        public T[] getMiddleArrayValue() {
+            return middleArrayValue;
+        }
+
+        public void setMiddleArrayValue(T[] middleArrayValue) {
+            this.middleArrayValue = middleArrayValue;
+        }
+    }
+
+    static class LeafFromMiddleWithT extends MiddleWithT<String> {
+
+        public LeafFromMiddleWithT() {
+        }
+    }
+
+    @Query
+    public GenericLeaf genericLeafQuery(GenericLeaf input) {
+        return null;
+    }
+
+    @Query
+    public GenericMiddle<String> genericMiddleQuery(GenericMiddle<String> input) {
+        return null;
+    }
+
+    @Query
+    public FullyConcretePair fullyConcretePairQuery(FullyConcretePair input) {
+        return null;
+    }
+
+    @Query
+    public ConcreteFromNonGeneric concreteFromNonGenericQuery(ConcreteFromNonGeneric input) {
+        return null;
+    }
+
+    @Query
+    public LeafFromMiddleWithT leafFromMiddleWithTQuery(LeafFromMiddleWithT input) {
+        return null;
+    }
+
+    static class NestedCollections {
+        List<Integer> singleList;
+        List<List<Integer>> doubleList;
+        List<List<List<Integer>>> tripleList;
+
+        public NestedCollections() {
+        }
+
+        public List<Integer> getSingleList() {
+            return singleList;
+        }
+
+        public void setSingleList(List<Integer> singleList) {
+            this.singleList = singleList;
+        }
+
+        public List<List<Integer>> getDoubleList() {
+            return doubleList;
+        }
+
+        public void setDoubleList(List<List<Integer>> doubleList) {
+            this.doubleList = doubleList;
+        }
+
+        public List<List<List<Integer>>> getTripleList() {
+            return tripleList;
+        }
+
+        public void setTripleList(List<List<List<Integer>>> tripleList) {
+            this.tripleList = tripleList;
+        }
+    }
+
+    @Query
+    public NestedCollections nestedCollectionsQuery(NestedCollections input) {
         return null;
     }
 

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/ReferenceCreatorTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/schema/creator/ReferenceCreatorTest.java
@@ -49,7 +49,7 @@ public class ReferenceCreatorTest {
                     reference.getGraphQLClassName());
             assertEquals(ReferenceType.INTERFACE, reference.getType());
             assertNull(reference.getAdaptTo());
-            assertFalse(reference.getAllParametrizedTypes().isEmpty());
+            assertTrue(reference.hasParametrizedTypes());
             assertTrue(reference.isAddParametrizedTypeNameExtension());
         } finally {
             ScanningContext.remove();

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Field.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Field.java
@@ -1,7 +1,9 @@
 package io.smallrye.graphql.schema.model;
 
 import java.io.Serializable;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
 
@@ -137,6 +139,43 @@ public class Field implements Serializable {
 
     public boolean hasWrapper() {
         return this.wrapper != null;
+    }
+
+    public String getGraphQLType() {
+        StringBuilder builder = new StringBuilder();
+
+        if (wrapper == null || !wrapper.isCollectionOrArrayOrMap()) {
+            builder.append(reference.getName());
+            if (notNull) {
+                builder.append('!');
+            }
+            return builder.toString();
+        }
+
+        Deque<Wrapper> stack = new ArrayDeque<>();
+        for (Wrapper w = wrapper; w != null; w = w.getWrapper()) {
+            if (!w.isCollectionOrArrayOrMap()) {
+                continue;
+            }
+            builder.append('[');
+            stack.push(w);
+        }
+
+        builder.append(reference.getName());
+
+        while (!stack.isEmpty()) {
+            Wrapper w = stack.pop();
+            if (w.isWrappedTypeNotNull()) {
+                builder.append('!');
+            }
+            builder.append(']');
+        }
+
+        if (notNull) {
+            builder.append('!');
+        }
+
+        return builder.toString();
     }
 
     public Transformation getTransformation() {

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/ParametrizedTypeEntry.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/ParametrizedTypeEntry.java
@@ -1,0 +1,50 @@
+package io.smallrye.graphql.schema.model;
+
+public class ParametrizedTypeEntry {
+
+    private String declaringClassName;
+    private String identifier;
+    private Reference reference;
+
+    public ParametrizedTypeEntry() {
+    }
+
+    public ParametrizedTypeEntry(String declaringClassName, String identifier, Reference reference) {
+        this.declaringClassName = declaringClassName;
+        this.identifier = identifier;
+        this.reference = reference;
+    }
+
+    public String getDeclaringClassName() {
+        return declaringClassName;
+    }
+
+    public void setDeclaringClassName(String declaringClassName) {
+        this.declaringClassName = declaringClassName;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public Reference getReference() {
+        return reference;
+    }
+
+    public void setReference(Reference reference) {
+        this.reference = reference;
+    }
+
+    @Override
+    public String toString() {
+        return "ParametrizedTypeEntry{" +
+                "declaringClassName=" + declaringClassName +
+                ", identifier=" + identifier +
+                ", reference=" + reference +
+                '}';
+    }
+}

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Reference.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Reference.java
@@ -1,12 +1,9 @@
 package io.smallrye.graphql.schema.model;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Represents a reference to some other type (type/input/enum/interface) This so that, as we are scanning, we can refer
@@ -22,8 +19,7 @@ public class Reference implements Serializable {
     private String graphQLClassName;
     private AdaptTo adaptTo = null; // If the type is mapped to a scalar
     private AdaptWith adaptWith = null; // If the type is mapped to another type with an adapter
-    private Map<String, Reference> classParametrizedTypes;
-    private Map<String, Reference> parentClassParametrizedTypes;
+    private Map<String, ParametrizedTypeEntry> parametrizedTypes;
     private boolean addParametrizedTypeNameExtension;
     private List<DirectiveInstance> directiveInstances;
 
@@ -49,8 +45,7 @@ public class Reference implements Serializable {
         this.graphQLClassName = builder.graphQLClassName;
         this.adaptTo = builder.adaptTo;
         this.adaptWith = builder.adaptWith;
-        this.classParametrizedTypes = builder.classParametrizedTypes;
-        this.parentClassParametrizedTypes = builder.parentClassParametrizedTypes;
+        this.parametrizedTypes = builder.parametrizedTypes;
         this.addParametrizedTypeNameExtension = builder.addParametrizedTypeNameExtension;
         this.directiveInstances = builder.directiveInstances;
         this.wrapper = builder.wrapper;
@@ -139,58 +134,37 @@ public class Reference implements Serializable {
         return this.adaptWith != null;
     }
 
-    public Map<String, Reference> getAllParametrizedTypes() {
-        if (classParametrizedTypes == null && parentClassParametrizedTypes == null) {
-            return new HashMap<>();
+    public Map<String, ParametrizedTypeEntry> getParametrizedTypes() {
+        return parametrizedTypes;
+    }
+
+    public void setParametrizedTypes(Map<String, ParametrizedTypeEntry> parametrizedTypes) {
+        this.parametrizedTypes = parametrizedTypes;
+    }
+
+    public boolean hasParametrizedTypes() {
+        return parametrizedTypes != null && !parametrizedTypes.isEmpty();
+    }
+
+    public Reference getParametrizedTypeByDeclaringClass(String declaringClassName, String identifier) {
+        if (parametrizedTypes == null) {
+            return null;
         }
-        if (classParametrizedTypes == null) {
-            return parentClassParametrizedTypes;
+        String key = declaringClassName + ":" + identifier;
+        ParametrizedTypeEntry entry = parametrizedTypes.get(key);
+        return entry != null ? entry.getReference() : null;
+    }
+
+    public Reference findByIdentifier(String identifier) {
+        if (parametrizedTypes == null) {
+            return null;
         }
-        if (parentClassParametrizedTypes == null) {
-            return classParametrizedTypes;
-        }
-
-        // fixme: the way how the ReferenceCreator is implemented this was used if
-        // two types of type variables were used smt like:
-        //  Class<A> extends Class<B>
-        // but since if the TYPE is Parametrized it does not look at the (in the ReferenceCreator)
-        // extended part type vars...
-        Stream<Map.Entry<String, Reference>> combinedStream = Stream.concat(
-                classParametrizedTypes.entrySet().stream(),
-                parentClassParametrizedTypes.entrySet().stream());
-
-        return combinedStream.collect(
-                Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue));
-    }
-
-    public Map<String, Reference> getClassParametrizedTypes() {
-        return classParametrizedTypes;
-    }
-
-    public void setClassParametrizedTypes(Map<String, Reference> classParametrizedTypes) {
-        this.classParametrizedTypes = classParametrizedTypes;
-    }
-
-    public boolean hasClassParameterizedTypes() {
-        return getAllParametrizedTypes() != null
-                && !getAllParametrizedTypes().isEmpty();
-    }
-
-    public Reference getClassParametrizedType(String name) {
-        if (hasClassParameterizedTypes()) {
-            return getAllParametrizedTypes().get(name);
+        for (ParametrizedTypeEntry entry : parametrizedTypes.values()) {
+            if (entry.getIdentifier().equals(identifier)) {
+                return entry.getReference();
+            }
         }
         return null;
-    }
-
-    public Map<String, Reference> getParentClassParametrizedTypes() {
-        return parentClassParametrizedTypes;
-    }
-
-    public void setParentClassParametrizedTypes(Map<String, Reference> parentClassParametrizedTypes) {
-        this.parentClassParametrizedTypes = parentClassParametrizedTypes;
     }
 
     public boolean isAddParametrizedTypeNameExtension() {
@@ -239,8 +213,7 @@ public class Reference implements Serializable {
                 ", adaptTo=" + adaptTo +
                 ", adaptWith=" + adaptWith +
                 ", directiveInstances=" + directiveInstances +
-                ", classParametrizedTypes" + classParametrizedTypes +
-                ", extendedClassParametrizedTypes" + parentClassParametrizedTypes +
+                ", parametrizedTypes=" + parametrizedTypes +
                 ", wrapper=" + wrapper
                 + '}';
     }
@@ -255,8 +228,7 @@ public class Reference implements Serializable {
         hash = 97 * hash + Objects.hashCode(this.adaptTo);
         hash = 97 * hash + Objects.hashCode(this.adaptWith);
         hash = 97 * hash + Objects.hashCode(this.directiveInstances);
-        hash = 97 * hash + Objects.hashCode(this.classParametrizedTypes);
-        hash = 97 * hash + Objects.hashCode(this.parentClassParametrizedTypes);
+        hash = 97 * hash + Objects.hashCode(this.parametrizedTypes);
         hash = 97 * hash + Objects.hashCode(this.wrapper);
         return hash;
     }
@@ -294,10 +266,7 @@ public class Reference implements Serializable {
         if (!Objects.equals(this.directiveInstances, other.directiveInstances)) {
             return false;
         }
-        if (!Objects.equals(this.classParametrizedTypes, other.classParametrizedTypes)) {
-            return false;
-        }
-        if (!Objects.equals(this.parentClassParametrizedTypes, other.parentClassParametrizedTypes)) {
+        if (!Objects.equals(this.parametrizedTypes, other.parametrizedTypes)) {
             return false;
         }
         return Objects.equals(this.wrapper, other.wrapper);
@@ -311,8 +280,7 @@ public class Reference implements Serializable {
         private String graphQLClassName;
         private AdaptTo adaptTo = null;
         private AdaptWith adaptWith = null;
-        private Map<String, Reference> classParametrizedTypes;
-        private Map<String, Reference> parentClassParametrizedTypes;
+        private Map<String, ParametrizedTypeEntry> parametrizedTypes;
         private boolean addParametrizedTypeNameExtension;
         private List<DirectiveInstance> directiveInstances;
         private Wrapper wrapper;
@@ -347,13 +315,8 @@ public class Reference implements Serializable {
             return this;
         }
 
-        public Builder classParametrizedTypes(Map<String, Reference> classParametrizedTypes) {
-            this.classParametrizedTypes = classParametrizedTypes;
-            return this;
-        }
-
-        public Builder extendedClassParametrizedTypes(Map<String, Reference> extendedClassParametrizedTypes) {
-            this.parentClassParametrizedTypes = extendedClassParametrizedTypes;
+        public Builder parametrizedTypes(Map<String, ParametrizedTypeEntry> parametrizedTypes) {
+            this.parametrizedTypes = parametrizedTypes;
             return this;
         }
 
@@ -379,7 +342,7 @@ public class Reference implements Serializable {
             this.graphQLClassName(reference.getGraphQLClassName());
             this.adaptTo(reference.getAdaptTo());
             this.adaptWith(reference.getAdaptWith());
-            this.classParametrizedTypes(reference.getClassParametrizedTypes());
+            this.parametrizedTypes(reference.getParametrizedTypes());
             this.addParametrizedTypeNameExtension(reference.isAddParametrizedTypeNameExtension());
             this.directiveInstances(reference.getDirectiveInstances());
             this.wrapper(reference.getWrapper());

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -928,8 +928,7 @@ public class Bootstrap {
     private Optional<GraphQLArgument> getAutoMapArgument(Field field) {
         // Auto Map argument
         if (field.hasWrapper() && field.getWrapper().isMap() && !field.isAdaptingWith()) { // TODO: Also pass this to the user adapter ?
-            Map<String, Reference> parametrizedTypeArguments = field.getReference().getAllParametrizedTypes();
-            Reference keyReference = parametrizedTypeArguments.get(AUTOMAP_KEY_KEY);
+            Reference keyReference = field.getReference().findByIdentifier(AUTOMAP_KEY_KEY);
 
             ReferenceType type = keyReference.getType();
             if (type.equals(ReferenceType.SCALAR) || type.equals(ReferenceType.ENUM)) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
@@ -463,14 +463,13 @@ public class ArgumentHelper extends AbstractHelper {
      */
     private Type getType(Reference reference) {
         Class<?> ownerClass = classloadingService.loadClass(reference.getClassName());
-        if (reference.getAllParametrizedTypes() == null
-                || reference.getAllParametrizedTypes().isEmpty()) {
+        if (!reference.hasParametrizedTypes()) {
             return ownerClass;
         }
 
         List<Type> typeParameters = new ArrayList<>();
         for (final TypeVariable<?> typeParameter : ownerClass.getTypeParameters()) {
-            final Reference typeRef = reference.getClassParametrizedType(typeParameter.getName());
+            final Reference typeRef = reference.findByIdentifier(typeParameter.getName());
             typeParameters.add(getType(typeRef));
         }
         final Type[] types = typeParameters.toArray(new Type[0]);

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/DefaultMapAdapter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/DefaultMapAdapter.java
@@ -36,10 +36,8 @@ public class DefaultMapAdapter<K, V> {
         for (Object e : entries) {
             Map<K, V> graphQLJavaMap = (Map<K, V>) e; // The entry complex type comes from graphql-java as an Map
 
-            Map<String, Reference> parametrizedTypeArguments = field.getReference().getAllParametrizedTypes();
-
-            Reference keyReference = parametrizedTypeArguments.get("K");
-            Reference valueReference = parametrizedTypeArguments.get("V");
+            Reference keyReference = field.getReference().findByIdentifier("K");
+            Reference valueReference = field.getReference().findByIdentifier("V");
 
             K k = (K) toObject(keyReference, graphQLJavaMap.get(KEY));
             V v = (V) toObject(valueReference, graphQLJavaMap.get(VALUE));
@@ -58,8 +56,7 @@ public class DefaultMapAdapter<K, V> {
             }
         } else {
 
-            Map<String, Reference> parametrizedTypeArguments = field.getReference().getAllParametrizedTypes();
-            Reference keyReference = parametrizedTypeArguments.get("K");
+            Reference keyReference = field.getReference().findByIdentifier("K");
 
             for (K k : key) {
 


### PR DESCRIPTION
- Fixes #2267

Went by what I described in this [comment](https://github.com/smallrye/smallrye-graphql/issues/2267#issuecomment-3237120332) but upgraded a bit - instead of just using class-qualified identifiers as plain string keys in the same `Map<String, Reference>`, I introduced a `ParametrizedTypeEntry` class that carries `declaringClassName`, identifier, and reference together. 

This also let me merge the two separate map (`classParametrizedTypes` and `parentClassParametrizedTypes`) into a single `Map<String, ParametrizedTypeEntry>` with composite keys (`declaringClassName:identifier`), which removes the need for the dual-map split and the "FIXME merge" logic in `getAllParametrizedTypes()` entirely. 
The `addParametrizedTypeNameExtension` flag that was already there handles the own/inherited distinction for name generation, so no information was lost.