### PR TITLE
Set a default query depth limit of 10 to prevent DoS via deeply nested queries

### DIFF
--- a/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/MicroProfileConfig.java
+++ b/server/implementation-cdi/src/main/java/io/smallrye/graphql/cdi/config/MicroProfileConfig.java
@@ -290,7 +290,7 @@ public class MicroProfileConfig implements Config {
             org.eclipse.microprofile.config.Config microProfileConfig = ConfigProvider.getConfig();
             queryDepthInstrumentation = microProfileConfig
                     .getOptionalValue(ConfigKey.INSTRUMENTATION_QUERY_DEPTH, Integer.class)
-                    .orElse(null);
+                    .orElse(DEFAULT_QUERY_DEPTH_LIMIT);
         }
         return Optional.ofNullable(queryDepthInstrumentation);
     }

--- a/server/implementation/src/main/java/io/smallrye/graphql/spi/config/Config.java
+++ b/server/implementation/src/main/java/io/smallrye/graphql/spi/config/Config.java
@@ -199,7 +199,7 @@ public interface Config {
     }
 
     default Optional<Integer> getQueryDepthInstrumentation() {
-        return Optional.empty();
+        return Optional.of(DEFAULT_QUERY_DEPTH_LIMIT);
     }
 
     default boolean isExcludeNullFieldsInResponses() {
@@ -217,6 +217,8 @@ public interface Config {
     default <T> T getConfigValue(String key, Class<T> type, T defaultValue) {
         return defaultValue;
     }
+
+    public static final int DEFAULT_QUERY_DEPTH_LIMIT = 10;
 
     public static final String SERVER_ERROR_DEFAULT_MESSAGE = "System error";
     public static final String FIELD_VISIBILITY_DEFAULT = "default";


### PR DESCRIPTION
Backport to 2.x (Quarkus 3).

GraphQL APIs with self-referential types (e.g. `User { friends: [User] }`) are vulnerable to memory exhaustion when no query depth limit is configured. A single deeply nested query can cause exponential result-tree expansion server-side, driving multi-gigabyte heap allocation.

The `MaxQueryDepthInstrumentation` from graphql-java was already wired up, but the default was `Optional.empty()` (no limit) — protection was entirely opt-in with no safe default.

This sets the default query depth limit to `10`, which covers virtually all legitimate query patterns. Applications can override via `smallrye.graphql.instrumentation.queryDepth` if they need deeper nesting.