### PR TITLE
Some CI optimizations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ on:
       - '!.github/workflows/build.yml'
       - '!.github/project.yml' # allow CI to run to see the current results (before the release)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
       - 'LICENSE'
       - 'NOTICE'
       - 'README*'
+      - '.github/**'
+      - '!.github/workflows/build.yml'
   pull_request:
     paths-ignore:
       - '.gitignore'
@@ -17,6 +19,9 @@ on:
       - 'LICENSE'
       - 'NOTICE'
       - 'README*'
+      - '.github/**'
+      - '!.github/workflows/build.yml'
+      - '!.github/project.yml' # allow CI to run to see the current results (before the release)
 
 jobs:
   build:


### PR DESCRIPTION
I only left `.github/project.yml` for the PRs, I don't really see a reason for them in pushes, note even if I put it there, it would be canceled via `concurrency` check.