### PR TITLE
Automatic backport for 2.x branch when setting a `triage/backport` and merging the PR into main

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,24 @@
+name: Automated Backporting
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'triage/backport')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Backport to 2.x
+        uses: kiegroup/git-backporting@v4.10.0
+        with:
+          target-branch: 2.x
+          pull-request: ${{ github.event.pull_request.url }}
+          auth: ${{ secrets.GITHUB_TOKEN }}
+          no-squash: true
+          title: "[2.x] ${{ github.event.pull_request.title }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
       - 'LICENSE'
       - 'NOTICE'
       - 'README*'
+      - '.github/**'
+      - '!.github/workflows/build.yml'
   pull_request:
     paths-ignore:
       - '.gitignore'
@@ -17,6 +19,8 @@ on:
       - 'LICENSE'
       - 'NOTICE'
       - 'README*'
+      - '.github/**'
+      - '!.github/workflows/build.yml'
 
 jobs:
   build:


### PR DESCRIPTION
Closes #2584

Also added files (technically a complement of a set) into `paths-ignore` - e.g. there is no need for CI jobs when something changes in the [dependabot.yml](https://github.com/smallrye/smallrye-graphql/blob/main/.github/dependabot.yml)

I set the label to `triage/backport` but maybe we can have something more explicit? (e.g. `triage/backport2.x`).

Regarding the workflow, to create automatic backport PR:
1) PR needs to be **OPEN**, target needs to be towards `main` (3.x),  and there needs to be a label of `triage/backport`.
2) After merging the PR, it will automatically (hopefully) create PR with `[2.x] {title-of-the-merged-pr}`

- Description should be a link the old PR. 
- Commits (hashes, commit names, and author(s)) should be the same. 
- Branch name should be in a format `bp-{target-branch}-{commit-sha-range}`.
- Target branch should be `2.x`