### PR TITLE
[2.x] Make sure `MethodKey#hashCode` produces stable hash code

### DIFF
--- a/client/model/src/main/java/io/smallrye/graphql/client/model/MethodKey.java
+++ b/client/model/src/main/java/io/smallrye/graphql/client/model/MethodKey.java
@@ -35,7 +35,18 @@ public class MethodKey {
     @Override
     public int hashCode() {
         int result = Objects.hash(methodName);
-        result = 31 * result + Arrays.hashCode(parameterTypes);
+        result = 31 * result + parameterTypesHashCode();
+        return result;
+    }
+
+    private int parameterTypesHashCode() {
+        if (parameterTypes == null) {
+            return 0;
+        }
+        int result = 1;
+        for (Class<?> parameterType : parameterTypes) {
+            result = 31 * result + (parameterType == null ? 0 : parameterType.getName().hashCode());
+        }
         return result;
     }
 


### PR DESCRIPTION
Part of bytecode recording in Quarkus is invoking `ClientModelBuilder#generateClientModels`, which populates `operationMap`. When `MethodKey`'s hash code is not stable, the internal hash map inside `operationMap` does not have a reproducible iteration order, which makes generated bytecode in Quarkus unstable.

Backport of https://github.com/smallrye/smallrye-graphql/pull/2535 