### PR TITLE
Preserve Kotlin list-item nullability inside Uni wrappers

### DIFF
--- a/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/OperationCreator.java
+++ b/common/schema-builder/src/main/java/io/smallrye/graphql/schema/creator/OperationCreator.java
@@ -22,9 +22,11 @@ import io.smallrye.graphql.schema.helper.MethodHelper;
 import io.smallrye.graphql.schema.helper.RolesAllowedDirectivesHelper;
 import io.smallrye.graphql.schema.model.Argument;
 import io.smallrye.graphql.schema.model.Execute;
+import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.Operation;
 import io.smallrye.graphql.schema.model.OperationType;
 import io.smallrye.graphql.schema.model.Reference;
+import io.smallrye.graphql.schema.model.Wrapper;
 import kotlin.metadata.Attributes;
 import kotlin.metadata.KmClassifier;
 import kotlin.metadata.KmFunction;
@@ -134,20 +136,8 @@ public class OperationCreator extends ModelCreator {
             if (function.isPresent()) {
                 // handle return type
                 if (operation.hasWrapper()) {
-                    KmType returnType = function.get().getReturnType();
-                    var nullable = isKotlinWrappedTypeNullable(returnType);
-                    if (operation.getWrapper().isCollectionOrArrayOrMap()) {
-                        operation.getWrapper().setWrappedTypeNotNull(!nullable);
-                        // workaround: consistent behavior to java: if wrapped type is non null, collection will be marked as non null
-                        if (!nullable && !operation.isNotNull()) {
-                            operation.setNotNull(true);
-                        }
-                    } else {
-                        // Uni, etc
-                        if (nullable) {
-                            operation.setNotNull(false);
-                        }
-                    }
+                    applyKotlinWrapperNullability(operation, operation.getWrapper(),
+                            function.get().getReturnType(), true);
                 }
 
                 // handle arguments
@@ -156,14 +146,12 @@ public class OperationCreator extends ModelCreator {
                 if (arguments.size() == valueParameters.size()) {
                     for (int i = 0; i < arguments.size(); i++) {
                         Argument argument = arguments.get(i);
-                        if (argument.hasWrapper() && argument.getWrapper().isCollectionOrArrayOrMap()) {
-                            KmValueParameter typeParameter = valueParameters.get(i);
-                            var paramNullable = isKotlinWrappedTypeNullable(typeParameter.getType());
-                            argument.getWrapper().setWrappedTypeNotNull(!paramNullable);
-                            // workaround:  consistent behavior to java: if wrapped type is not null, collection will be marked as not null
-                            if (!paramNullable && !argument.isNotNull()) {
-                                argument.setNotNull(true);
-                            }
+                        if (argument.hasWrapper()) {
+                            // Arguments cannot be async wrappers (Uni etc.), so only collection-like
+                            // wrappers may control the argument's own nullability.
+                            applyKotlinWrapperNullability(argument, argument.getWrapper(),
+                                    valueParameters.get(i).getType(),
+                                    argument.getWrapper().isCollectionOrArrayOrMap());
                         }
                     }
                 }
@@ -171,12 +159,50 @@ public class OperationCreator extends ModelCreator {
         }
     }
 
-    private static boolean isKotlinWrappedTypeNullable(KmType kotlinType) {
-        if (kotlinType.getArguments().isEmpty()) {
-            return false;
+    /**
+     * Apply Kotlin nullability metadata to the whole wrapper chain of a field.
+     * <p>
+     * For a plain {@code List<String>}, the collection wrapper's wrapped-type nullability comes from
+     * {@code String}. For {@code Uni<List<String>>}, the async wrapper's type-argument nullability
+     * controls the field/operation nullability, and the nested collection wrapper still needs the
+     * list-item nullability from {@code String}.
+     *
+     * @param field the field/operation/argument being configured
+     * @param wrapper the current wrapper in the chain
+     * @param kotlinType the Kotlin type corresponding to that wrapper
+     * @param controlsFieldNullability whether this level should update {@code field.notNull}
+     */
+    private static void applyKotlinWrapperNullability(Field field,
+            Wrapper wrapper,
+            KmType kotlinType,
+            boolean controlsFieldNullability) {
+        if (wrapper == null || kotlinType == null || kotlinType.getArguments().isEmpty()) {
+            return;
         }
-        KmTypeProjection arg = kotlinType.getArguments().get(0);
-        return Attributes.isNullable(arg.getType());
+        KmTypeProjection projection = kotlinType.getArguments().get(0);
+        if (projection.getType() == null) {
+            // star projection carries no nullability information
+            return;
+        }
+        KmType argType = projection.getType();
+        boolean argNullable = Attributes.isNullable(argType);
+
+        if (wrapper.isCollectionOrArrayOrMap()) {
+            wrapper.setWrappedTypeNotNull(!argNullable);
+            // workaround: consistent behavior to java: if wrapped type is non null, collection will be marked as non null
+            if (controlsFieldNullability && !argNullable && !field.isNotNull()) {
+                field.setNotNull(true);
+            }
+        } else if (controlsFieldNullability && argNullable) {
+            // Uni, CompletionStage, etc.: nullability of the immediate wrapped type maps to the GraphQL field
+            field.setNotNull(false);
+        }
+
+        if (wrapper.hasWrapper()) {
+            // Nested wrappers (e.g. List inside Uni) must still receive item nullability, but must not
+            // override field nullability already decided by an outer async wrapper.
+            applyKotlinWrapperNullability(field, wrapper.getWrapper(), argType, false);
+        }
     }
 
     private boolean compareParameterLists(List<KmValueParameter> kotlinParameters,

--- a/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
+++ b/common/schema-builder/src/test/java/io/smallrye/graphql/index/SchemaBuilderTest.java
@@ -442,6 +442,38 @@ public class SchemaBuilderTest {
     }
 
     @Test
+    public void testKotlinTypeWrappedInUniAndCollectionNullability() {
+        Indexer indexer = new Indexer();
+        indexDirectory(indexer, "io/smallrye/graphql/kotlin");
+        IndexView index = indexer.complete();
+        Schema schema = SchemaBuilder.build(index);
+
+        // Uni<List<Foo>> -> [Foo!]!
+        var uniListNonNullItems = getQueryByName(schema, "uniListNonNullItems");
+        assertEquals("[Foo!]!", uniListNonNullItems.getGraphQLType());
+        assertTrue(uniListNonNullItems.isNotNull());
+        assertTrue(uniListNonNullItems.getWrapper().getWrapper().isWrappedTypeNotNull());
+
+        // Uni<List<Foo?>> -> [Foo]!
+        var uniListNullableItems = getQueryByName(schema, "uniListNullableItems");
+        assertEquals("[Foo]!", uniListNullableItems.getGraphQLType());
+        assertTrue(uniListNullableItems.isNotNull());
+        assertFalse(uniListNullableItems.getWrapper().getWrapper().isWrappedTypeNotNull());
+
+        // Uni<List<Foo>?> -> [Foo!]
+        var uniNullableListNonNullItems = getQueryByName(schema, "uniNullableListNonNullItems");
+        assertEquals("[Foo!]", uniNullableListNonNullItems.getGraphQLType());
+        assertFalse(uniNullableListNonNullItems.isNotNull());
+        assertTrue(uniNullableListNonNullItems.getWrapper().getWrapper().isWrappedTypeNotNull());
+
+        // Uni<List<Foo?>?> -> [Foo]
+        var uniNullableListNullableItems = getQueryByName(schema, "uniNullableListNullableItems");
+        assertEquals("[Foo]", uniNullableListNullableItems.getGraphQLType());
+        assertFalse(uniNullableListNullableItems.isNotNull());
+        assertFalse(uniNullableListNullableItems.getWrapper().getWrapper().isWrappedTypeNotNull());
+    }
+
+    @Test
     public void testParametrizedGenericTypes() {
         Indexer indexer = new Indexer();
         indexDirectory(indexer, "io/smallrye/graphql/index/generic/parametrized");

--- a/common/schema-builder/src/test/kotlin/io/smallrye/graphql/kotlin/Foo.kt
+++ b/common/schema-builder/src/test/kotlin/io/smallrye/graphql/kotlin/Foo.kt
@@ -60,4 +60,17 @@ class Example {
 
   @Query("yyy5")
   fun yyy5(): List<Foo>? = listOf()
+
+  // Uni-wrapped lists: list-item nullability must be preserved (quarkusio/quarkus#48350)
+  @Query("uniListNonNullItems")
+  fun uniListNonNullItems(): Uni<List<Foo>> = Uni.createFrom().item(listOf())
+
+  @Query("uniListNullableItems")
+  fun uniListNullableItems(): Uni<List<Foo?>> = Uni.createFrom().item(listOf())
+
+  @Query("uniNullableListNonNullItems")
+  fun uniNullableListNonNullItems(): Uni<List<Foo>?> = Uni.createFrom().nullItem()
+
+  @Query("uniNullableListNullableItems")
+  fun uniNullableListNullableItems(): Uni<List<Foo?>?> = Uni.createFrom().nullItem()
 }

--- a/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Field.java
+++ b/common/schema-model/src/main/java/io/smallrye/graphql/schema/model/Field.java
@@ -144,14 +144,6 @@ public class Field implements Serializable {
     public String getGraphQLType() {
         StringBuilder builder = new StringBuilder();
 
-        if (wrapper == null || !wrapper.isCollectionOrArrayOrMap()) {
-            builder.append(reference.getName());
-            if (notNull) {
-                builder.append('!');
-            }
-            return builder.toString();
-        }
-
         Deque<Wrapper> stack = new ArrayDeque<>();
         for (Wrapper w = wrapper; w != null; w = w.getWrapper()) {
             if (!w.isCollectionOrArrayOrMap()) {


### PR DESCRIPTION
## Summary
- Fix Kotlin GraphQL schema generation so `Uni<List<String>>` (and similar Mutiny/CompletionStage wrappers) keeps list-item nullability from Kotlin metadata, producing `[String!]!` instead of `[String]!`.
- Recursively apply nullability across the wrapper chain in `OperationCreator`, while still only letting collection-like argument wrappers control argument-level nullability.
- Update `Field.getGraphQLType()` to skip non-collection wrappers when rendering nested list types, and add schema-builder coverage for the Uni+List nullability matrix.

Fixes: https://github.com/quarkusio/quarkus/issues/48350
