### PR TITLE
Skip Quarkus and WildFly CI jobs on the main (3.x) branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,10 @@ jobs:
           ./mvnw -B install -Dversion.io.smallrye.graphql=$SMALLRYE_VERSION --file wildfly-graphql-feature-pack/pom.xml
 
   quarkus-tests:
+    # TODO: revert when Quarkus upgrades to Vert.x 5.x
+    if: >-
+      (github.event_name == 'pull_request' && github.base_ref != 'main') ||
+      (github.event_name == 'push' && github.ref_name != 'main')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,10 @@ jobs:
         # the GITHUB* properties are a workaround for Stork whose MicroProfileConfigProvider blows up when it sees an empty property
 
   wildfly-tests:
+    # TODO: revert when WildFly upgrades to Vert.x 5.x
+    if: >-
+      (github.event_name == 'pull_request' && github.base_ref != 'main') ||
+      (github.event_name == 'push' && github.ref_name != 'main')
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
I don't think there is a need for these two (three) jobs to be executed for 3.x.