### PR TITLE
Fix the release of the Gradle plugin

### DIFF
--- a/tools/gradle-plugin/build.gradle
+++ b/tools/gradle-plugin/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     api gradleApi()
-    implementation enforcedPlatform("io.smallrye:smallrye-graphql-parent:${version}")
+    implementation platform("io.smallrye:smallrye-graphql-parent:${version}")
     implementation "io.smallrye:jandex"
     implementation "io.smallrye:smallrye-graphql"
     implementation "io.smallrye:smallrye-graphql-schema-builder"


### PR DESCRIPTION
backport of https://github.com/smallrye/smallrye-graphql/pull/2539 to 2.x