### PR TITLE
Migrate from Jackson 2.x to Jackson 3.1.4

### DIFF
--- a/client/api/pom.xml
+++ b/client/api/pom.xml
@@ -40,7 +40,7 @@
 <!--            <scope>provided</scope>-->
 <!--        </dependency>-->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/client/api/src/main/java/io/smallrye/graphql/client/Request.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/Request.java
@@ -2,7 +2,7 @@ package io.smallrye.graphql.client;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public interface Request {
     String getDocument();

--- a/client/api/src/main/java/io/smallrye/graphql/client/Response.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/Response.java
@@ -3,7 +3,7 @@ package io.smallrye.graphql.client;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public interface Response {
 

--- a/client/api/src/main/java/io/smallrye/graphql/client/typesafe/api/TypesafeResponse.java
+++ b/client/api/src/main/java/io/smallrye/graphql/client/typesafe/api/TypesafeResponse.java
@@ -7,9 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.GraphQLError;
+import tools.jackson.databind.node.ObjectNode;
 
 public final class TypesafeResponse<T> extends ErrorOr<T> {
     private Map<String, List<String>> transportMeta;

--- a/client/implementation-vertx/pom.xml
+++ b/client/implementation-vertx/pom.xml
@@ -29,12 +29,8 @@
             <artifactId>microprofile-config-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClient.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/dynamic/VertxDynamicGraphQLClient.java
@@ -13,8 +13,6 @@ import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.Request;
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.core.Document;
@@ -41,6 +39,7 @@ import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
+import tools.jackson.databind.node.ObjectNode;
 
 public class VertxDynamicGraphQLClient implements DynamicGraphQLClient {
 

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/typesafe/VertxTypesafeGraphQLClientProxy.java
@@ -24,12 +24,6 @@ import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.InvalidResponseException;
 import io.smallrye.graphql.client.impl.RequestImpl;
 import io.smallrye.graphql.client.impl.discovery.ServiceURLSupplier;
@@ -55,6 +49,11 @@ import io.vertx.core.http.WebSocketClient;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 class VertxTypesafeGraphQLClientProxy {
 

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/WebSocketSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/WebSocketSubprotocolHandler.java
@@ -1,10 +1,9 @@
 package io.smallrye.graphql.client.vertx.websocket;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.UniEmitter;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * An implementation of this interface is responsible for handling a particular subscription websocket protocol.

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqltransportws/GraphQLTransportWSSubprotocolHandler.java
@@ -10,12 +10,6 @@ import java.util.stream.StreamSupport;
 
 import org.jboss.logging.Logger;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.InvalidResponseException;
@@ -30,6 +24,11 @@ import io.smallrye.mutiny.subscription.Cancellable;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.UniEmitter;
 import io.vertx.core.http.WebSocket;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Implementation of the `graphql-transport-ws` protocol. The protocol specification is at
@@ -302,7 +301,7 @@ public class GraphQLTransportWSSubprotocolHandler implements WebSocketSubprotoco
     private ObjectNode parseIncomingMessage(String message) {
         try {
             return (ObjectNode) MAPPER.readTree(message);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Failed to parse incoming message", e);
         }
     }

--- a/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
+++ b/client/implementation-vertx/src/main/java/io/smallrye/graphql/client/vertx/websocket/graphqlws/GraphQLWSSubprotocolHandler.java
@@ -8,11 +8,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.jboss.logging.Logger;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.InvalidResponseException;
@@ -27,6 +22,10 @@ import io.smallrye.mutiny.subscription.Cancellable;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.smallrye.mutiny.subscription.UniEmitter;
 import io.vertx.core.http.WebSocket;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Handler for the legacy `graphql-ws` subprotocol
@@ -210,7 +209,7 @@ public class GraphQLWSSubprotocolHandler implements WebSocketSubprotocolHandler 
     private ObjectNode parseIncomingMessage(String message) {
         try {
             return (ObjectNode) MAPPER.readTree(message);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Failed to parse incoming message", e);
         }
     }

--- a/client/implementation-vertx/src/test/java/io/smallrye/graphql/client/vertx/test/DynamicClientExceptionTest.java
+++ b/client/implementation-vertx/src/test/java/io/smallrye/graphql/client/vertx/test/DynamicClientExceptionTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.InvalidResponseException;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClientBuilder;
@@ -17,6 +15,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Make sure than when executing a sync operation with a dynamic client and

--- a/client/implementation-vertx/src/test/java/test/tck/VertxTypesafeGraphQLClientFixture.java
+++ b/client/implementation-vertx/src/test/java/test/tck/VertxTypesafeGraphQLClientFixture.java
@@ -13,9 +13,6 @@ import java.util.Map;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.smallrye.graphql.client.typesafe.api.TypesafeGraphQLClientBuilder;
 import io.smallrye.graphql.client.vertx.typesafe.VertxTypesafeGraphQLClientBuilder;
 import io.vertx.core.MultiMap;
@@ -25,6 +22,8 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import tck.graphql.typesafe.TypesafeGraphQLClientFixture;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 public class VertxTypesafeGraphQLClientFixture implements TypesafeGraphQLClientFixture {
     private final WebClient mockWebClient = Mockito.mock(WebClient.class);
@@ -141,7 +140,7 @@ public class VertxTypesafeGraphQLClientFixture implements TypesafeGraphQLClientF
             then(mockHttpRequest).should().sendBuffer(captor.capture());
             String requestString = captor.getValue().toString();
             try {
-                requestSent = new ObjectMapper().readTree(requestString);
+                requestSent = JsonMapper.builder().build().readTree(requestString);
             } catch (Exception e) {
                 throw new RuntimeException("Failed to parse request JSON", e);
             }

--- a/client/implementation/pom.xml
+++ b/client/implementation/pom.xml
@@ -67,16 +67,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/RequestImpl.java
@@ -4,20 +4,19 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.Request;
 import io.smallrye.graphql.jackson.jsonb.JsonbCompatModule;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 public class RequestImpl implements Request {
     public static final ObjectMapper MAPPER = JsonMapper.builder()
             .addModule(new JsonbCompatModule())
-            .enable(com.fasterxml.jackson.databind.DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
-            .disable(com.fasterxml.jackson.databind.cfg.JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES)
+            .enable(tools.jackson.databind.DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+            .disable(tools.jackson.databind.cfg.JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES)
             .build();
 
     private final String document;
@@ -78,7 +77,7 @@ public class RequestImpl implements Request {
     public String toJson() {
         try {
             return MAPPER.writeValueAsString(toJsonObject());
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new RuntimeException("Failed to serialize request to JSON", e);
         }
     }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/ResponseImpl.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/ResponseImpl.java
@@ -8,15 +8,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.impl.typesafe.json.JsonReader;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class ResponseImpl implements Response {
 
@@ -144,7 +143,7 @@ public class ResponseImpl implements Response {
      */
     private static Set<String> fieldNames(ObjectNode node) {
         Set<String> names = new LinkedHashSet<>();
-        node.fieldNames().forEachRemaining(names::add);
+        node.propertyNames().forEach(names::add);
         return names;
     }
 

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/ResponseReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/ResponseReader.java
@@ -8,14 +8,13 @@ import java.util.Map;
 
 import org.jboss.logging.Logger;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.InvalidResponseException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class ResponseReader {
     private static final Logger LOG = Logger.getLogger(ResponseReader.class.getName());
@@ -50,16 +49,14 @@ public class ResponseReader {
             } else {
                 return null;
             }
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             return null;
         }
     }
 
     private static ObjectNode checkExpectedResponseFields(ObjectNode jsonResponse,
             Boolean allowUnexpectedResponseFields) {
-        var fieldNames = jsonResponse.fieldNames();
-        while (fieldNames.hasNext()) {
-            String key = fieldNames.next();
+        for (String key : jsonResponse.propertyNames()) {
             if (!key.equalsIgnoreCase("data")
                     && !key.equalsIgnoreCase("errors")
                     && !key.equalsIgnoreCase("extensions")) {
@@ -143,7 +140,7 @@ public class ResponseReader {
                 for (JsonNode jsonValue : locations) {
                     ObjectNode location = (ObjectNode) jsonValue;
                     Map<String, Integer> map = new HashMap<>();
-                    location.fields().forEachRemaining(entry -> {
+                    location.properties().forEach(entry -> {
                         // TODO: how to handle non-numeric location segments?
                         if (entry.getValue().isNumber()) {
                             map.put(entry.getKey(), entry.getValue().intValue());
@@ -187,7 +184,7 @@ public class ResponseReader {
                     && errorObject.get("extensions").isObject()) {
                 ObjectNode extensions = (ObjectNode) errorObject.get("extensions");
                 Map<String, Object> extensionMap = new HashMap<>();
-                extensions.fields().forEachRemaining(entry -> {
+                extensions.properties().forEach(entry -> {
                     extensionMap.put(entry.getKey(), decode(entry.getValue()));
                 });
                 decodedError.setExtensions(extensionMap);
@@ -201,7 +198,7 @@ public class ResponseReader {
         try {
             // check if there are any other fields beyond the ones described by the specification
             Map<String, Object> otherFields = new HashMap<>();
-            errorObject.fieldNames().forEachRemaining(key -> {
+            errorObject.propertyNames().forEach(key -> {
                 if (!key.equals("extensions") &&
                         !key.equals("locations") &&
                         !key.equals("message") &&

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/SmallRyeGraphQLClientLogging.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/SmallRyeGraphQLClientLogging.java
@@ -7,7 +7,7 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.JsonNodeType;
 
 @MessageLogger(projectCode = "SRGQL")
 public interface SmallRyeGraphQLClientLogging {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/ResultBuilder.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/ResultBuilder.java
@@ -7,12 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.StreamSupport;
 
-import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.InvalidResponseException;
 import io.smallrye.graphql.client.impl.RequestImpl;
@@ -22,6 +16,11 @@ import io.smallrye.graphql.client.impl.typesafe.json.JsonUtils;
 import io.smallrye.graphql.client.impl.typesafe.reflection.MethodInvocation;
 import io.smallrye.graphql.client.typesafe.api.ErrorOr;
 import io.smallrye.graphql.client.typesafe.api.TypesafeResponse;
+import tools.jackson.core.JsonPointer;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class ResultBuilder {
     private static final ObjectMapper MAPPER = RequestImpl.MAPPER;

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonArrayReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonArrayReader.java
@@ -9,13 +9,12 @@ import java.util.Set;
 import java.util.stream.Collector;
 import java.util.stream.StreamSupport;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-
 import io.smallrye.graphql.client.InvalidResponseException;
 import io.smallrye.graphql.client.impl.typesafe.CollectionUtils;
 import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 
 class JsonArrayReader extends Reader<ArrayNode> {
 

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonBooleanReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonBooleanReader.java
@@ -1,9 +1,8 @@
 package io.smallrye.graphql.client.impl.typesafe.json;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
+import tools.jackson.databind.JsonNode;
 
 class JsonBooleanReader extends Reader<JsonNode> {
     JsonBooleanReader(TypeInfo type, Location location, JsonNode value, FieldInfo field) {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonMapReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonMapReader.java
@@ -3,12 +3,11 @@ package io.smallrye.graphql.client.impl.typesafe.json;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-
 import io.smallrye.graphql.client.InvalidResponseException;
 import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 
 class JsonMapReader extends Reader<ArrayNode> {
 
@@ -49,7 +48,7 @@ class JsonMapReader extends Reader<ArrayNode> {
 
             Object keyDeserialized = JsonReader.readJson(keyLocation, keyType, keyJson, field);
             Object valueDeserialized = JsonReader.readJson(valueLocation, valueType,
-                    valueJson != null ? valueJson : com.fasterxml.jackson.databind.node.NullNode.getInstance(), field);
+                    valueJson != null ? valueJson : tools.jackson.databind.node.NullNode.getInstance(), field);
 
             result.put(keyDeserialized, valueDeserialized);
         }

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonNullReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonNullReader.java
@@ -2,10 +2,9 @@ package io.smallrye.graphql.client.impl.typesafe.json;
 
 import static io.smallrye.graphql.client.impl.typesafe.json.GraphQLClientValueHelper.check;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
+import tools.jackson.databind.JsonNode;
 
 class JsonNullReader extends Reader<JsonNode> {
     JsonNullReader(TypeInfo type, Location location, JsonNode value, FieldInfo field) {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonNumberReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonNumberReader.java
@@ -6,10 +6,9 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
+import tools.jackson.databind.JsonNode;
 
 class JsonNumberReader extends Reader<JsonNode> {
     JsonNumberReader(TypeInfo type, Location location, JsonNode value, FieldInfo field) {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonObjectReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonObjectReader.java
@@ -6,13 +6,12 @@ import static io.smallrye.graphql.client.impl.typesafe.json.JsonUtils.toMap;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.InvalidResponseException;
 import io.smallrye.graphql.client.impl.SmallRyeGraphQLClientMessages;
 import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 class JsonObjectReader extends Reader<ObjectNode> {
     JsonObjectReader(TypeInfo type, Location location, ObjectNode value, FieldInfo field) {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonReader.java
@@ -10,10 +10,6 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.stream.StreamSupport;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.GraphQLClientException;
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.InvalidResponseException;
@@ -22,6 +18,9 @@ import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
 import io.smallrye.graphql.client.typesafe.api.ErrorOr;
 import io.smallrye.graphql.client.typesafe.api.TypesafeResponse;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class JsonReader extends Reader<JsonNode> {
     public static Object readJson(String description, TypeInfo type, JsonNode value, FieldInfo field) {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonStringReader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonStringReader.java
@@ -14,12 +14,11 @@ import jakarta.json.bind.annotation.JsonbNumberFormat;
 import org.eclipse.microprofile.graphql.DateFormat;
 import org.eclipse.microprofile.graphql.NumberFormat;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import io.smallrye.graphql.client.InvalidResponseException;
 import io.smallrye.graphql.client.impl.typesafe.reflection.ConstructionInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
+import tools.jackson.databind.JsonNode;
 
 class JsonStringReader extends Reader<JsonNode> {
     JsonStringReader(TypeInfo type, Location location, JsonNode value, FieldInfo field) {

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonUtils.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/JsonUtils.java
@@ -5,9 +5,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class JsonUtils {
     public static Object toValue(JsonNode value) {
@@ -42,7 +42,7 @@ public class JsonUtils {
         if (jsonObject == null)
             return null;
         Map<String, Object> map = new LinkedHashMap<>();
-        jsonObject.fields().forEachRemaining(entry -> map.put(entry.getKey(), toValue(entry.getValue())));
+        jsonObject.properties().forEach(entry -> map.put(entry.getKey(), toValue(entry.getValue())));
         return map;
     }
 

--- a/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/Reader.java
+++ b/client/implementation/src/main/java/io/smallrye/graphql/client/impl/typesafe/json/Reader.java
@@ -2,10 +2,9 @@ package io.smallrye.graphql.client.impl.typesafe.json;
 
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import io.smallrye.graphql.client.impl.typesafe.reflection.FieldInfo;
 import io.smallrye.graphql.client.impl.typesafe.reflection.TypeInfo;
+import tools.jackson.databind.JsonNode;
 
 abstract class Reader<T extends JsonNode> {
     protected final TypeInfo type;

--- a/client/implementation/src/test/java/io/smallrye/graphql/client/RequestImplTest.java
+++ b/client/implementation/src/test/java/io/smallrye/graphql/client/RequestImplTest.java
@@ -8,9 +8,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.impl.RequestImpl;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Validates the JSON serialization of the query and variables in a RequestImpl

--- a/client/tck/pom.xml
+++ b/client/tck/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/client/tck/src/main/java/tck/graphql/typesafe/ErrorBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/ErrorBehavior.java
@@ -39,7 +39,7 @@ class ErrorBehavior {
                 /**//**/"\"queryPath\":[\"greeting\"]," +
                 /**//**/"\"classification\":\"DataFetchingException\"," +
                 /**//**/"\"code\":\"no-greeting\"}" +
-                "}]}}");
+                "}]}");
         StringApi api = fixture.build(StringApi.class);
 
         GraphQLClientException thrown = catchThrowableOfType(api::greeting, GraphQLClientException.class);
@@ -101,7 +101,7 @@ class ErrorBehavior {
                 /**//**/"\"queryPath\":[\"greeting\"]," +
                 /**//**/"\"classification\":\"DataFetchingException\"," +
                 /**//**/"\"code\":\"no-greeting\"}" +
-                "}]}}");
+                "}]}");
         StringApi api = fixture.build(StringApi.class);
 
         GraphQLClientException thrown = catchThrowableOfType(api::greeting, GraphQLClientException.class);
@@ -287,7 +287,7 @@ class ErrorBehavior {
                 /**//**/"\"queryPath\":[\"foo\"]," +
                 /**//**/"\"classification\":\"ValidationError\"," +
                 /**//**/"\"code\":\"team-search-disabled\"}" +
-                "}]}}");
+                "}]}");
         SuperHeroApi api = fixture.build(SuperHeroApi.class);
 
         ErrorOr<List<Team>> response = api.teams();
@@ -314,7 +314,7 @@ class ErrorBehavior {
                 /**//**/"\"queryPath\":[\"foo\"]," +
                 /**//**/"\"classification\":\"ValidationError\"," +
                 /**//**/"\"code\":\"team-search-disabled\"}" +
-                "}]}}");
+                "}]}");
         SuperHeroApi api = fixture.build(SuperHeroApi.class);
 
         GraphQLClientException throwable = catchThrowableOfType(api::teams, GraphQLClientException.class);
@@ -349,7 +349,7 @@ class ErrorBehavior {
                 /**//**/"\"description\":\"not feeling so well\"," +
                 /**//**/"\"queryPath\":[\"bar\"]," +
                 /**//**/"\"code\":\"dizzy\"}" +
-                "}]}}");
+                "}]}");
         SuperHeroApi api = fixture.build(SuperHeroApi.class);
 
         ErrorOr<List<Team>> response = api.teams();
@@ -383,7 +383,7 @@ class ErrorBehavior {
                 /**//**/"\"queryPath\":[\"foo\"]," +
                 /**//**/"\"classification\":\"ValidationError\"," +
                 /**//**/"\"code\":\"team-search-disabled\"}" +
-                "}]}}");
+                "}]}");
         SuperHeroApi api = fixture.build(SuperHeroApi.class);
 
         GraphQLClientException throwable = catchThrowableOfType(api::teams, GraphQLClientException.class);
@@ -406,7 +406,7 @@ class ErrorBehavior {
                 /**/"\"path\": [\"teams\",\"name\"],\n" +
                 /**/"\"extensions\":{" +
                 /**//**/"\"code\":\"team-name-disabled\"}" +
-                "}]}}");
+                "}]}");
         SuperHeroApi api = fixture.build(SuperHeroApi.class);
 
         GraphQLClientException throwable = catchThrowableOfType(api::teams, GraphQLClientException.class);
@@ -471,7 +471,7 @@ class ErrorBehavior {
                 /**/"\"locations\":[{\"line\":1,\"column\":2,\"sourceName\":\"loc\"}]," +
                 /**/"\"path\": [\"find\",\"teams\"],\n" +
                 /**/"\"extensions\":{\"code\":\"team-search-disabled\"}" +
-                "}]}}");
+                "}]}");
         SuperHeroWrappedApi api = fixture.build(SuperHeroWrappedApi.class);
 
         Wrapper response = api.find();
@@ -597,7 +597,7 @@ class ErrorBehavior {
                 /**/"\"locations\":[{\"line\":1,\"column\":2,\"sourceName\":\"loc\"}]," +
                 /**/"\"path\": [\"outer\",\"inner\",\"content\"],\n" +
                 /**/"\"extensions\":{\"code\":\"dummy-code\"}" +
-                "}]}}";
+                "}]}";
     }
 
     private void thenDeeplyNestedErrorException(GraphQLClientException throwable) {

--- a/client/tck/src/main/java/tck/graphql/typesafe/TypesafeResponseBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/TypesafeResponseBehavior.java
@@ -9,12 +9,12 @@ import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.GraphQLError;
 import io.smallrye.graphql.client.typesafe.api.GraphQLClientApi;
 import io.smallrye.graphql.client.typesafe.api.TypesafeResponse;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 public class TypesafeResponseBehavior {
     private final TypesafeGraphQLClientFixture fixture = TypesafeGraphQLClientFixture.load();
@@ -52,8 +52,9 @@ public class TypesafeResponseBehavior {
 
         TypesafeResponse<String> result = api.greetings();
         then(fixture.query()).isEqualTo("query greetings { greetings }");
-        ObjectMapper mapper = new ObjectMapper()
-                .enable(com.fasterxml.jackson.databind.DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+        ObjectMapper mapper = JsonMapper.builder()
+                .enable(tools.jackson.databind.DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .build();
         ObjectNode expectedExtensions = (ObjectNode) mapper.readTree("{\"pi\":3.14159,\"extension\":\"bell\"}");
         then(result.getExtensions()).isEqualTo(expectedExtensions);
         then(result.getTransportMeta()).isEqualTo(

--- a/client/tck/src/main/java/tck/graphql/typesafe/TypesafeResponseBehavior.java
+++ b/client/tck/src/main/java/tck/graphql/typesafe/TypesafeResponseBehavior.java
@@ -76,7 +76,7 @@ public class TypesafeResponseBehavior {
                 /**//**/"\"queryPath\":[\"greeting\"]," +
                 /**//**/"\"classification\":\"DataFetchingException\"," +
                 /**//**/"\"code\":\"no-greetings\"}" +
-                "}]}}");
+                "}]}");
         StringApi api = fixture.build(StringApi.class);
         assertThrows(NoSuchElementException.class, () -> api.greetings().get());
         GraphQLError error = api.greetings().getErrors().get(0);

--- a/common/jackson-jsonb-compat/pom.xml
+++ b/common/jackson-jsonb-compat/pom.xml
@@ -15,16 +15,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.json.bind</groupId>

--- a/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbAnnotationIntrospector.java
+++ b/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbAnnotationIntrospector.java
@@ -15,25 +15,23 @@ import jakarta.json.bind.annotation.JsonbTypeInfo;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.PropertyName;
-import com.fasterxml.jackson.databind.cfg.MapperConfig;
-import com.fasterxml.jackson.databind.introspect.Annotated;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
-import com.fasterxml.jackson.databind.introspect.AnnotatedField;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
-import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
-import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
+
+import tools.jackson.databind.PropertyName;
+import tools.jackson.databind.cfg.MapperConfig;
+import tools.jackson.databind.introspect.Annotated;
+import tools.jackson.databind.introspect.AnnotatedField;
+import tools.jackson.databind.introspect.AnnotatedMember;
+import tools.jackson.databind.introspect.AnnotatedMethod;
+import tools.jackson.databind.introspect.NopAnnotationIntrospector;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
 
 public class JsonbAnnotationIntrospector extends NopAnnotationIntrospector {
 
     private static final long serialVersionUID = 1L;
 
     @Override
-    public PropertyName findNameForSerialization(Annotated a) {
+    public PropertyName findNameForSerialization(MapperConfig<?> config, Annotated a) {
         JsonbProperty prop = a.getAnnotation(JsonbProperty.class);
         if (prop != null && !prop.value().isEmpty()) {
             return PropertyName.construct(prop.value());
@@ -42,7 +40,7 @@ public class JsonbAnnotationIntrospector extends NopAnnotationIntrospector {
     }
 
     @Override
-    public PropertyName findNameForDeserialization(Annotated a) {
+    public PropertyName findNameForDeserialization(MapperConfig<?> config, Annotated a) {
         JsonbProperty prop = a.getAnnotation(JsonbProperty.class);
         if (prop != null && !prop.value().isEmpty()) {
             return PropertyName.construct(prop.value());
@@ -51,12 +49,12 @@ public class JsonbAnnotationIntrospector extends NopAnnotationIntrospector {
     }
 
     @Override
-    public boolean hasIgnoreMarker(AnnotatedMember m) {
+    public boolean hasIgnoreMarker(MapperConfig<?> config, AnnotatedMember m) {
         return m.hasAnnotation(JsonbTransient.class);
     }
 
     @Override
-    public JsonInclude.Value findPropertyInclusion(Annotated a) {
+    public JsonInclude.Value findPropertyInclusion(MapperConfig<?> config, Annotated a) {
         // Field-level: @JsonbProperty(nillable = true)
         JsonbProperty prop = a.getAnnotation(JsonbProperty.class);
         if (prop != null && prop.nillable()) {
@@ -77,7 +75,7 @@ public class JsonbAnnotationIntrospector extends NopAnnotationIntrospector {
     }
 
     @Override
-    public Object findSerializer(Annotated a) {
+    public Object findSerializer(MapperConfig<?> config, Annotated a) {
         JsonbDateFormat dateFormat = a.getAnnotation(JsonbDateFormat.class);
         if (dateFormat != null) {
             return new JsonbDateFormatSerializer(dateFormat.value(), dateFormat.locale());
@@ -90,7 +88,7 @@ public class JsonbAnnotationIntrospector extends NopAnnotationIntrospector {
     }
 
     @Override
-    public Object findDeserializer(Annotated a) {
+    public Object findDeserializer(MapperConfig<?> config, Annotated a) {
         JsonbDateFormat dateFormat = a.getAnnotation(JsonbDateFormat.class);
         if (dateFormat != null) {
             Class<?> rawType = resolveRawType(a);
@@ -119,20 +117,16 @@ public class JsonbAnnotationIntrospector extends NopAnnotationIntrospector {
     }
 
     @Override
-    public TypeResolverBuilder<?> findTypeResolver(MapperConfig<?> config, AnnotatedClass ac, JavaType baseType) {
+    public Object findTypeResolverBuilder(MapperConfig<?> config, Annotated ac) {
         JsonbTypeInfo typeInfo = ac.getAnnotation(JsonbTypeInfo.class);
         if (typeInfo != null) {
-            StdTypeResolverBuilder builder = new StdTypeResolverBuilder();
-            builder.init(JsonTypeInfo.Id.NAME, null);
-            builder.inclusion(JsonTypeInfo.As.PROPERTY);
-            builder.typeProperty(typeInfo.key());
-            return builder;
+            return new StdTypeResolverBuilder(JsonTypeInfo.Id.NAME, JsonTypeInfo.As.PROPERTY, typeInfo.key());
         }
         return null;
     }
 
     @Override
-    public List<NamedType> findSubtypes(Annotated a) {
+    public List<NamedType> findSubtypes(MapperConfig<?> config, Annotated a) {
         JsonbTypeInfo typeInfo = a.getAnnotation(JsonbTypeInfo.class);
         if (typeInfo != null) {
             List<NamedType> subtypes = new ArrayList<>();

--- a/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbCompatModule.java
+++ b/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbCompatModule.java
@@ -1,6 +1,6 @@
 package io.smallrye.graphql.jackson.jsonb;
 
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.module.SimpleModule;
 
 public class JsonbCompatModule extends SimpleModule {
 

--- a/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbDateFormatDeserializer.java
+++ b/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbDateFormatDeserializer.java
@@ -1,6 +1,5 @@
 package io.smallrye.graphql.jackson.jsonb;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,13 +13,12 @@ import java.util.Locale;
 
 import jakarta.json.bind.annotation.JsonbDateFormat;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
-public class JsonbDateFormatDeserializer extends JsonDeserializer<Object> implements ContextualDeserializer {
+public class JsonbDateFormatDeserializer extends ValueDeserializer<Object> {
 
     private DateTimeFormatter formatter;
     private Class<?> targetType;
@@ -36,7 +34,7 @@ public class JsonbDateFormatDeserializer extends JsonDeserializer<Object> implem
     }
 
     @Override
-    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+    public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
         if (property != null) {
             JsonbDateFormat ann = property.getAnnotation(JsonbDateFormat.class);
             if (ann != null) {
@@ -48,7 +46,7 @@ public class JsonbDateFormatDeserializer extends JsonDeserializer<Object> implem
     }
 
     @Override
-    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public Object deserialize(JsonParser p, DeserializationContext ctxt) {
         String text = p.getText();
         TemporalAccessor parsed = formatter.parse(text);
 

--- a/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbDateFormatSerializer.java
+++ b/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbDateFormatSerializer.java
@@ -1,15 +1,14 @@
 package io.smallrye.graphql.jackson.jsonb;
 
-import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class JsonbDateFormatSerializer extends JsonSerializer<TemporalAccessor> {
+public class JsonbDateFormatSerializer extends ValueSerializer<TemporalAccessor> {
 
     private final DateTimeFormatter formatter;
 
@@ -19,7 +18,7 @@ public class JsonbDateFormatSerializer extends JsonSerializer<TemporalAccessor> 
     }
 
     @Override
-    public void serialize(TemporalAccessor value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(TemporalAccessor value, JsonGenerator gen, SerializationContext serializers) {
         gen.writeString(formatter.format(value));
     }
 }

--- a/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbNumberFormatDeserializer.java
+++ b/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbNumberFormatDeserializer.java
@@ -1,6 +1,5 @@
 package io.smallrye.graphql.jackson.jsonb;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
@@ -10,13 +9,13 @@ import java.util.Locale;
 
 import jakarta.json.bind.annotation.JsonbNumberFormat;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
-public class JsonbNumberFormatDeserializer extends JsonDeserializer<Object> implements ContextualDeserializer {
+public class JsonbNumberFormatDeserializer extends ValueDeserializer<Object> {
 
     private String pattern;
     private String locale;
@@ -33,7 +32,7 @@ public class JsonbNumberFormatDeserializer extends JsonDeserializer<Object> impl
     }
 
     @Override
-    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+    public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
         if (property != null) {
             JsonbNumberFormat ann = property.getAnnotation(JsonbNumberFormat.class);
             if (ann != null) {
@@ -45,7 +44,7 @@ public class JsonbNumberFormatDeserializer extends JsonDeserializer<Object> impl
     }
 
     @Override
-    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public Object deserialize(JsonParser p, DeserializationContext ctxt) {
         String text = p.getText();
         Locale loc = resolveLocale(ctxt);
         DecimalFormat fmt = new DecimalFormat(pattern, DecimalFormatSymbols.getInstance(loc));
@@ -55,7 +54,7 @@ public class JsonbNumberFormatDeserializer extends JsonDeserializer<Object> impl
         try {
             parsed = fmt.parse(text);
         } catch (ParseException e) {
-            throw new IOException("Failed to parse number from '" + text + "' with pattern '" + pattern + "'", e);
+            throw DatabindException.from(p, "Failed to parse number from '" + text + "' with pattern '" + pattern + "'", e);
         }
 
         if (targetType == int.class || targetType == Integer.class) {

--- a/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbNumberFormatSerializer.java
+++ b/common/jackson-jsonb-compat/src/main/java/io/smallrye/graphql/jackson/jsonb/JsonbNumberFormatSerializer.java
@@ -1,15 +1,14 @@
 package io.smallrye.graphql.jackson.jsonb;
 
-import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class JsonbNumberFormatSerializer extends JsonSerializer<Number> {
+public class JsonbNumberFormatSerializer extends ValueSerializer<Number> {
 
     private final String pattern;
     private final String locale;
@@ -20,13 +19,13 @@ public class JsonbNumberFormatSerializer extends JsonSerializer<Number> {
     }
 
     @Override
-    public void serialize(Number value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(Number value, JsonGenerator gen, SerializationContext serializers) {
         Locale loc = resolveLocale(serializers);
         DecimalFormat fmt = new DecimalFormat(pattern, DecimalFormatSymbols.getInstance(loc));
         gen.writeString(fmt.format(value));
     }
 
-    private Locale resolveLocale(SerializerProvider serializers) {
+    private Locale resolveLocale(SerializationContext serializers) {
         if (locale != null && !locale.isEmpty()
                 && !jakarta.json.bind.annotation.JsonbNumberFormat.DEFAULT_LOCALE.equals(locale)) {
             return Locale.forLanguageTag(locale);

--- a/common/jackson-jsonb-compat/src/test/java/io/smallrye/graphql/jackson/jsonb/JsonbAnnotationIntrospectorTest.java
+++ b/common/jackson-jsonb-compat/src/test/java/io/smallrye/graphql/jackson/jsonb/JsonbAnnotationIntrospectorTest.java
@@ -16,14 +16,14 @@ import jakarta.json.bind.annotation.JsonbTypeInfo;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 class JsonbAnnotationIntrospectorTest {
 
-    private final ObjectMapper mapper = new ObjectMapper()
-            .registerModule(new JsonbCompatModule())
-            .registerModule(new JavaTimeModule());
+    private final ObjectMapper mapper = JsonMapper.builder()
+            .addModule(new JsonbCompatModule())
+            .build();
 
     // -- @JsonbProperty --
 
@@ -130,9 +130,10 @@ class JsonbAnnotationIntrospectorTest {
 
     @Test
     void jsonbNumberFormatSerializesWithPattern() throws Exception {
-        ObjectMapper usMapper = new ObjectMapper()
-                .registerModule(new JsonbCompatModule())
-                .setLocale(Locale.US);
+        ObjectMapper usMapper = JsonMapper.builder()
+                .addModule(new JsonbCompatModule())
+                .defaultLocale(Locale.US)
+                .build();
         String json = usMapper.writeValueAsString(new NumberFormatBean());
         assertThat(json).contains("\"1,234.50\"");
     }

--- a/common/schema-builder/pom.xml
+++ b/common/schema-builder/pom.xml
@@ -56,7 +56,7 @@
             <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/Annotations.java
@@ -642,9 +642,9 @@ public class Annotations {
     public static final DotName JACKSON_CREATOR = DotName.createSimple("com.fasterxml.jackson.annotation.JsonCreator");
     public static final DotName JACKSON_FORMAT = DotName.createSimple("com.fasterxml.jackson.annotation.JsonFormat");
     public static final DotName JACKSON_SERIALIZE = DotName
-            .createSimple("com.fasterxml.jackson.databind.annotation.JsonSerialize");
+            .createSimple("tools.jackson.databind.annotation.JsonSerialize");
     public static final DotName JACKSON_DESERIALIZE = DotName
-            .createSimple("com.fasterxml.jackson.databind.annotation.JsonDeserialize");
+            .createSimple("tools.jackson.databind.annotation.JsonDeserialize");
 
     // Bean Validation Annotations (SmallRye extra, not part of the spec)
     public static final DotName JAVAX_BEAN_VALIDATION_NOT_NULL = DotName.createSimple("javax.validation.constraints.NotNull");

--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/AdaptWithHelper.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/helper/AdaptWithHelper.java
@@ -161,7 +161,7 @@ public class AdaptWithHelper {
                     AnnotationValue converterValue = serializeAnn.value("converter");
                     if (converterValue != null) {
                         AdaptWith adaptWith = new AdaptWith(
-                                "com.fasterxml.jackson.databind.util.StdConverter",
+                                "tools.jackson.databind.util.StdConverter",
                                 "convert", "convert");
                         Type type = converterValue.asClass();
                         return new AdapterType(type, adaptWith);

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -30,10 +30,6 @@ import org.jboss.jandex.Indexer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
 import io.smallrye.graphql.index.app.SomeDirective;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.SchemaBuilderException;
@@ -45,6 +41,10 @@ import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.Reference;
 import io.smallrye.graphql.schema.model.Schema;
 import io.smallrye.graphql.schema.model.Type;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Test the model creation
@@ -52,7 +52,7 @@ import io.smallrye.graphql.schema.model.Type;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class SchemaBuilderTest {
-    private static final ObjectMapper MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    private static final ObjectMapper MAPPER = JsonMapper.builder().enable(SerializationFeature.INDENT_OUTPUT).build();
 
     @Test
     public void testSchemaModelCreation() {
@@ -65,7 +65,7 @@ public class SchemaBuilderTest {
     private static String toJson(Object obj) {
         try {
             return MAPPER.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new RuntimeException(e);
         }
     }

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Scalars.java
@@ -123,8 +123,8 @@ public class Scalars {
     public static void addJson() {
         populateScalar("jakarta.json.JsonValue", JSON, Object.class.getName());
         populateScalar("jakarta.json.JsonObject", JSON, Object.class.getName());
-        populateScalar("com.fasterxml.jackson.databind.JsonNode", JSON, Object.class.getName());
-        populateScalar("com.fasterxml.jackson.databind.node.ObjectNode", JSON, Object.class.getName());
+        populateScalar("tools.jackson.databind.JsonNode", JSON, Object.class.getName());
+        populateScalar("tools.jackson.databind.node.ObjectNode", JSON, Object.class.getName());
     }
 
     static {

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>

--- a/docs/snippets/examples/dynamicclient/MyClientUsage.java
+++ b/docs/snippets/examples/dynamicclient/MyClientUsage.java
@@ -7,7 +7,7 @@ import io.smallrye.graphql.client.core.Document;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 import jakarta.inject.Inject;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ArrayNode;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.hibernate-validator>9.1.0.Final</version.hibernate-validator>
         <version.glasfish-el>4.0.2</version.glasfish-el>
         <version.rxjava>2.2.21</version.rxjava>
-        <version.jackson>2.21.3</version.jackson>
+        <version.jackson>3.1.4</version.jackson>
         <version.mongo-bson>5.7.1</version.mongo-bson>
         <version.mockito>5.23.0</version.mockito>
         <version.weld.servlet>5.1.0.Final</version.weld.servlet>
@@ -383,7 +383,7 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
+                <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${version.jackson}</version>
                 <scope>import</scope>

--- a/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/CdiExecutionTest.java
+++ b/server/implementation-cdi/src/test/java/io/smallrye/graphql/execution/CdiExecutionTest.java
@@ -22,13 +22,12 @@ import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.cdi.producer.GraphQLProducer;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Schema;
 import io.smallrye.graphql.spi.LookupService;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Test a basic query

--- a/server/implementation-servlet/pom.xml
+++ b/server/implementation-servlet/pom.xml
@@ -63,7 +63,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/server/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/HttpServletResponseWriter.java
+++ b/server/implementation-servlet/src/main/java/io/smallrye/graphql/servlet/HttpServletResponseWriter.java
@@ -4,10 +4,10 @@ import java.io.IOException;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.smallrye.graphql.execution.ExecutionResponse;
 import io.smallrye.graphql.execution.ExecutionResponseWriter;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Writing the response to HTTP servlet
@@ -16,7 +16,7 @@ import io.smallrye.graphql.execution.ExecutionResponseWriter;
  */
 public class HttpServletResponseWriter implements ExecutionResponseWriter {
     private static final String APPLICATION_JSON_UTF8 = "application/json;charset=UTF-8";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
 
     private final HttpServletResponse response;
 

--- a/server/implementation/pom.xml
+++ b/server/implementation/pom.xml
@@ -28,16 +28,8 @@
 
         <!-- Jackson -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>

--- a/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/bootstrap/Bootstrap.java
@@ -23,8 +23,6 @@ import java.util.stream.Collectors;
 import org.eclipse.microprofile.graphql.Name;
 
 import com.apollographql.federation.graphqljava.Federation;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import graphql.Scalars;
 import graphql.introspection.Introspection.DirectiveLocation;
@@ -89,6 +87,9 @@ import io.smallrye.graphql.schema.model.Wrapper;
 import io.smallrye.graphql.spi.ClassloadingService;
 import io.smallrye.graphql.spi.LookupService;
 import io.smallrye.graphql.spi.config.Config;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Bootstrap MicroProfile GraphQL
@@ -1179,7 +1180,7 @@ public class Bootstrap {
             ObjectMapper objectMapper = JacksonCreator.getObjectMapper(deserType.getName());
             try {
                 return objectMapper.readValue(jsonString, deserType);
-            } catch (JsonProcessingException e) {
+            } catch (JacksonException e) {
                 throw new RuntimeException("Failed to deserialize default value: " + jsonString, e);
             }
         }
@@ -1248,7 +1249,7 @@ public class Bootstrap {
 
     private static final String COMMA = ",";
 
-    private static final ObjectMapper JSON_OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper JSON_OBJECT_MAPPER = JsonMapper.builder().build();
 
     private static final String CONTEXT = "io.smallrye.graphql.api.Context";
     private static final String OBSERVES = "javax.enterprise.event.Observes";

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponse.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/ExecutionResponse.java
@@ -16,20 +16,21 @@ import jakarta.json.JsonReader;
 import jakarta.json.spi.JsonProvider;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import graphql.ExecutionResult;
 import graphql.GraphQLError;
 import io.smallrye.graphql.execution.error.ExecutionErrorsService;
 import io.smallrye.graphql.spi.config.Config;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Response from an execution
@@ -99,7 +100,7 @@ public class ExecutionResponse {
     public String getExecutionResultAsString() {
         try {
             return OBJECT_MAPPER.writeValueAsString(getExecutionResultAsJsonObject());
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new RuntimeException(e);
         }
     }
@@ -287,7 +288,7 @@ public class ExecutionResponse {
         if (jsonNode instanceof ObjectNode) {
             ObjectNode objectNode = (ObjectNode) jsonNode;
             ObjectNode result = NODE_FACTORY.objectNode();
-            objectNode.fields().forEachRemaining(entry -> {
+            objectNode.properties().forEach(entry -> {
                 if (entry.getValue() != null && !entry.getValue().isNull()) {
                     result.set(entry.getKey(), excludeNullFields(entry.getValue()));
                 }
@@ -306,11 +307,12 @@ public class ExecutionResponse {
     }
 
     private static ObjectMapper createObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.ALWAYS);
-        mapper.disable(SerializationFeature.INDENT_OUTPUT);
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        return mapper;
+        return JsonMapper.builder()
+                .disable(SerializationFeature.INDENT_OUTPUT)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .changeDefaultPropertyInclusion(v -> JsonInclude.Value.construct(JsonInclude.Include.ALWAYS,
+                        JsonInclude.Include.ALWAYS))
+                .build();
     }
 
     private static final String DATA = "data";

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/DataFetcherException.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/DataFetcherException.java
@@ -1,10 +1,10 @@
 package io.smallrye.graphql.execution.datafetcher;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
 import io.smallrye.graphql.schema.model.Operation;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * There was an issue when fetching data.
@@ -12,8 +12,9 @@ import io.smallrye.graphql.schema.model.Operation;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 public class DataFetcherException extends RuntimeException {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .enable(SerializationFeature.INDENT_OUTPUT);
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .build();
 
     public DataFetcherException() {
     }
@@ -29,7 +30,7 @@ public class DataFetcherException extends RuntimeException {
     private static String toJson(Operation operation) {
         try {
             return OBJECT_MAPPER.writeValueAsString(operation);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             return operation.toString();
         }
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/ArgumentHelper.java
@@ -17,9 +17,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLScalarType;
 import io.smallrye.graphql.execution.Classes;
@@ -34,6 +31,8 @@ import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.transformation.AbstractDataFetcherException;
 import io.smallrye.graphql.transformation.TransformException;
 import io.smallrye.graphql.transformation.Transformer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Help with the arguments when doing reflection calls
@@ -369,9 +368,9 @@ public class ArgumentHelper extends AbstractHelper {
      * @return a java object of this type.
      */
     private static boolean isJacksonJsonNodeType(String className) {
-        return "com.fasterxml.jackson.databind.JsonNode".equals(className)
-                || "com.fasterxml.jackson.databind.node.ObjectNode".equals(className)
-                || "com.fasterxml.jackson.databind.node.ArrayNode".equals(className);
+        return "tools.jackson.databind.JsonNode".equals(className)
+                || "tools.jackson.databind.node.ObjectNode".equals(className)
+                || "tools.jackson.databind.node.ArrayNode".equals(className);
     }
 
     private Object correctComplexObjectFromMap(Map m, Field field, DataFetchingEnvironment dfe)
@@ -458,7 +457,7 @@ public class ArgumentHelper extends AbstractHelper {
             }
 
             return result;
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new TransformException(e, field, m);
         }
     }
@@ -523,7 +522,7 @@ public class ArgumentHelper extends AbstractHelper {
         try {
             ObjectMapper objectMapper = JacksonCreator.getObjectMapper(className);
             return objectMapper.readValue(jsonString, objectMapper.constructType(type));
-        } catch (JsonProcessingException jpe) {
+        } catch (JacksonException jpe) {
             throw new TransformException(jpe, field, jsonString);
         }
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/DefaultMapAdapter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/datafetcher/helper/DefaultMapAdapter.java
@@ -6,9 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.smallrye.graphql.api.Entry;
 import io.smallrye.graphql.json.JacksonCreator;
 import io.smallrye.graphql.schema.model.Field;
@@ -17,6 +14,8 @@ import io.smallrye.graphql.schema.model.ReferenceType;
 import io.smallrye.graphql.schema.model.Wrapper;
 import io.smallrye.graphql.schema.model.WrapperType;
 import io.smallrye.graphql.spi.ClassloadingService;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * The adapter to change map to Entry Set.Users can also supply their own adapter.
@@ -80,7 +79,7 @@ public class DefaultMapAdapter<K, V> {
                 ObjectMapper objectMapper = JacksonCreator.getObjectMapper(className);
                 Class<?> clazz = classloadingService.loadClass(className);
                 return (T) objectMapper.readValue(jsonString, clazz);
-            } catch (JsonProcessingException jpe) {
+            } catch (JacksonException jpe) {
                 throw new RuntimeException(jpe);
             }
         }

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExecutionErrorsService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/error/ExecutionErrorsService.java
@@ -6,16 +6,16 @@ import java.util.Optional;
 
 import jakarta.json.JsonValue;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import graphql.ExceptionWhileDataFetching;
 import graphql.GraphQLError;
 import graphql.validation.ValidationError;
 import io.smallrye.graphql.spi.config.Config;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Help to create the exceptions
@@ -25,7 +25,7 @@ import io.smallrye.graphql.spi.config.Config;
 public class ExecutionErrorsService {
 
     private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
 
     private final ErrorExtensionProviders errorExtensionProviders = new ErrorExtensionProviders();
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/execution/event/EventEmitter.java
@@ -13,14 +13,13 @@ import jakarta.annotation.Priority;
 
 import org.jboss.logging.Logger;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import graphql.GraphQL;
 import graphql.schema.GraphQLSchema;
 import io.smallrye.graphql.api.Context;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.spi.EventingService;
 import io.smallrye.graphql.spi.config.Config;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Fire some events while booting or executing.

--- a/server/implementation/src/main/java/io/smallrye/graphql/json/GraphQLNamingStrategy.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/json/GraphQLNamingStrategy.java
@@ -2,7 +2,7 @@ package io.smallrye.graphql.json;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.PropertyNamingStrategies;
 
 /**
  * Naming strategy that takes GraphQL annotations into account

--- a/server/implementation/src/main/java/io/smallrye/graphql/json/JacksonCreator.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/json/JacksonCreator.java
@@ -1,31 +1,11 @@
 package io.smallrye.graphql.json;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.DeserializationConfig;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.KeyDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.deser.KeyDeserializers;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import io.smallrye.graphql.api.CustomFloatScalar;
 import io.smallrye.graphql.api.CustomIntScalar;
@@ -34,6 +14,23 @@ import io.smallrye.graphql.jackson.jsonb.JsonbCompatModule;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.InputType;
 import io.smallrye.graphql.spi.ClassloadingService;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.DeserializationConfig;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.KeyDeserializer;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.deser.KeyDeserializers;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 /**
  * Here we create ObjectMapper instances for certain input objects.
@@ -87,40 +84,39 @@ public class JacksonCreator {
     }
 
     private static ObjectMapper createObjectMapper(Map<String, String> customFieldNameMapping) {
-        ObjectMapper mapper = createDefaultObjectMapper();
-        mapper.setPropertyNamingStrategy(new GraphQLNamingStrategy(customFieldNameMapping));
-        return mapper;
+        return defaultMapperBuilder()
+                .propertyNamingStrategy(new GraphQLNamingStrategy(customFieldNameMapping))
+                .build();
     }
 
     private static ObjectMapper createDefaultObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JsonbCompatModule());
-        mapper.registerModule(new JavaTimeModule());
-        mapper.registerModule(new Jdk8Module());
-        mapper.registerModule(CUSTOM_SCALARS_MODULE);
-        mapper.registerModule(createComplexKeyModule());
-        mapper.setSerializationInclusion(JsonInclude.Include.ALWAYS);
-        mapper.enable(SerializationFeature.INDENT_OUTPUT);
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        // Include null values in serialization (required by @JsonbCreator / Jackson creator methods)
-        mapper.setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS);
-        return mapper;
+        return defaultMapperBuilder().build();
+    }
+
+    private static JsonMapper.Builder defaultMapperBuilder() {
+        return JsonMapper.builder()
+                .addModule(new JsonbCompatModule())
+                .addModule(CUSTOM_SCALARS_MODULE)
+                .addModule(createComplexKeyModule())
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .changeDefaultPropertyInclusion(v -> JsonInclude.Value.construct(JsonInclude.Include.ALWAYS,
+                        JsonInclude.Include.ALWAYS));
     }
 
     private static SimpleModule createCustomScalarsModule() {
         SimpleModule module = new SimpleModule("CustomScalars");
 
         // CustomStringScalar serializer/deserializer
-        module.addSerializer(CustomStringScalar.class, new JsonSerializer<CustomStringScalar>() {
+        module.addSerializer(CustomStringScalar.class, new ValueSerializer<CustomStringScalar>() {
             @Override
-            public void serialize(CustomStringScalar value, JsonGenerator gen, SerializerProvider serializers)
-                    throws IOException {
+            public void serialize(CustomStringScalar value, JsonGenerator gen, SerializationContext serializers) {
                 gen.writeString(value.stringValueForSerialization());
             }
         });
-        module.addDeserializer(CustomStringScalar.class, new JsonDeserializer<CustomStringScalar>() {
+        module.addDeserializer(CustomStringScalar.class, new ValueDeserializer<CustomStringScalar>() {
             @Override
-            public CustomStringScalar deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            public CustomStringScalar deserialize(JsonParser p, DeserializationContext ctxt) {
                 JsonNode node = p.readValueAsTree();
                 if (node == null || node.isNull()) {
                     return null;
@@ -141,16 +137,15 @@ public class JacksonCreator {
         });
 
         // CustomIntScalar serializer/deserializer
-        module.addSerializer(CustomIntScalar.class, new JsonSerializer<CustomIntScalar>() {
+        module.addSerializer(CustomIntScalar.class, new ValueSerializer<CustomIntScalar>() {
             @Override
-            public void serialize(CustomIntScalar value, JsonGenerator gen, SerializerProvider serializers)
-                    throws IOException {
+            public void serialize(CustomIntScalar value, JsonGenerator gen, SerializationContext serializers) {
                 gen.writeNumber(value.intValueForSerialization());
             }
         });
-        module.addDeserializer(CustomIntScalar.class, new JsonDeserializer<CustomIntScalar>() {
+        module.addDeserializer(CustomIntScalar.class, new ValueDeserializer<CustomIntScalar>() {
             @Override
-            public CustomIntScalar deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            public CustomIntScalar deserialize(JsonParser p, DeserializationContext ctxt) {
                 JsonNode node = p.readValueAsTree();
                 if (node == null || node.isNull()) {
                     return null;
@@ -171,16 +166,15 @@ public class JacksonCreator {
         });
 
         // CustomFloatScalar serializer/deserializer
-        module.addSerializer(CustomFloatScalar.class, new JsonSerializer<CustomFloatScalar>() {
+        module.addSerializer(CustomFloatScalar.class, new ValueSerializer<CustomFloatScalar>() {
             @Override
-            public void serialize(CustomFloatScalar value, JsonGenerator gen, SerializerProvider serializers)
-                    throws IOException {
+            public void serialize(CustomFloatScalar value, JsonGenerator gen, SerializationContext serializers) {
                 gen.writeNumber(value.floatValueForSerialization());
             }
         });
-        module.addDeserializer(CustomFloatScalar.class, new JsonDeserializer<CustomFloatScalar>() {
+        module.addDeserializer(CustomFloatScalar.class, new ValueDeserializer<CustomFloatScalar>() {
             @Override
-            public CustomFloatScalar deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            public CustomFloatScalar deserialize(JsonParser p, DeserializationContext ctxt) {
                 JsonNode node = p.readValueAsTree();
                 if (node == null || node.isNull()) {
                     return null;
@@ -201,27 +195,27 @@ public class JacksonCreator {
         });
 
         // jakarta.json.JsonObject deserializer — needed for JSON scalar type support
-        module.addDeserializer(jakarta.json.JsonObject.class, new JsonDeserializer<jakarta.json.JsonObject>() {
+        module.addDeserializer(jakarta.json.JsonObject.class, new ValueDeserializer<jakarta.json.JsonObject>() {
             @Override
-            public jakarta.json.JsonObject deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            public jakarta.json.JsonObject deserialize(JsonParser p, DeserializationContext ctxt) {
                 JsonNode node = p.readValueAsTree();
                 return (jakarta.json.JsonObject) jacksonNodeToJsonPValue(node);
             }
         });
 
         // jakarta.json.JsonArray deserializer
-        module.addDeserializer(jakarta.json.JsonArray.class, new JsonDeserializer<jakarta.json.JsonArray>() {
+        module.addDeserializer(jakarta.json.JsonArray.class, new ValueDeserializer<jakarta.json.JsonArray>() {
             @Override
-            public jakarta.json.JsonArray deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            public jakarta.json.JsonArray deserialize(JsonParser p, DeserializationContext ctxt) {
                 JsonNode node = p.readValueAsTree();
                 return (jakarta.json.JsonArray) jacksonNodeToJsonPValue(node);
             }
         });
 
         // jakarta.json.JsonValue deserializer
-        module.addDeserializer(jakarta.json.JsonValue.class, new JsonDeserializer<jakarta.json.JsonValue>() {
+        module.addDeserializer(jakarta.json.JsonValue.class, new ValueDeserializer<jakarta.json.JsonValue>() {
             @Override
-            public jakarta.json.JsonValue deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            public jakarta.json.JsonValue deserialize(JsonParser p, DeserializationContext ctxt) {
                 JsonNode node = p.readValueAsTree();
                 return jacksonNodeToJsonPValue(node);
             }
@@ -230,16 +224,16 @@ public class JacksonCreator {
         return module;
     }
 
-    private static com.fasterxml.jackson.databind.Module createComplexKeyModule() {
-        return new com.fasterxml.jackson.databind.Module() {
+    private static tools.jackson.databind.JacksonModule createComplexKeyModule() {
+        return new tools.jackson.databind.JacksonModule() {
             @Override
             public String getModuleName() {
                 return "ComplexMapKeys";
             }
 
             @Override
-            public com.fasterxml.jackson.core.Version version() {
-                return com.fasterxml.jackson.core.Version.unknownVersion();
+            public tools.jackson.core.Version version() {
+                return tools.jackson.core.Version.unknownVersion();
             }
 
             @Override
@@ -247,16 +241,17 @@ public class JacksonCreator {
                 context.addKeyDeserializers(new KeyDeserializers() {
                     @Override
                     public KeyDeserializer findKeyDeserializer(JavaType keyType, DeserializationConfig config,
-                            BeanDescription beanDesc) throws JsonMappingException {
+                            BeanDescription.Supplier beanDescSupplier) {
                         Class<?> raw = keyType.getRawClass();
                         if (!isComplexKeyType(raw)) {
                             return null;
                         }
                         return new KeyDeserializer() {
                             @Override
-                            public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
-                                ObjectMapper mapper = (ObjectMapper) ctxt.getParser().getCodec();
-                                return mapper.readValue(key, keyType);
+                            public Object deserializeKey(String key, DeserializationContext ctxt) {
+                                try (JsonParser parser = ctxt.tokenStreamFactory().createParser(key)) {
+                                    return ctxt.readValue(parser, keyType);
+                                }
                             }
                         };
                     }
@@ -271,7 +266,8 @@ public class JacksonCreator {
         }
         String name = type.getName();
         return !name.startsWith("java.") && !name.startsWith("javax.")
-                && !name.startsWith("jakarta.") && !name.startsWith("com.fasterxml.");
+                && !name.startsWith("jakarta.") && !name.startsWith("com.fasterxml.")
+                && !name.startsWith("tools.jackson.");
     }
 
     private static jakarta.json.JsonValue jacksonNodeToJsonPValue(JsonNode node) {
@@ -280,7 +276,7 @@ public class JacksonCreator {
         }
         if (node.isObject()) {
             jakarta.json.JsonObjectBuilder builder = jakarta.json.Json.createObjectBuilder();
-            node.fields().forEachRemaining(entry -> builder.add(entry.getKey(), jacksonNodeToJsonPValue(entry.getValue())));
+            node.properties().forEach(entry -> builder.add(entry.getKey(), jacksonNodeToJsonPValue(entry.getValue())));
             return builder.build();
         }
         if (node.isArray()) {

--- a/server/implementation/src/main/java/io/smallrye/graphql/json/JsonInputRegistry.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/json/JsonInputRegistry.java
@@ -2,9 +2,8 @@ package io.smallrye.graphql.json;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.smallrye.graphql.schema.model.InputType;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Here we register input objects to be used when creating method calls

--- a/server/implementation/src/main/java/io/smallrye/graphql/scalar/GraphQLScalarTypes.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/scalar/GraphQLScalarTypes.java
@@ -63,8 +63,8 @@ public class GraphQLScalarTypes {
 
     public static void addJson() {
         SCALAR_MAP.put(Object.class.getName(), ExtendedScalars.Json);
-        SCALAR_MAP.put("com.fasterxml.jackson.databind.JsonNode", ExtendedScalars.Json);
-        SCALAR_MAP.put("com.fasterxml.jackson.databind.node.ObjectNode", ExtendedScalars.Json);
+        SCALAR_MAP.put("tools.jackson.databind.JsonNode", ExtendedScalars.Json);
+        SCALAR_MAP.put("tools.jackson.databind.node.ObjectNode", ExtendedScalars.Json);
         SCALARS_BY_NAME.put(ExtendedScalars.Json.getName(), ExtendedScalars.Json);
     }
 

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/EventingService.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/EventingService.java
@@ -3,13 +3,12 @@ package io.smallrye.graphql.spi;
 import java.util.Collections;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import graphql.GraphQL;
 import graphql.schema.GraphQLSchema;
 import io.smallrye.graphql.api.Context;
 import io.smallrye.graphql.execution.event.InvokeInfo;
 import io.smallrye.graphql.schema.model.Operation;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Some events during bootstrap and execution that allows extension

--- a/server/implementation/src/test/java/io/smallrye/graphql/execution/error/ExecutionErrorsServiceTest.java
+++ b/server/implementation/src/test/java/io/smallrye/graphql/execution/error/ExecutionErrorsServiceTest.java
@@ -10,9 +10,6 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import graphql.ExceptionWhileDataFetching;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorException;
@@ -21,6 +18,8 @@ import graphql.language.SourceLocation;
 import graphql.validation.ValidationError;
 import graphql.validation.ValidationErrorType;
 import io.smallrye.graphql.spi.config.Config;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Test for {@link ExecutionErrorsService}

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientInjectionTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientInjectionTest.java
@@ -14,13 +14,12 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.GraphQLClient;
 import io.smallrye.graphql.client.core.Document;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClient;
 import io.vertx.core.MultiMap;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Verify a named dynamic client injected via CDI and configured via MP Config properties

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientSingleOperationsTestBase.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/DynamicClientSingleOperationsTestBase.java
@@ -23,13 +23,12 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.core.Document;
 import io.smallrye.graphql.client.core.ScalarType;
 import io.smallrye.graphql.client.core.Variable;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClient;
+import tools.jackson.databind.node.ObjectNode;
 
 public abstract class DynamicClientSingleOperationsTestBase {
 

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/NestedRecordsTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/NestedRecordsTest.java
@@ -28,14 +28,13 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.core.Document;
 import io.smallrye.graphql.client.core.InputObject;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClientBuilder;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/RecordTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/RecordTest.java
@@ -26,13 +26,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.core.Document;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClientBuilder;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * This test verifies that the server side can handle Java records in GraphQL apis, both as input and as output types.

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/extensions/DynamicClientInboundExtensionsTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/extensions/DynamicClientInboundExtensionsTest.java
@@ -25,13 +25,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClient;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClientBuilder;
 import io.smallrye.graphql.execution.context.SmallRyeContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Test extension(s) features of the dynamic client
@@ -72,7 +72,7 @@ public class DynamicClientInboundExtensionsTest {
                 field("poolWithExtensions",
                         field("volume")))));
         // Compare structurally by converting both to JsonNode through a common JSON round-trip
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = JsonMapper.builder().build();
         JsonNode expected = mapper.readTree(mapper.writeValueAsString(getMap()));
         JsonNode actual = mapper.readTree(response.getExtensions().toString());
         assertEquals(expected, actual);

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/fragments/DynamicClientFragmentTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/client/dynamic/fragments/DynamicClientFragmentTest.java
@@ -24,13 +24,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.core.Document;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClient;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClientBuilder;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/json/CustomJsonbService.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/json/CustomJsonbService.java
@@ -4,9 +4,9 @@ import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.smallrye.graphql.spi.EventingService;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class CustomJsonbService implements EventingService {
 
@@ -17,8 +17,9 @@ public class CustomJsonbService implements EventingService {
 
     @Override
     public Map<String, ObjectMapper> overrideObjectMapperConfig() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setDateFormat(new SimpleDateFormat("MM dd yyyy HH:mm Z"));
+        ObjectMapper mapper = JsonMapper.builder()
+                .defaultDateFormat(new SimpleDateFormat("MM dd yyyy HH:mm Z"))
+                .build();
         return Collections.singletonMap(DateWrapper.class.getName(), mapper);
     }
 }

--- a/server/integration-tests/src/test/java/io/smallrye/graphql/tests/subscription/SubscriptionFieldBatchingTest.java
+++ b/server/integration-tests/src/test/java/io/smallrye/graphql/tests/subscription/SubscriptionFieldBatchingTest.java
@@ -16,13 +16,12 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.smallrye.graphql.api.Subscription;
 import io.smallrye.graphql.client.Response;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import io.smallrye.graphql.client.vertx.dynamic.VertxDynamicGraphQLClientBuilder;
 import io.smallrye.mutiny.Multi;
+import tools.jackson.databind.node.ObjectNode;
 
 @ExtendWith(ArquillianExtension.class)
 public class SubscriptionFieldBatchingTest {

--- a/server/tck/pom.xml
+++ b/server/tck/pom.xml
@@ -89,7 +89,7 @@
         </dependency>
         
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Aligns SmallRye GraphQL with Jackson 3.x in preparation for Quarkus 4, which targets `tools.jackson:jackson-bom:3.1.4` (see [geoand/quarkus jackson3 branch](https://github.com/geoand/quarkus/tree/jackson3)).

This is a mechanical migration with no behavioral changes:

- **Maven coordinates**: `com.fasterxml.jackson` → `tools.jackson` (except `jackson-annotations` which stays on 2.x by design)
- **Java packages**: `com.fasterxml.jackson.databind/core` → `tools.jackson.databind/core`
- **Class renames**: `JsonSerializer` → `ValueSerializer`, `JsonDeserializer` → `ValueDeserializer`, `SerializerProvider` → `SerializationContext`, `JsonProcessingException` → `JacksonException` (now unchecked)
- **ObjectMapper immutability**: all post-construction configuration converted to `JsonMapper.builder()` pattern
- **Built-in modules**: removed explicit `jackson-datatype-jdk8` and `jackson-datatype-jsr310` dependencies (merged into `jackson-databind` in 3.x)
- **AnnotationIntrospector API**: updated `jackson-jsonb-compat` module for Jackson 3 method signatures

Validated locally against the MicroProfile GraphQL TCK (387 tests, 0 failures).